### PR TITLE
add v8::Exception

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -6,6 +6,7 @@ v8_static_library("rusty_v8") {
     "src/V8.cc",
     "src/array_buffer.cc",
     "src/context.cc",
+    "src/exception.cc",
     "src/handle_scope.cc",
     "src/inspector/channel.cc",
     "src/inspector/client.cc",

--- a/src/exception.cc
+++ b/src/exception.cc
@@ -8,10 +8,6 @@ v8::String *v8__Message__Get(v8::Message* self) {
   return local_to_ptr(self->Get());
 }
 
-v8::Message *v8__Exception__CreateMessage(v8::Isolate* isolate, v8::Local<v8::Value> exception) {
-  return local_to_ptr(v8::Exception::CreateMessage(isolate, exception));
-}
-
 v8::Value *v8__Exception__RangeError(v8::Local<v8::String> message) {
   return local_to_ptr(v8::Exception::RangeError(message));
 }
@@ -30,5 +26,17 @@ v8::Value *v8__Exception__TypeError(v8::Local<v8::String> message) {
 
 v8::Value *v8__Exception__Error(v8::Local<v8::String> message) {
   return local_to_ptr(v8::Exception::Error(message));
+}
+
+v8::Message *v8__Exception__CreateMessage(v8::Isolate* isolate, v8::Local<v8::Value> exception) {
+  return local_to_ptr(v8::Exception::CreateMessage(isolate, exception));
+}
+
+v8::StackTrace *v8__Exception__GetStackTrace(v8::Local<v8::Value> exception) {
+  return local_to_ptr(v8::Exception::GetStackTrace(exception));
+}
+
+int v8__StackTrace__GetFrameCount(v8::StackTrace* self) {
+  return self->GetFrameCount();
 }
 }

--- a/src/exception.cc
+++ b/src/exception.cc
@@ -4,7 +4,23 @@
 using namespace support;
 
 extern "C" {
+v8::Value *v8__Exception__RangeError(v8::Local<v8::String> message) {
+  return local_to_ptr(v8::Exception::RangeError(message));
+}
+
+v8::Value *v8__Exception__ReferenceError(v8::Local<v8::String> message) {
+  return local_to_ptr(v8::Exception::ReferenceError(message));
+}
+
+v8::Value *v8__Exception__SyntaxError(v8::Local<v8::String> message) {
+  return local_to_ptr(v8::Exception::SyntaxError(message));
+}
+
 v8::Value *v8__Exception__TypeError(v8::Local<v8::String> message) {
   return local_to_ptr(v8::Exception::TypeError(message));
+}
+
+v8::Value *v8__Exception__Error(v8::Local<v8::String> message) {
+  return local_to_ptr(v8::Exception::Error(message));
 }
 }

--- a/src/exception.cc
+++ b/src/exception.cc
@@ -1,0 +1,10 @@
+#include "support.h"
+#include "v8/include/v8.h"
+
+using namespace support;
+
+extern "C" {
+v8::Value *v8__Exception__TypeError(v8::Local<v8::String> message) {
+  return local_to_ptr(v8::Exception::TypeError(message));
+}
+}

--- a/src/exception.cc
+++ b/src/exception.cc
@@ -4,6 +4,14 @@
 using namespace support;
 
 extern "C" {
+v8::String *v8__Message__Get(v8::Message* self) {
+  return local_to_ptr(self->Get());
+}
+
+v8::Message *v8__Exception__CreateMessage(v8::Isolate* isolate, v8::Local<v8::Value> exception) {
+  return local_to_ptr(v8::Exception::CreateMessage(isolate, exception));
+}
+
 v8::Value *v8__Exception__RangeError(v8::Local<v8::String> message) {
   return local_to_ptr(v8::Exception::RangeError(message));
 }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,9 +1,17 @@
 #![allow(non_snake_case)]
+
+use crate::isolate::CxxIsolate;
+use crate::support::Opaque;
 use crate::Local;
 use crate::String;
 use crate::Value;
 
 extern "C" {
+  fn v8__Message__Get(message: *mut Message) -> *mut String;
+  fn v8__Exception__CreateMessage(
+    isolate: *mut CxxIsolate,
+    exception: *mut Value,
+  ) -> *mut Message;
   fn v8__Exception__RangeError(message: *mut String) -> *mut Value;
   fn v8__Exception__ReferenceError(message: *mut String) -> *mut Value;
   fn v8__Exception__SyntaxError(message: *mut String) -> *mut Value;
@@ -11,31 +19,66 @@ extern "C" {
   fn v8__Exception__Error(message: *mut String) -> *mut Value;
 }
 
+#[repr(C)]
+pub struct StackTrace(Opaque);
+
+#[repr(C)]
+pub struct Message(Opaque);
+
+impl Message {
+  pub fn get(&mut self) -> Local<'_, String> {
+    unsafe { Local::from_raw(v8__Message__Get(self)) }.unwrap()
+  }
+}
+
+/// Create new error objects by calling the corresponding error object
+/// constructor with the message.
 pub mod Exception {
   use super::*;
+  use crate::isolate::LockedIsolate;
 
-  pub fn RangeError<'sc>(mut message: Local<'_, String>) -> Local<'_, Value> {
+  /// Creates an error message for the given exception.
+  /// Will try to reconstruct the original stack trace from the exception value,
+  /// or capture the current stack trace if not available.
+  pub fn CreateMessage<'sc>(
+    isolate: &mut impl LockedIsolate,
+    mut exception: Local<'sc, Value>,
+  ) -> Local<'sc, Message> {
+    unsafe {
+      Local::from_raw(v8__Exception__CreateMessage(
+        isolate.cxx_isolate(),
+        &mut *exception,
+      ))
+    }
+    .unwrap()
+  }
+
+  /// Returns the original stack trace that was captured at the creation time
+  /// of a given exception, or an empty handle if not available.
+  pub fn GetStackTrace(_exception: Local<'_, Value>) -> Local<'_, StackTrace> {
+    unimplemented!();
+  }
+
+  pub fn RangeError(mut message: Local<'_, String>) -> Local<'_, Value> {
     unsafe { Local::from_raw(v8__Exception__RangeError(&mut *message)) }
       .unwrap()
   }
 
-  pub fn ReferenceError<'sc>(
-    mut message: Local<'_, String>,
-  ) -> Local<'_, Value> {
+  pub fn ReferenceError(mut message: Local<'_, String>) -> Local<'_, Value> {
     unsafe { Local::from_raw(v8__Exception__ReferenceError(&mut *message)) }
       .unwrap()
   }
 
-  pub fn SyntaxError<'sc>(mut message: Local<'_, String>) -> Local<'_, Value> {
+  pub fn SyntaxError(mut message: Local<'_, String>) -> Local<'_, Value> {
     unsafe { Local::from_raw(v8__Exception__SyntaxError(&mut *message)) }
       .unwrap()
   }
 
-  pub fn TypeError<'sc>(mut message: Local<'_, String>) -> Local<'_, Value> {
+  pub fn TypeError(mut message: Local<'_, String>) -> Local<'_, Value> {
     unsafe { Local::from_raw(v8__Exception__TypeError(&mut *message)) }.unwrap()
   }
 
-  pub fn Error<'sc>(mut message: Local<'_, String>) -> Local<'_, Value> {
+  pub fn Error(mut message: Local<'_, String>) -> Local<'_, Value> {
     unsafe { Local::from_raw(v8__Exception__Error(&mut *message)) }.unwrap()
   }
 }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,0 +1,16 @@
+#![allow(non_snake_case)]
+use crate::Local;
+use crate::String;
+use crate::Value;
+
+extern "C" {
+  fn v8__Exception__TypeError(message: *mut String) -> *mut Value;
+}
+
+pub mod Exception {
+  use super::*;
+
+  pub fn TypeError<'sc>(mut message: Local<'_, String>) -> Local<'_, Value> {
+    unsafe { Local::from_raw(v8__Exception__TypeError(&mut *message)) }.unwrap()
+  }
+}

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -4,13 +4,38 @@ use crate::String;
 use crate::Value;
 
 extern "C" {
+  fn v8__Exception__RangeError(message: *mut String) -> *mut Value;
+  fn v8__Exception__ReferenceError(message: *mut String) -> *mut Value;
+  fn v8__Exception__SyntaxError(message: *mut String) -> *mut Value;
   fn v8__Exception__TypeError(message: *mut String) -> *mut Value;
+  fn v8__Exception__Error(message: *mut String) -> *mut Value;
 }
 
 pub mod Exception {
   use super::*;
 
+  pub fn RangeError<'sc>(mut message: Local<'_, String>) -> Local<'_, Value> {
+    unsafe { Local::from_raw(v8__Exception__RangeError(&mut *message)) }
+      .unwrap()
+  }
+
+  pub fn ReferenceError<'sc>(
+    mut message: Local<'_, String>,
+  ) -> Local<'_, Value> {
+    unsafe { Local::from_raw(v8__Exception__ReferenceError(&mut *message)) }
+      .unwrap()
+  }
+
+  pub fn SyntaxError<'sc>(mut message: Local<'_, String>) -> Local<'_, Value> {
+    unsafe { Local::from_raw(v8__Exception__SyntaxError(&mut *message)) }
+      .unwrap()
+  }
+
   pub fn TypeError<'sc>(mut message: Local<'_, String>) -> Local<'_, Value> {
     unsafe { Local::from_raw(v8__Exception__TypeError(&mut *message)) }.unwrap()
+  }
+
+  pub fn Error<'sc>(mut message: Local<'_, String>) -> Local<'_, Value> {
+    unsafe { Local::from_raw(v8__Exception__Error(&mut *message)) }.unwrap()
   }
 }

--- a/src/isolate.cc
+++ b/src/isolate.cc
@@ -17,6 +17,14 @@ void v8__Isolate__Dispose(Isolate& isolate) {
   delete allocator;
 }
 
+void v8__Isolate__Enter(Isolate& isolate) {
+  isolate.Enter();
+}
+
+void v8__Isolate__Exit(Isolate& isolate) {
+  isolate.Exit();
+}
+
 Isolate::CreateParams* v8__Isolate__CreateParams__NEW() {
   return new Isolate::CreateParams();
 }

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -9,6 +9,8 @@ use crate::support::UniqueRef;
 extern "C" {
   fn v8__Isolate__New(params: *mut CreateParams) -> &'static mut CxxIsolate;
   fn v8__Isolate__Dispose(this: &mut CxxIsolate) -> ();
+  fn v8__Isolate__Enter(this: &mut CxxIsolate) -> ();
+  fn v8__Isolate__Exit(this: &mut CxxIsolate) -> ();
 
   fn v8__Isolate__CreateParams__NEW() -> *mut CreateParams;
   fn v8__Isolate__CreateParams__DELETE(this: &mut CreateParams);
@@ -45,6 +47,14 @@ impl Isolate {
   /// Initial configuration parameters for a new Isolate.
   pub fn create_params() -> UniqueRef<CreateParams> {
     CreateParams::new()
+  }
+
+  pub fn enter(&mut self) {
+    unsafe { v8__Isolate__Enter(self.0) }
+  }
+
+  pub fn exit(&mut self) {
+    unsafe { v8__Isolate__Exit(self.0) }
   }
 }
 

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -49,10 +49,18 @@ impl Isolate {
     CreateParams::new()
   }
 
+  /// Sets this isolate as the entered one for the current thread.
+  /// Saves the previously entered one (if any), so that it can be
+  /// restored when exiting.  Re-entering an isolate is allowed.
   pub fn enter(&mut self) {
     unsafe { v8__Isolate__Enter(self.0) }
   }
 
+  /// Exits this isolate by restoring the previously entered one in the
+  /// current thread.  The isolate may still stay the same, if it was
+  /// entered more than once.
+  ///
+  /// Requires: self == Isolate::GetCurrent().
   pub fn exit(&mut self) {
     unsafe { v8__Isolate__Exit(self.0) }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate lazy_static;
 extern crate libc;
 
 mod context;
+mod exception;
 mod handle_scope;
 mod isolate;
 mod local;
@@ -32,6 +33,7 @@ pub mod platform;
 pub mod V8;
 
 pub use context::Context;
+pub use exception::Exception;
 pub use handle_scope::HandleScope;
 pub use isolate::Isolate;
 pub use local::Local;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -232,7 +232,9 @@ fn exception() {
     v8::Exception::ReferenceError(local);
     v8::Exception::SyntaxError(local);
     v8::Exception::TypeError(local);
-    v8::Exception::Error(local);
+    let exception = v8::Exception::Error(local);
+    let mut msg = v8::Exception::CreateMessage(scope, exception);
+    msg.get();
     c.exit();
   });
   isolate.exit();

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -225,10 +225,14 @@ fn exception() {
   v8::HandleScope::enter(&mut locker, |scope| {
     let mut c = v8::Context::new(scope);
     c.enter();
-    let reference = "This is a test type error";
+    let reference = "This is a test error";
     let local =
       v8::String::new(scope, reference, v8::NewStringType::Normal).unwrap();
+    v8::Exception::RangeError(local);
+    v8::Exception::ReferenceError(local);
+    v8::Exception::SyntaxError(local);
     v8::Exception::TypeError(local);
+    v8::Exception::Error(local);
     c.exit();
   });
   isolate.exit();

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -211,3 +211,25 @@ fn test_primitives() {
     assert!(!false_.is_null_or_undefined());
   });
 }
+
+#[test]
+fn exception() {
+  setup();
+  let mut params = v8::Isolate::create_params();
+  params.set_array_buffer_allocator(
+    v8::array_buffer::Allocator::new_default_allocator(),
+  );
+  let mut isolate = v8::Isolate::new(params);
+  let mut locker = v8::Locker::new(&mut isolate);
+  isolate.enter();
+  v8::HandleScope::enter(&mut locker, |scope| {
+    let mut c = v8::Context::new(scope);
+    c.enter();
+    let reference = "This is a test type error";
+    let local =
+      v8::String::new(scope, reference, v8::NewStringType::Normal).unwrap();
+    v8::Exception::TypeError(local);
+    c.exit();
+  });
+  isolate.exit();
+}

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -237,6 +237,7 @@ fn exception() {
     let msg_string = msg.get();
     let rust_msg_string = msg_string.to_rust_string_lossy(scope);
     assert_eq!("Uncaught Error: This is a test error".to_string(), rust_msg_string);
+    assert!(v8::Exception::GetStackTrace(exception).is_none());
     context.exit();
   });
   isolate.exit();

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -223,8 +223,8 @@ fn exception() {
   let mut locker = v8::Locker::new(&mut isolate);
   isolate.enter();
   v8::HandleScope::enter(&mut locker, |scope| {
-    let mut c = v8::Context::new(scope);
-    c.enter();
+    let mut context = v8::Context::new(scope);
+    context.enter();
     let reference = "This is a test error";
     let local =
       v8::String::new(scope, reference, v8::NewStringType::Normal).unwrap();
@@ -234,8 +234,10 @@ fn exception() {
     v8::Exception::TypeError(local);
     let exception = v8::Exception::Error(local);
     let mut msg = v8::Exception::CreateMessage(scope, exception);
-    msg.get();
-    c.exit();
+    let msg_string = msg.get();
+    let rust_msg_string = msg_string.to_rust_string_lossy(scope);
+    assert_eq!("Uncaught Error: This is a test error".to_string(), rust_msg_string);
+    context.exit();
   });
   isolate.exit();
 }


### PR DESCRIPTION
- [x] v8::Exception::TypeError
- [x] v8::Exception::RangeError
- [x] v8::Exception::ReferenceError
- [x] v8::Exception::SyntaxError
- [x] v8::Exception::Error
- [x] v8::Exception::GetStackTrace - needs `v8::StackTrace`
- [x] v8::Exception::CreateMessage

Because of how errors are defined:
```c++
#define DEFINE_ERROR(NAME, name)                                         \
  Local<Value> Exception::NAME(v8::Local<v8::String> raw_message) {      \
    i::Isolate* isolate = i::Isolate::Current();                         \
    LOG_API(isolate, NAME, New);                                         \
    ENTER_V8_NO_SCRIPT_NO_EXCEPTION(isolate);                            \
    i::Object error;                                                     \
    {                                                                    \
      i::HandleScope scope(isolate);                                     \
      i::Handle<i::String> message = Utils::OpenHandle(*raw_message);    \
      i::Handle<i::JSFunction> constructor = isolate->name##_function(); \
      error = *isolate->factory()->NewError(constructor, message);       \
    }                                                                    \
    i::Handle<i::Object> result(error, isolate);                         \
    return Utils::ToLocal(result);                                       \
  }

DEFINE_ERROR(RangeError, range_error)
DEFINE_ERROR(ReferenceError, reference_error)
DEFINE_ERROR(SyntaxError, syntax_error)
DEFINE_ERROR(TypeError, type_error)
DEFINE_ERROR(Error, error)

#undef DEFINE_ERROR
```
I had to port `Isolate.enter` and `Isolate.exit` as well (they set isolate for current thread which is used by `i::Isolate::Current()`
