### PR TITLE
Refactor v8::Object bindings

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -658,10 +658,9 @@ v8::Object* v8__Object__New(v8::Isolate* isolate) {
   return local_to_ptr(v8::Object::New(isolate));
 }
 
-v8::Object* v8__Object__New2(v8::Isolate* isolate,
-                             v8::Local<v8::Value> prototype_or_null,
-                             v8::Local<v8::Name>* names,
-                             v8::Local<v8::Value>* values, size_t length) {
+v8::Object* v8__Object__New__with_prototype_and_properties(
+    v8::Isolate* isolate, v8::Local<v8::Value> prototype_or_null,
+    v8::Local<v8::Name>* names, v8::Local<v8::Value>* values, size_t length) {
   return local_to_ptr(
       v8::Object::New(isolate, prototype_or_null, names, values, length));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,6 @@ pub use snapshot::OwnedStartupData;
 pub use snapshot::SnapshotCreator;
 pub use snapshot::StartupData;
 pub use string::NewStringType;
-pub use support::MaybeBool;
 pub use support::SharedRef;
 pub use support::UniquePtr;
 pub use support::UniqueRef;

--- a/src/support.rs
+++ b/src/support.rs
@@ -236,7 +236,7 @@ where
 
 #[repr(C)]
 #[derive(Debug, PartialEq)]
-pub enum MaybeBool {
+pub(crate) enum MaybeBool {
   JustFalse = 0,
   JustTrue = 1,
   Nothing = 2,


### PR DESCRIPTION
* Rename `Object::new2()` to `Object::with_prototype_and_properties()`.
* Make `Object::with_prototype_and_properties()` take a slice of keys
  and a slice of values as arguments, instead of using
  `Vec<v8::Local<v8::Name>>` and `Vec<v8::Local<v8::Value>>>`.
* Remove type `MaybeBool` from the public interface. These methods now
  return `Option<bool>` instead.
* Fix parameter type mismatches between Rust and C++ APIs.