### PR TITLE
ArrayBuffer::new_backing_store_from_boxed_slice doesn't need to be un…

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -267,16 +267,18 @@ impl ArrayBuffer {
   ///
   /// The result can be later passed to ArrayBuffer::New. The raw pointer
   /// to the buffer must not be passed again to any V8 API function.
-  pub unsafe fn new_backing_store_from_boxed_slice(
+  pub fn new_backing_store_from_boxed_slice(
     data: Box<[u8]>,
   ) -> UniqueRef<BackingStore> {
     let byte_length = data.len();
     let data_ptr = Box::into_raw(data) as *mut c_void;
-    UniqueRef::from_raw(v8__ArrayBuffer__NewBackingStore__with_data(
-      data_ptr,
-      byte_length,
-      backing_store_deleter_callback,
-      null_mut(),
-    ))
+    unsafe {
+      UniqueRef::from_raw(v8__ArrayBuffer__NewBackingStore__with_data(
+        data_ptr,
+        byte_length,
+        backing_store_deleter_callback,
+        null_mut(),
+      ))
+    }
   }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -274,8 +274,7 @@ fn array_buffer() {
     assert_eq!(false, bs.is_shared());
 
     let data: Box<[u8]> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_boxed_slice();
-    let unique_bs =
-      unsafe { v8::ArrayBuffer::new_backing_store_from_boxed_slice(data) };
+    let unique_bs = v8::ArrayBuffer::new_backing_store_from_boxed_slice(data);
     assert_eq!(10, unique_bs.byte_length());
     assert_eq!(false, unique_bs.is_shared());
     assert_eq!(unique_bs[0], 0);


### PR DESCRIPTION
…safe