### PR TITLE
Reset slot when dropping v8::Global

### DIFF
--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -118,7 +118,7 @@ fn global_handles() {
     assert_eq!(_g4.get(scope).unwrap().value(), 123);
     assert!(g5.is_empty());
     let num = g6.get(scope).unwrap();
-    g6.reset(scope);
+    drop(g6);
     assert_eq!(num.value(), 100);
   }
   g1.reset(scope);


### PR DESCRIPTION
Harmonize the behavior of the Drop trait for v8::Global with the
behavior of the C++ destructor ~Global(). Before this commit it
would panic, now it clears the slot.

(Please tell me if there's a reason it currently works this way.)