### PR TITLE
Add shared_ptr wrapper and implement ArrayBuffer::get_backing_store() + new_with_backing_store()

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -70,7 +70,6 @@ v8::MaybeLocal<v8::Promise> HostImportModuleDynamicallyCallback(
 }
 
 extern "C" {
-
 void v8__V8__SetFlagsFromCommandLine(int* argc, char** argv) {
   v8::V8::SetFlagsFromCommandLine(argc, argv, true);
 }
@@ -325,6 +324,10 @@ v8::BackingStore* v8__ArrayBuffer__NewBackingStore(v8::Isolate* isolate,
   return u.release();
 }
 
+two_pointers_t v8__ArrayBuffer__GetBackingStore(v8::ArrayBuffer& self) {
+  return make_pod<two_pointers_t>(self.GetBackingStore());
+}
+
 size_t v8__BackingStore__ByteLength(v8::BackingStore& self) {
   return self.ByteLength();
 }
@@ -334,6 +337,21 @@ bool v8__BackingStore__IsShared(v8::BackingStore& self) {
 }
 
 void v8__BackingStore__DELETE(v8::BackingStore& self) { delete &self; }
+
+v8::BackingStore* std__shared_ptr__v8__BackingStore__get(
+    const std::shared_ptr<v8::BackingStore>& ptr) {
+  return ptr.get();
+}
+
+void std__shared_ptr__v8__BackingStore__reset(
+    std::shared_ptr<v8::BackingStore>& ptr) {
+  ptr.reset();
+}
+
+long std__shared_ptr__v8__BackingStore__use_count(
+    const std::shared_ptr<v8::BackingStore>& ptr) {
+  return ptr.use_count();
+}
 
 v8::String* v8__String__NewFromUtf8(v8::Isolate* isolate, const char* data,
                                     v8::NewStringType type, int length) {
@@ -419,9 +437,14 @@ void v8__ArrayBuffer__Allocator__DELETE(v8::ArrayBuffer::Allocator& self) {
   delete &self;
 }
 
-v8::ArrayBuffer* v8__ArrayBuffer__New(v8::Isolate* isolate,
-                                      size_t byte_length) {
+v8::ArrayBuffer* v8__ArrayBuffer__New__byte_length(v8::Isolate* isolate,
+                                                   size_t byte_length) {
   return local_to_ptr(v8::ArrayBuffer::New(isolate, byte_length));
+}
+
+v8::ArrayBuffer* v8__ArrayBuffer__New__backing_store(
+    v8::Isolate* isolate, std::shared_ptr<v8::BackingStore>& backing_store) {
+  return local_to_ptr(v8::ArrayBuffer::New(isolate, backing_store));
 }
 
 size_t v8__ArrayBuffer__ByteLength(v8::ArrayBuffer& self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub use snapshot::{FunctionCodeHandling, SnapshotCreator, StartupData};
 pub use string::NewStringType;
 pub use string::String;
 pub use support::MaybeBool;
+pub use support::SharedRef;
 pub use support::UniqueRef;
 pub use try_catch::{TryCatch, TryCatchScope};
 pub use uint8_array::Uint8Array;

--- a/src/support.h
+++ b/src/support.h
@@ -2,6 +2,7 @@
 #define SUPPORT_H_
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <memory>
 #include <new>
@@ -11,9 +12,8 @@
 #include "v8/include/v8.h"
 
 // Check assumptions made in binding code.
-// TODO(ry) re-enable the following
-// static_assert(sizeof(bool) == sizeof(uint8_t));
-// static_assert(sizeof(std::unique_ptr<void>) == sizeof(void*));
+static_assert(sizeof(bool) == sizeof(uint8_t), "");
+static_assert(sizeof(std::unique_ptr<void>) == sizeof(void*), "");
 
 namespace support {
 template <class T>
@@ -34,6 +34,44 @@ void construct_in_place(uninit_t<T>& buf, Args... args) {
   new (&buf)
       construct_in_place_helper<T, Args...>(buf, std::forward<Args>(args)...);
 }
+
+template <class P>
+struct make_pod {
+  template <class V>
+  inline make_pod(V&& value) : pod_(helper<V>(value)) {}
+  template <class V>
+  inline make_pod(const V& value) : pod_(helper<V>(value)) {}
+  inline operator P() { return pod_; }
+
+ private:
+  P pod_;
+
+  template <class V>
+  union helper {
+    static_assert(std::is_pod<P>::value, "type P must a pod type");
+    static_assert(sizeof(V) <= sizeof(P),
+                  "type P must be at least as big as type V");
+    static_assert(alignof(V) <= alignof(P),
+                  "alignment of type P must be compatible with that of type V");
+
+    inline helper(V&& value) : value_(value), padding_() {}
+    inline helper(const V& value) : value_(value), padding_() {}
+    inline ~helper() {}
+
+    inline operator P() {
+      // Do a memcpy here avoid undefined behavior.
+      P result;
+      memcpy(&result, this, sizeof result);
+      return result;
+    }
+
+   private:
+    struct {
+      V value_;
+      char padding_[sizeof(P) - sizeof(V)];
+    };
+  };
+};
 
 // The C-ABI compatible equivalent of V8's Maybe<bool>.
 enum class MaybeBool { JustFalse = 0, JustTrue = 1, Nothing = 2 };
@@ -86,6 +124,13 @@ inline static v8::Global<T> ptr_to_global(T* ptr) {
   std::swap(ptr, *reinterpret_cast<T**>(&global));
   return global;
 }
+
+// Because, for some reason, Clang complains that `std::aray<void*, 2` is an
+// incomplete type, incompatible with C linkage.
+struct two_pointers_t {
+  void* a;
+  void* b;
+};
 
 }  // namespace support
 


### PR DESCRIPTION
TODO: add test that the C++ reference count actually increases/decreases as expected, and that memory is released when the reference count gets to zero.