### PR TITLE
Rename String::new_empty() to String::empty()

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -658,10 +658,9 @@ v8::Object* v8__Object__New(v8::Isolate* isolate) {
   return local_to_ptr(v8::Object::New(isolate));
 }
 
-v8::Object* v8__Object__New2(v8::Isolate* isolate,
-                             v8::Local<v8::Value> prototype_or_null,
-                             v8::Local<v8::Name>* names,
-                             v8::Local<v8::Value>* values, size_t length) {
+v8::Object* v8__Object__New__with_prototype_and_properties(
+    v8::Isolate* isolate, v8::Local<v8::Value> prototype_or_null,
+    v8::Local<v8::Name>* names, v8::Local<v8::Value>* values, size_t length) {
   return local_to_ptr(
       v8::Object::New(isolate, prototype_or_null, names, values, length));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,6 @@ pub use snapshot::OwnedStartupData;
 pub use snapshot::SnapshotCreator;
 pub use snapshot::StartupData;
 pub use string::NewStringType;
-pub use support::MaybeBool;
 pub use support::SharedRef;
 pub use support::UniquePtr;
 pub use support::UniqueRef;

--- a/src/string.rs
+++ b/src/string.rs
@@ -63,7 +63,7 @@ bitflags! {
 }
 
 impl String {
-  pub fn new_empty<'sc>(scope: &mut impl ToLocal<'sc>) -> Local<'sc, String> {
+  pub fn empty<'sc>(scope: &mut impl ToLocal<'sc>) -> Local<'sc, String> {
     let ptr = unsafe { v8__String__Empty(scope.isolate()) };
     // FIXME(bnoordhuis) v8__String__Empty() is infallible so there
     // is no need to box up the result, only to unwrap it again.
@@ -76,7 +76,7 @@ impl String {
     new_type: NewStringType,
   ) -> Option<Local<'sc, String>> {
     if buffer.is_empty() {
-      return Some(Self::new_empty(scope));
+      return Some(Self::empty(scope));
     }
     let ptr = unsafe {
       v8__String__NewFromUtf8(

--- a/src/support.rs
+++ b/src/support.rs
@@ -236,7 +236,7 @@ where
 
 #[repr(C)]
 #[derive(Debug, PartialEq)]
-pub enum MaybeBool {
+pub(crate) enum MaybeBool {
   JustFalse = 0,
   JustTrue = 1,
   Nothing = 2,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -152,7 +152,7 @@ fn test_string() {
   {
     let mut hs = v8::HandleScope::new(scope);
     let scope = hs.enter();
-    let local = v8::String::new_empty(scope);
+    let local = v8::String::empty(scope);
     assert_eq!(0, local.length());
     assert_eq!(0, local.utf8_length(scope));
     assert_eq!("", local.to_rust_string_lossy(scope));


### PR DESCRIPTION
This is more consistent with the C++ API.