### PR TITLE
Make EscapableHandleScope::escape() inheritable, tighten lifetimes

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -107,7 +107,6 @@ pub struct FunctionCallbackInfo {
 }
 
 unsafe impl<'s> ScopeDefinition<'s> for FunctionCallbackInfo {
-  type Parent = ();
   type Args = ();
   unsafe fn enter_scope(_: *mut Self, _: Self::Args) {}
 }
@@ -122,7 +121,6 @@ pub struct PropertyCallbackInfo {
 }
 
 unsafe impl<'s> ScopeDefinition<'s> for PropertyCallbackInfo {
-  type Parent = ();
   type Args = ();
   unsafe fn enter_scope(_: *mut Self, _: Self::Args) {}
 }
@@ -235,7 +233,7 @@ where
   fn mapping() -> Self {
     let f = |info: *const FunctionCallbackInfo| {
       let scope: FunctionCallbackScope =
-        &mut crate::scope::Entered::new(info as *mut FunctionCallbackInfo);
+        &mut crate::scope::Entered::new_root(info as *mut FunctionCallbackInfo);
       let args = FunctionCallbackArguments::from_function_callback_info(info);
       let rv = ReturnValue::from_function_callback_info(info);
       (F::get())(scope, args, rv);
@@ -262,7 +260,7 @@ where
   fn mapping() -> Self {
     let f = |key: Local<Name>, info: *const PropertyCallbackInfo| {
       let scope: PropertyCallbackScope =
-        &mut crate::scope::Entered::new(info as *mut PropertyCallbackInfo);
+        &mut crate::scope::Entered::new_root(info as *mut PropertyCallbackInfo);
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
       (F::get())(scope, key, args, rv);

--- a/src/handle_scope.rs
+++ b/src/handle_scope.rs
@@ -1,7 +1,5 @@
 // Copyright 2019-2020 the Deno authors. All rights reserved. MIT license.
 
-use std::marker::PhantomData;
-
 use crate::isolate::Isolate;
 use crate::scope::Scope;
 use crate::scope::ScopeDefinition;
@@ -11,15 +9,15 @@ use crate::Local;
 use crate::Value;
 
 extern "C" {
-  fn v8__HandleScope__CONSTRUCT(buf: *mut CxxHandleScope, isolate: &Isolate);
-  fn v8__HandleScope__DESTRUCT(this: &mut CxxHandleScope);
+  fn v8__HandleScope__CONSTRUCT(buf: *mut HandleScope, isolate: *mut Isolate);
+  fn v8__HandleScope__DESTRUCT(this: &mut HandleScope);
   fn v8__EscapableHandleScope__CONSTRUCT(
-    buf: *mut CxxEscapableHandleScope,
-    isolate: &Isolate,
+    buf: *mut EscapableHandleScope,
+    isolate: *mut Isolate,
   );
-  fn v8__EscapableHandleScope__DESTRUCT(this: &mut CxxEscapableHandleScope);
+  fn v8__EscapableHandleScope__DESTRUCT(this: &mut EscapableHandleScope);
   fn v8__EscapableHandleScope__Escape(
-    this: &mut CxxEscapableHandleScope,
+    this: &mut EscapableHandleScope,
     value: *mut Value,
   ) -> *mut Value;
 }
@@ -36,84 +34,69 @@ extern "C" {
 /// garbage collector will no longer track the object stored in the
 /// handle and may deallocate it.  The behavior of accessing a handle
 /// for which the handle scope has been deleted is undefined.
-pub struct HandleScope<P>(CxxHandleScope, PhantomData<P>);
-
 #[repr(C)]
-pub(crate) struct CxxHandleScope([usize; 3]);
+pub struct HandleScope([usize; 3]);
 
-impl<'s, P> HandleScope<P>
-where
-  P: InIsolate,
-{
-  pub fn new(parent: &'s mut P) -> Scope<'s, Self> {
-    Scope::new(parent.isolate())
+impl<'s> HandleScope {
+  pub fn new<P>(parent: &'s mut P) -> Scope<'s, Self, P>
+  where
+    P: InIsolate,
+  {
+    let isolate: *mut Isolate = parent.isolate();
+    Scope::new(isolate, parent)
   }
 }
 
-impl<'s, P> HandleScope<P> {
-  pub(crate) fn inner(&self) -> &CxxHandleScope {
-    &self.0
+unsafe impl<'s> ScopeDefinition<'s> for HandleScope {
+  type Args = *mut Isolate;
+  unsafe fn enter_scope(buf: *mut Self, isolate: *mut Isolate) {
+    v8__HandleScope__CONSTRUCT(buf, isolate);
   }
 }
 
-unsafe impl<'s, P> ScopeDefinition<'s> for HandleScope<P> {
-  type Parent = P;
-  type Args = &'s mut Isolate;
-  unsafe fn enter_scope(ptr: *mut Self, isolate: &mut Isolate) {
-    v8__HandleScope__CONSTRUCT(&mut (*ptr).0, isolate);
-  }
-}
-
-impl<P> Drop for HandleScope<P> {
+impl Drop for HandleScope {
   fn drop(&mut self) {
-    unsafe { v8__HandleScope__DESTRUCT(&mut self.0) }
+    unsafe { v8__HandleScope__DESTRUCT(self) }
   }
 }
 
 /// A HandleScope which first allocates a handle in the current scope
 /// which will be later filled with the escape value.
-pub struct EscapableHandleScope<P>(CxxEscapableHandleScope, PhantomData<P>);
-
 #[repr(C)]
-pub(crate) struct CxxEscapableHandleScope([usize; 4]);
+pub struct EscapableHandleScope([usize; 4]);
 
-impl<'p: 's, 's, P> EscapableHandleScope<P>
-where
-  P: ToLocalOrReturnsLocal<'p>,
-{
-  pub fn new(parent: &'s mut P) -> Scope<'s, Self> {
-    Scope::new(parent.isolate())
+impl<'s> EscapableHandleScope {
+  pub fn new<'p: 's, P>(parent: &'s mut P) -> Scope<'s, Self, P>
+  where
+    P: ToLocalOrReturnsLocal<'p>,
+  {
+    let isolate: *mut Isolate = parent.isolate();
+    Scope::new(isolate, parent)
   }
-}
 
-impl<P> EscapableHandleScope<P> {
   /// Pushes the value into the previous scope and returns a handle to it.
   /// Cannot be called twice.
-  pub fn escape<'parent, T>(&mut self, value: Local<T>) -> Local<'parent, T> {
-    unsafe {
-      Local::from_raw(v8__EscapableHandleScope__Escape(
-        &mut self.0,
-        value.as_ptr() as *mut Value,
-      ) as *mut T)
-    }
+  pub(crate) unsafe fn escape<'p, T>(
+    &mut self,
+    value: Local<T>,
+  ) -> Local<'p, T> {
+    Local::from_raw(v8__EscapableHandleScope__Escape(
+      self,
+      value.as_ptr() as *mut Value,
+    ) as *mut T)
     .unwrap()
   }
+}
 
-  pub(crate) fn inner(&self) -> &CxxEscapableHandleScope {
-    &self.0
+unsafe impl<'s> ScopeDefinition<'s> for EscapableHandleScope {
+  type Args = *mut Isolate;
+  unsafe fn enter_scope(buf: *mut Self, isolate: *mut Isolate) {
+    v8__EscapableHandleScope__CONSTRUCT(buf, isolate);
   }
 }
 
-unsafe impl<'s, P> ScopeDefinition<'s> for EscapableHandleScope<P> {
-  type Parent = P;
-  type Args = &'s mut Isolate;
-  unsafe fn enter_scope(ptr: *mut Self, isolate: &mut Isolate) {
-    v8__EscapableHandleScope__CONSTRUCT(&mut (*ptr).0, isolate);
-  }
-}
-
-impl<P> Drop for EscapableHandleScope<P> {
+impl Drop for EscapableHandleScope {
   fn drop(&mut self) {
-    unsafe { v8__EscapableHandleScope__DESTRUCT(&mut self.0) }
+    unsafe { v8__EscapableHandleScope__DESTRUCT(self) }
   }
 }

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -28,6 +28,10 @@ impl Locker {
     }
   }
 
+  pub fn isolate(&mut self) -> &mut Isolate {
+    unsafe { &mut *self.isolate }
+  }
+
   pub(crate) fn get_raw_isolate_(&self) -> *mut Isolate {
     self.isolate
   }

--- a/tests/compile_fail/handle_scope_escape_lifetime.rs
+++ b/tests/compile_fail/handle_scope_escape_lifetime.rs
@@ -1,0 +1,23 @@
+// Copyright 2019-2020 the Deno authors. All rights reserved. MIT license.
+use rusty_v8 as v8;
+
+pub fn main() {
+  let mut locker: v8::Locker = mock();
+  let mut hs0 = v8::HandleScope::new(&mut locker);
+  let hs0 = hs0.enter();
+
+  let _fail = {
+    let mut hs1 = v8::HandleScope::new(hs0);
+    let hs1 = hs1.enter();
+
+    let mut hs2 = v8::EscapableHandleScope::new(hs1);
+    let hs2 = hs2.enter();
+
+    let value: v8::Local<v8::Value> = v8::Integer::new(hs2, 42).into();
+    hs2.escape(value)
+  };
+}
+
+fn mock<T>() -> T {
+  unimplemented!()
+}

--- a/tests/compile_fail/handle_scope_escape_lifetime.stderr
+++ b/tests/compile_fail/handle_scope_escape_lifetime.stderr
@@ -1,0 +1,11 @@
+error[E0597]: `hs1` does not live long enough
+  --> $DIR/handle_scope_escape_lifetime.rs:11:15
+   |
+9  |   let _fail = {
+   |       ----- borrow later stored here
+10 |     let mut hs1 = v8::HandleScope::new(hs0);
+11 |     let hs1 = hs1.enter();
+   |               ^^^ borrowed value does not live long enough
+...
+18 |   };
+   |   - `hs1` dropped here while still borrowed

--- a/tests/compile_fail/handle_scope_escape_to_nowhere.rs
+++ b/tests/compile_fail/handle_scope_escape_to_nowhere.rs
@@ -1,0 +1,12 @@
+// Copyright 2019-2020 the Deno authors. All rights reserved. MIT license.
+use rusty_v8 as v8;
+
+pub fn main() {
+  let context: v8::Local<v8::Context> = mock();
+  let mut cs = v8::CallbackScope::new(context);
+  let _hs = v8::EscapableHandleScope::new(cs.enter());
+}
+
+fn mock<T>() -> T {
+  unimplemented!()
+}

--- a/tests/compile_fail/handle_scope_escape_to_nowhere.stderr
+++ b/tests/compile_fail/handle_scope_escape_to_nowhere.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `rusty_v8::scope::Entered<'_, rusty_v8::scope::CallbackScope>: rusty_v8::scope_traits::ToLocal<'_>` is not satisfied
+  --> $DIR/handle_scope_escape_to_nowhere.rs:7:43
+   |
+7  |   let _hs = v8::EscapableHandleScope::new(cs.enter());
+   |                                           ^^^^^^^^^^ the trait `rusty_v8::scope_traits::ToLocal<'_>` is not implemented for `rusty_v8::scope::Entered<'_, rusty_v8::scope::CallbackScope>`
+   | 
+  ::: $WORKSPACE/src/handle_scope.rs:71:8
+   |
+71 |     P: ToLocalOrReturnsLocal<'p>,
+   |        ------------------------- required by this bound in `rusty_v8::handle_scope::EscapableHandleScope::new`
+   |
+   = help: the following implementations were found:
+             <rusty_v8::scope::Entered<'s, rusty_v8::function::FunctionCallbackInfo> as rusty_v8::scope_traits::ToLocal<'s>>
+             <rusty_v8::scope::Entered<'s, rusty_v8::function::PropertyCallbackInfo> as rusty_v8::scope_traits::ToLocal<'s>>
+             <rusty_v8::scope::Entered<'s, rusty_v8::handle_scope::EscapableHandleScope, P> as rusty_v8::scope_traits::ToLocal<'s>>
+             <rusty_v8::scope::Entered<'s, rusty_v8::handle_scope::HandleScope, P> as rusty_v8::scope_traits::ToLocal<'s>>
+             <rusty_v8::scope::Entered<'s, rusty_v8::scope::ContextScope, P> as rusty_v8::scope_traits::ToLocal<'s>>
+   = note: required because of the requirements on the impl of `rusty_v8::scope_traits::ToLocalOrReturnsLocal<'_>` for `rusty_v8::scope::Entered<'_, rusty_v8::scope::CallbackScope>`

--- a/tests/compile_fail/handle_scope_lifetimes.rs
+++ b/tests/compile_fail/handle_scope_lifetimes.rs
@@ -1,17 +1,20 @@
-extern crate rusty_v8 as v8;
+// Copyright 2019-2020 the Deno authors. All rights reserved. MIT license.
+use rusty_v8 as v8;
 
 pub fn main() {
-  let mut isolate: v8::scope::Entered<v8::HandleScope<v8::Locker>> = mock();
+  let mut locker: v8::Locker = mock();
+  let mut root_hs = v8::HandleScope::new(&mut locker);
+  let root_hs = root_hs.enter();
 
   {
-    let mut hs = v8::EscapableHandleScope::new(&mut isolate);
+    let mut hs = v8::EscapableHandleScope::new(root_hs);
     let hs = hs.enter();
-    let _fail = v8::EscapableHandleScope::new(&mut isolate);
+    let _fail = v8::EscapableHandleScope::new(root_hs);
     let _local = v8::Integer::new(hs, 123);
   }
 
   {
-    let mut hs1 = v8::EscapableHandleScope::new(&mut isolate);
+    let mut hs1 = v8::EscapableHandleScope::new(root_hs);
     let hs1 = hs1.enter();
     let _local1 = v8::Integer::new(hs1, 123);
 
@@ -23,13 +26,13 @@ pub fn main() {
   }
 
   let _leak1 = {
-    let mut hs = v8::EscapableHandleScope::new(&mut isolate);
+    let mut hs = v8::EscapableHandleScope::new(root_hs);
     let hs = hs.enter();
     v8::Integer::new(hs, 456)
   };
 
   let _leak = {
-    let mut hs = v8::EscapableHandleScope::new(&mut isolate);
+    let mut hs = v8::EscapableHandleScope::new(root_hs);
     hs.enter()
   };
 }
@@ -37,5 +40,3 @@ pub fn main() {
 fn mock<T>() -> T {
   unimplemented!()
 }
-
-fn access<T>(_value: T) {}

--- a/tests/compile_fail/handle_scope_lifetimes.stderr
+++ b/tests/compile_fail/handle_scope_lifetimes.stderr
@@ -1,44 +1,44 @@
-error[E0499]: cannot borrow `isolate` as mutable more than once at a time
-  --> $DIR/handle_scope_lifetimes.rs:9:47
+error[E0499]: cannot borrow `*root_hs` as mutable more than once at a time
+  --> $DIR/handle_scope_lifetimes.rs:12:47
    |
-7  |     let mut hs = v8::EscapableHandleScope::new(&mut isolate);
-   |                                                ------------ first mutable borrow occurs here
-8  |     let hs = hs.enter();
-9  |     let _fail = v8::EscapableHandleScope::new(&mut isolate);
-   |                                               ^^^^^^^^^^^^ second mutable borrow occurs here
-10 |     let _local = v8::Integer::new(hs, 123);
+10 |     let mut hs = v8::EscapableHandleScope::new(root_hs);
+   |                                                ------- first mutable borrow occurs here
+11 |     let hs = hs.enter();
+12 |     let _fail = v8::EscapableHandleScope::new(root_hs);
+   |                                               ^^^^^^^ second mutable borrow occurs here
+13 |     let _local = v8::Integer::new(hs, 123);
    |                                   -- first borrow later used here
 
 error[E0499]: cannot borrow `*hs1` as mutable more than once at a time
-  --> $DIR/handle_scope_lifetimes.rs:20:34
+  --> $DIR/handle_scope_lifetimes.rs:23:34
    |
-18 |     let mut hs2 = v8::EscapableHandleScope::new(hs1);
+21 |     let mut hs2 = v8::EscapableHandleScope::new(hs1);
    |                                                 --- first mutable borrow occurs here
-19 |     let hs2 = hs2.enter();
-20 |     let _fail = v8::Integer::new(hs1, 123);
+22 |     let hs2 = hs2.enter();
+23 |     let _fail = v8::Integer::new(hs1, 123);
    |                                  ^^^ second mutable borrow occurs here
-21 |     let _local2 = v8::Integer::new(hs2, 123);
+24 |     let _local2 = v8::Integer::new(hs2, 123);
    |                                    --- first borrow later used here
 
 error[E0597]: `hs` does not live long enough
-  --> $DIR/handle_scope_lifetimes.rs:27:14
+  --> $DIR/handle_scope_lifetimes.rs:30:14
    |
-25 |   let _leak1 = {
+28 |   let _leak1 = {
    |       ------ borrow later stored here
-26 |     let mut hs = v8::EscapableHandleScope::new(&mut isolate);
-27 |     let hs = hs.enter();
+29 |     let mut hs = v8::EscapableHandleScope::new(root_hs);
+30 |     let hs = hs.enter();
    |              ^^ borrowed value does not live long enough
-28 |     v8::Integer::new(hs, 456)
-29 |   };
+31 |     v8::Integer::new(hs, 456)
+32 |   };
    |   - `hs` dropped here while still borrowed
 
 error[E0597]: `hs` does not live long enough
-  --> $DIR/handle_scope_lifetimes.rs:33:5
+  --> $DIR/handle_scope_lifetimes.rs:36:5
    |
-33 |     hs.enter()
+36 |     hs.enter()
    |     ^^--------
    |     |
    |     borrowed value does not live long enough
    |     borrow later used here
-34 |   };
+37 |   };
    |   - `hs` dropped here while still borrowed

--- a/tests/compile_fail/try_catch_lifetimes.rs
+++ b/tests/compile_fail/try_catch_lifetimes.rs
@@ -1,7 +1,8 @@
-extern crate rusty_v8 as v8;
+// Copyright 2019-2020 the Deno authors. All rights reserved. MIT license.
+use rusty_v8 as v8;
 
 pub fn main() {
-  let mut scope: v8::Scope<v8::HandleScope<v8::Locker>> = mock();
+  let mut scope: v8::Scope<v8::HandleScope, v8::Locker> = mock();
   let scope = scope.enter();
   let context: v8::Local<v8::Context> = mock();
 

--- a/tests/compile_fail/try_catch_lifetimes.stderr
+++ b/tests/compile_fail/try_catch_lifetimes.stderr
@@ -1,11 +1,11 @@
 error[E0597]: `try_catch` does not live long enough
-  --> $DIR/try_catch_lifetimes.rs:10:14
+  --> $DIR/try_catch_lifetimes.rs:11:14
    |
-8  |   let _leaked = {
+9  |   let _leaked = {
    |       ------- borrow later stored here
-9  |     let mut try_catch = v8::TryCatch::new(scope);
-10 |     let tc = try_catch.enter();
+10 |     let mut try_catch = v8::TryCatch::new(scope);
+11 |     let tc = try_catch.enter();
    |              ^^^^^^^^^ borrowed value does not live long enough
 ...
-15 |   };
+16 |   };
    |   - `try_catch` dropped here while still borrowed

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8,7 +8,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use rusty_v8 as v8;
-use v8::InIsolate;
 // TODO(piscisaureus): Ideally there would be no need to import this trait.
 use v8::MapFnTo;
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1513,16 +1513,6 @@ fn primitive_array() {
 }
 
 #[test]
-fn ui() {
-  // This environment variable tells build.rs that we're running trybuild tests,
-  // so it won't rebuild V8.
-  std::env::set_var("DENO_TRYBUILD", "1");
-
-  let t = trybuild::TestCases::new();
-  t.compile_fail("tests/compile_fail/*.rs");
-}
-
-#[test]
 fn equality() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();

--- a/tests/test_ui.rs
+++ b/tests/test_ui.rs
@@ -1,0 +1,21 @@
+use std::env;
+use trybuild;
+
+#[test]
+fn ui() {
+  // This environment variable tells build.rs that we're running trybuild tests,
+  // so it won't rebuild V8.
+  env::set_var("DENO_TRYBUILD", "1");
+
+  let t = trybuild::TestCases::new();
+  t.compile_fail("tests/compile_fail/handle_scope_escape_lifetime.rs");
+  t.compile_fail("tests/compile_fail/handle_scope_lifetimes.rs");
+  t.compile_fail("tests/compile_fail/try_catch_lifetimes.rs");
+
+  // For unclear reasons rustc on Windows in Github Actions omits some
+  // diagnostic information, causing this test to fail. It might have something
+  // to do with this Rust issue: https://github.com/rust-lang/rust/issues/53081.
+  if cfg!(not(windows)) || env::var("GITHUB_ACTION").is_err() {
+    t.compile_fail("tests/compile_fail/handle_scope_escape_to_nowhere.rs");
+  }
+}


### PR DESCRIPTION
And a lot of scope-related restructuring.