### PR TITLE
Remove rust-abi wrapper for v8::ResolveCallback (#204)

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1355,25 +1355,23 @@ int v8__Module__GetIdentityHash(const v8::Module& self) {
 
 // This is an extern C calling convention compatible version of
 // v8::Module::ResolveCallback.
-typedef v8::Module* (*v8__Module__ResolveCallback)(
-    v8::Local<v8::Context> context, v8::Local<v8::String> specifier,
-    v8::Local<v8::Module> referrer);
+using v8__Module__ResolveCallback =
+    const v8::Module* (*)(v8::Local<v8::Context> context,
+                          v8::Local<v8::String> specifier,
+                          v8::Local<v8::Module> referrer);
 
 MaybeBool v8__Module__InstantiateModule(v8::Module& self,
                                         v8::Local<v8::Context> context,
                                         v8__Module__ResolveCallback c_cb) {
-  static v8__Module__ResolveCallback static_cb = nullptr;
+  thread_local v8__Module__ResolveCallback static_cb = nullptr;
   assert(static_cb == nullptr);
   static_cb = c_cb;
+
   auto cxx_cb = [](v8::Local<v8::Context> context,
                    v8::Local<v8::String> specifier,
                    v8::Local<v8::Module> referrer) {
-    v8::Module* m = static_cb(context, specifier, referrer);
-    if (m == nullptr) {
-      return v8::MaybeLocal<v8::Module>();
-    } else {
-      return v8::MaybeLocal<v8::Module>(ptr_to_local(m));
-    }
+    const auto* m = static_cb(context, specifier, referrer);
+    return ptr_to_maybe_local(const_cast<v8::Module*>(m));
   };
 
   auto r = maybe_to_maybe_bool(self.InstantiateModule(context, cxx_cb));


### PR DESCRIPTION
It will be back, but in a different form.