### PR TITLE
add v8::Context::Scope

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -32,13 +32,11 @@ impl Context {
 
   pub fn scope<'sc>(
     handle_scope: &mut HandleScope<'sc>,
-    mut f: impl FnMut(Local<Context>, &mut HandleScope<'sc>) -> (),
+    mut f: impl FnMut(&mut HandleScope<'sc>, Local<Context>) -> (),
   ) {
-    let mut context = unsafe {
-      Local::from_raw(v8__Context__New(handle_scope.cxx_isolate())).unwrap()
-    };
+    let mut context = Context::new(handle_scope);
     context.enter();
-    f(context, handle_scope);
+    f(handle_scope, context);
     context.exit();
   }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -29,4 +29,16 @@ impl Context {
     // TODO: enter/exit should be controlled by a scope.
     unsafe { v8__Context__Exit(self) };
   }
+
+  pub fn scope<'sc>(
+    handle_scope: &mut HandleScope<'sc>,
+    mut f: impl FnMut(Local<Context>, &mut HandleScope<'sc>) -> (),
+  ) {
+    let mut context = unsafe {
+      Local::from_raw(v8__Context__New(handle_scope.cxx_isolate())).unwrap()
+    };
+    context.enter();
+    f(context, handle_scope);
+    context.exit();
+  }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -118,19 +118,18 @@ fn script_compile_and_run() {
   let mut locker = v8::Locker::new(&mut isolate);
 
   v8::HandleScope::enter(&mut locker, |s| {
-    let mut context = v8::Context::new(s);
-    context.enter();
-    let source =
-      v8::String::new(s, "'Hello ' + 13 + 'th planet'", Default::default())
-        .unwrap();
-    let mut script = v8::Script::compile(s, context, source, None).unwrap();
-    source.to_rust_string_lossy(s);
-    let result = script.run(s, context).unwrap();
-    // TODO: safer casts.
-    let result: v8::Local<v8::String> =
-      unsafe { std::mem::transmute_copy(&result) };
-    assert_eq!(result.to_rust_string_lossy(s), "Hello 13th planet");
-    context.exit();
+    v8::Context::scope(s, |context, s| {
+      let source =
+        v8::String::new(s, "'Hello ' + 13 + 'th planet'", Default::default())
+          .unwrap();
+      let mut script = v8::Script::compile(s, context, source, None).unwrap();
+      source.to_rust_string_lossy(s);
+      let result = script.run(s, context).unwrap();
+      // TODO: safer casts.
+      let result: v8::Local<v8::String> =
+        unsafe { std::mem::transmute_copy(&result) };
+      assert_eq!(result.to_rust_string_lossy(s), "Hello 13th planet");
+    });
   });
 }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -118,7 +118,7 @@ fn script_compile_and_run() {
   let mut locker = v8::Locker::new(&mut isolate);
 
   v8::HandleScope::enter(&mut locker, |s| {
-    v8::Context::scope(s, |context, s| {
+    v8::Context::scope(s, |s, context| {
       let source =
         v8::String::new(s, "'Hello ' + 13 + 'th planet'", Default::default())
           .unwrap();


### PR DESCRIPTION
I'm not really sure that porting `v8::Context::Scope` is needed... wouldn't it be equivalent to do it like this?

```rust
impl Context {
  pub fn new<'sc>(scope: &mut HandleScope<'sc>) -> Local<'sc, Context> {
    // TODO: optional arguments;
    let context = unsafe { Local::from_raw(v8__Context__New(scope.cxx_isolate())).unwrap() };
    unsafe { v8__Context__Enter(&mut context) };
    context
  }
}

impl Drop for Context {
  pub fn drop(&mut self) {
    unsafe { v8__Context__Exit(self) };
  } 
}
```
then the test could be rewritten as:
```rust
#[test]
fn script_compile_and_run() {
  setup();
  let mut params = v8::Isolate::create_params();
  params.set_array_buffer_allocator(
    v8::array_buffer::Allocator::new_default_allocator(),
  );
  let mut isolate = v8::Isolate::new(params);
  let mut locker = v8::Locker::new(&mut isolate);

  v8::HandleScope::enter(&mut locker, |s| {
    let context = v8::Context::new(s);
    let source =
      v8::String::new(s, "'Hello ' + 13 + 'th planet'", Default::default())
        .unwrap();
    let mut script = v8::Script::compile(s, context, source, None).unwrap();
    source.to_rust_string_lossy(s);
    let result = script.run(s, context).unwrap();
    // TODO: safer casts.
    let result: v8::Local<v8::String> =
      unsafe { std::mem::transmute_copy(&result) };
    assert_eq!(result.to_rust_string_lossy(s), "Hello 13th planet");
    drop(context);
  });
}
```

The same could be applied to `HandleScope` I guess?

EDIT: I guess it's a good idea after all. 