### PR TITLE
Implement fmt::Display for StringView

### DIFF
--- a/src/inspector/string_view.rs
+++ b/src/inspector/string_view.rs
@@ -40,7 +40,6 @@ use std::string;
 //    TODO: find/open upstream issue to allow #[repr(bool)] support.
 
 #[repr(u8)]
-#[derive(Debug)]
 pub enum StringView<'a> {
   // Do not reorder!
   U16(CharacterArray<'a, u16>),
@@ -196,7 +195,7 @@ impl<'a, T> Deref for CharacterArray<'a, T> {
   }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 pub struct StringViewIterator<'a: 'b, 'b> {
   view: &'a StringView<'b>,
   pos: usize,


### PR DESCRIPTION
Make StringView objects inspectable to make it easier to debug the
V8 inspector's wire protocol.

StringBuffer objects can't be inspected yet because they need a mutable
reference if they want to call `StringBuffer::string()`, which makes
sense because that method calls out to a C++ virtual method that can
modify the object.

For now, instances can be inspected like this:

    let mut sb = StringBuffer::create(...);
    println!("StringBuffer({})", sb.string().unwrap());

Closes #233