### PR TITLE
Add V8InspectorClientImpl::console_api_message()

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1378,6 +1378,13 @@ void v8_inspector__V8InspectorClient__BASE__quitMessageLoopOnPause(
     v8_inspector::V8InspectorClient& self);
 void v8_inspector__V8InspectorClient__BASE__runIfWaitingForDebugger(
     v8_inspector::V8InspectorClient& self, int contextGroupId);
+void v8_inspector__V8InspectorClient__BASE__consoleAPIMessage(
+    v8_inspector::V8InspectorClient& self, int contextGroupId,
+    v8::Isolate::MessageErrorLevel level,
+    const v8_inspector::StringView& message,
+    const v8_inspector::StringView& url,
+    unsigned lineNumber, unsigned columnNumber,
+    v8_inspector::V8StackTrace* stackTrace);
 }  // extern "C"
 
 struct v8_inspector__V8InspectorClient__BASE
@@ -1394,6 +1401,17 @@ struct v8_inspector__V8InspectorClient__BASE
   void runIfWaitingForDebugger(int contextGroupId) override {
     v8_inspector__V8InspectorClient__BASE__runIfWaitingForDebugger(
         *this, contextGroupId);
+  }
+  void consoleAPIMessage(
+      int contextGroupId,
+      v8::Isolate::MessageErrorLevel level,
+      const v8_inspector::StringView& message,
+      const v8_inspector::StringView& url,
+      unsigned lineNumber, unsigned columnNumber,
+      v8_inspector::V8StackTrace* stackTrace) override {
+    v8_inspector__V8InspectorClient__BASE__consoleAPIMessage(
+        *this, contextGroupId, level, message, url,
+        lineNumber, columnNumber, stackTrace);
   }
 };
 
@@ -1414,6 +1432,17 @@ void v8_inspector__V8InspectorClient__quitMessageLoopOnPause(
 void v8_inspector__V8InspectorClient__runIfWaitingForDebugger(
     v8_inspector::V8InspectorClient& self, int contextGroupId) {
   self.runIfWaitingForDebugger(contextGroupId);
+}
+
+void v8_inspector__V8InspectorClient__consoleAPIMessage(
+    v8_inspector::V8InspectorClient& self, int contextGroupId,
+    v8::Isolate::MessageErrorLevel level,
+    const v8_inspector::StringView& message,
+    const v8_inspector::StringView& url,
+    unsigned lineNumber, unsigned columnNumber,
+    v8_inspector::V8StackTrace* stackTrace) {
+  self.consoleAPIMessage(contextGroupId, level, message, url,
+                         lineNumber, columnNumber, stackTrace);
 }
 
 void v8_inspector__StringBuffer__DELETE(v8_inspector::StringBuffer& self) {

--- a/src/inspector/mod.rs
+++ b/src/inspector/mod.rs
@@ -4,6 +4,7 @@ mod session;
 mod string_buffer;
 mod string_view;
 mod v8_inspector;
+mod v8_stack_trace;
 
 pub use channel::{AsChannel, Channel, ChannelBase, ChannelImpl};
 pub use client::AsV8InspectorClient;
@@ -14,3 +15,4 @@ pub use session::V8InspectorSession;
 pub use string_buffer::StringBuffer;
 pub use string_view::StringView;
 pub use v8_inspector::V8Inspector;
+pub use v8_stack_trace::V8StackTrace;

--- a/src/inspector/v8_stack_trace.rs
+++ b/src/inspector/v8_stack_trace.rs
@@ -1,0 +1,9 @@
+use crate::support::CxxVTable;
+
+#[repr(C)]
+pub struct V8StackTrace {
+  _cxx_vtable: CxxVTable,
+}
+
+// TODO(bnoordhuis) This needs to be fleshed out more but that can wait
+// until it's actually needed.


### PR DESCRIPTION
This makes it possible to intercept console.log() messages through
the V8 inspector API.