### PR TITLE
Remove v8::Locker

### DIFF
--- a/src/inspector/v8_inspector.rs
+++ b/src/inspector/v8_inspector.rs
@@ -4,6 +4,7 @@ use super::session::V8InspectorSession;
 use super::Channel;
 use super::StringView;
 use super::V8InspectorClient;
+use crate::scope_traits::InIsolate;
 use crate::support::int;
 use crate::support::Delete;
 use crate::support::Opaque;
@@ -37,7 +38,7 @@ pub struct V8Inspector(Opaque);
 
 impl V8Inspector {
   pub fn create<T>(
-    isolate: &mut Isolate,
+    isolate: &mut impl InIsolate,
     client: &mut T,
   ) -> UniqueRef<V8Inspector>
   where
@@ -45,7 +46,7 @@ impl V8Inspector {
   {
     unsafe {
       UniqueRef::from_raw(v8_inspector__V8Inspector__create(
-        isolate,
+        isolate.isolate(),
         client.as_client_mut(),
       ))
     }

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -367,12 +367,6 @@ impl InIsolate for OwnedIsolate {
   }
 }
 
-impl InIsolate for Isolate {
-  fn isolate(&mut self) -> &mut Isolate {
-    self
-  }
-}
-
 impl Drop for OwnedIsolate {
   fn drop(&mut self) {
     unsafe { self.0.as_mut().dispose() }

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -174,7 +174,7 @@ impl Isolate {
       unsafe {
         self.set_data(0, handle_ptr as *mut c_void);
       }
-      return handle;
+      handle
     } else {
       let handle = unsafe { Arc::from_raw(slot_ptr) };
       // Call into_raw so again to avoid double free.

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -2,6 +2,7 @@
 use crate::array_buffer::Allocator;
 use crate::external_references::ExternalReferences;
 use crate::promise::PromiseRejectMessage;
+use crate::scope_traits::InIsolate;
 use crate::support::intptr_t;
 use crate::support::Delete;
 use crate::support::Opaque;
@@ -21,6 +22,8 @@ use std::ffi::c_void;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::ptr::NonNull;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 pub type MessageCallback = extern "C" fn(Local<Message>, Local<Value>);
 
@@ -160,22 +163,36 @@ impl Isolate {
     CreateParams::new()
   }
 
+  pub fn thread_safe_handle(&mut self) -> Arc<IsolateHandle> {
+    let slot_ptr = self.get_data(0) as *mut IsolateHandle;
+    if slot_ptr.is_null() {
+      let handle = Arc::new(IsolateHandle::new(self));
+      let handle_ptr = Arc::into_raw(handle.clone());
+      unsafe {
+        self.set_data(0, handle_ptr as *mut c_void);
+      }
+      return handle;
+    } else {
+      todo!()
+    }
+  }
+
   /// Associate embedder-specific data with the isolate. |slot| has to be
   /// between 0 and GetNumberOfDataSlots() - 1.
   pub unsafe fn set_data(&mut self, slot: u32, ptr: *mut c_void) {
-    v8__Isolate__SetData(self, slot, ptr)
+    v8__Isolate__SetData(self, slot + 1, ptr)
   }
 
   /// Retrieve embedder-specific data from the isolate.
   /// Returns NULL if SetData has never been called for the given |slot|.
   pub fn get_data(&self, slot: u32) -> *mut c_void {
-    unsafe { v8__Isolate__GetData(self, slot) }
+    unsafe { v8__Isolate__GetData(self, slot + 1) }
   }
 
   /// Returns the maximum number of available embedder data slots. Valid slots
   /// are in the range of 0 - GetNumberOfDataSlots() - 1.
   pub fn get_number_of_data_slots(&self) -> u32 {
-    unsafe { v8__Isolate__GetNumberOfDataSlots(self) }
+    unsafe { v8__Isolate__GetNumberOfDataSlots(self) - 1 }
   }
 
   /// Sets this isolate as the entered one for the current thread.
@@ -282,23 +299,61 @@ impl Isolate {
     }
   }
 
+  /// Runs the default MicrotaskQueue until it gets empty.
+  /// Any exceptions thrown by microtask callbacks are swallowed.
+  pub fn run_microtasks(&mut self) {
+    unsafe { v8__Isolate__RunMicrotasks(self) }
+  }
+
+  /// Enqueues the callback to the default MicrotaskQueue
+  pub fn enqueue_microtask(&mut self, microtask: Local<Function>) {
+    unsafe { v8__Isolate__EnqueueMicrotask(self, microtask) }
+  }
+
+  /// Disposes the isolate.  The isolate must not be entered by any
+  /// thread to be disposable.
+  unsafe fn dispose(&mut self) {
+    let slot_ptr = self.get_data(0) as *const IsolateHandle;
+    if !slot_ptr.is_null() {
+      self.set_data(0, std::ptr::null_mut());
+      let handle = Arc::from_raw(slot_ptr);
+      let some_ptr = handle.0.lock().unwrap().take();
+      assert!(some_ptr.is_some());
+    }
+    v8__Isolate__Dispose(self)
+  }
+}
+
+// Should out live Isolate
+// Should error out (if not panic) if called when Isolate has exited.
+// None indicates that the isolate has exited.
+// TODO(ry) Use AtomicPtr? Use Cell? Only one thread ever modifies it.
+/// Thread safe reference to an Isolate.
+pub struct IsolateHandle(Mutex<Option<*mut Isolate>>);
+
+unsafe impl Send for IsolateHandle {}
+unsafe impl Sync for IsolateHandle {}
+
+impl IsolateHandle {
+  fn new(isolate: *mut Isolate) -> Self {
+    IsolateHandle(Mutex::new(Some(isolate)))
+  }
+
   /// Forcefully terminate the current thread of JavaScript execution
   /// in the given isolate.
   ///
   /// This method can be used by any thread even if that thread has not
   /// acquired the V8 lock with a Locker object.
-  pub fn terminate_execution(&self) {
-    unsafe { v8__Isolate__TerminateExecution(self) }
-  }
-
-  /// Is V8 terminating JavaScript execution.
   ///
-  /// Returns true if JavaScript execution is currently terminating
-  /// because of a call to TerminateExecution.  In that case there are
-  /// still JavaScript frames on the stack and the termination
-  /// exception is still active.
-  pub fn is_execution_terminating(&self) -> bool {
-    unsafe { v8__Isolate__IsExecutionTerminating(self) }
+  /// Returns false if Isolate was already destroyed.
+  pub fn terminate_execution(&self) -> bool {
+    let g = self.0.lock().unwrap();
+    if let Some(ptr) = *g {
+      unsafe { v8__Isolate__TerminateExecution(ptr) };
+      true
+    } else {
+      false
+    }
   }
 
   /// Resume execution capability in the given isolate, whose execution
@@ -313,19 +368,33 @@ impl Isolate {
   ///
   /// This method can be used by any thread even if that thread has not
   /// acquired the V8 lock with a Locker object.
-  pub fn cancel_terminate_execution(&self) {
-    unsafe { v8__Isolate__CancelTerminateExecution(self) }
+  ///
+  /// Returns false if Isolate was already destroyed.
+  pub fn cancel_terminate_execution(&self) -> bool {
+    let g = self.0.lock().unwrap();
+    if let Some(ptr) = *g {
+      unsafe { v8__Isolate__CancelTerminateExecution(ptr) };
+      true
+    } else {
+      false
+    }
   }
 
-  /// Runs the default MicrotaskQueue until it gets empty.
-  /// Any exceptions thrown by microtask callbacks are swallowed.
-  pub fn run_microtasks(&mut self) {
-    unsafe { v8__Isolate__RunMicrotasks(self) }
-  }
-
-  /// Enqueues the callback to the default MicrotaskQueue
-  pub fn enqueue_microtask(&mut self, microtask: Local<Function>) {
-    unsafe { v8__Isolate__EnqueueMicrotask(self, microtask) }
+  /// Is V8 terminating JavaScript execution.
+  ///
+  /// Returns true if JavaScript execution is currently terminating
+  /// because of a call to TerminateExecution.  In that case there are
+  /// still JavaScript frames on the stack and the termination
+  /// exception is still active.
+  ///
+  /// Returns false if Isolate was already destroyed.
+  pub fn is_execution_terminating(&self) -> bool {
+    let g = self.0.lock().unwrap();
+    if let Some(ptr) = *g {
+      unsafe { v8__Isolate__IsExecutionTerminating(ptr) }
+    } else {
+      false
+    }
   }
 
   /// Request V8 to interrupt long running JavaScript code and invoke
@@ -334,6 +403,8 @@ impl Isolate {
   /// There may be a number of interrupt requests in flight.
   /// Can be called from another thread without acquiring a |Locker|.
   /// Registered |callback| must not reenter interrupted Isolate.
+  ///
+  /// Returns false if Isolate was already destroyed.
   // Clippy warns that this method is dereferencing a raw pointer, but it is
   // not: https://github.com/rust-lang/rust-clippy/issues/3045
   #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -341,14 +412,14 @@ impl Isolate {
     &self,
     callback: InterruptCallback,
     data: *mut c_void,
-  ) {
-    unsafe { v8__Isolate__RequestInterrupt(self, callback, data) }
-  }
-
-  /// Disposes the isolate.  The isolate must not be entered by any
-  /// thread to be disposable.
-  pub unsafe fn dispose(&mut self) {
-    v8__Isolate__Dispose(self)
+  ) -> bool {
+    let g = self.0.lock().unwrap();
+    if let Some(ptr) = *g {
+      unsafe { v8__Isolate__RequestInterrupt(ptr, callback, data) };
+      true
+    } else {
+      false
+    }
   }
 }
 
@@ -359,6 +430,18 @@ pub unsafe fn new_owned_isolate(isolate_ptr: *mut Isolate) -> OwnedIsolate {
 
 /// Same as Isolate but gets disposed when it goes out of scope.
 pub struct OwnedIsolate(NonNull<Isolate>);
+
+impl InIsolate for OwnedIsolate {
+  fn isolate(&mut self) -> &mut Isolate {
+    self.deref_mut()
+  }
+}
+
+impl InIsolate for Isolate {
+  fn isolate(&mut self) -> &mut Isolate {
+    self
+  }
+}
 
 impl Drop for OwnedIsolate {
   fn drop(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,9 @@
 //!
 //! let mut create_params = v8::Isolate::create_params();
 //! create_params.set_array_buffer_allocator(v8::new_default_allocator());
-//! let isolate = v8::Isolate::new(create_params);
+//! let mut isolate = v8::Isolate::new(create_params);
 //!
-//! let mut locker = v8::Locker::new(&isolate);
-//! let scope = locker.enter();
-//!
-//! let mut handle_scope = v8::HandleScope::new(scope);
+//! let mut handle_scope = v8::HandleScope::new(&mut isolate);
 //! let scope = handle_scope.enter();
 //!
 //! let context = v8::Context::new(scope);
@@ -154,7 +151,6 @@ pub use property_attribute::*;
 pub use scope::CallbackScope;
 pub use scope::ContextScope;
 pub use scope::FunctionCallbackScope;
-pub use scope::Locker;
 pub use scope::PropertyCallbackScope;
 pub use scope::Scope;
 pub use scope_traits::*;

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -246,49 +246,6 @@ impl<'s, X> From<&'s PromiseRejectMessage<'s>> for Scope<'s, CallbackScope<X>> {
   }
 }
 
-#[repr(C)]
-/// v8::Locker is a scoped lock object. While it's active, i.e. between its
-/// construction and destruction, the current thread is allowed to use the locked
-/// isolate. V8 guarantees that an isolate can be locked by at most one thread at
-/// any time. In other words, the scope of a v8::Locker is a critical section.
-pub struct Locker {
-  has_lock: bool,
-  top_level: bool,
-  isolate: *mut Isolate,
-}
-
-extern "C" {
-  fn v8__Locker__CONSTRUCT(buf: *mut Locker, isolate: *mut Isolate);
-  fn v8__Locker__DESTRUCT(this: &mut Locker);
-}
-
-impl<'s> Locker {
-  // TODO(piscisaureus): We should not be sharing &Isolate references between
-  // threads while at the same time dereferencing to &mut Isolate *within* the
-  // various scopes. Instead, add a separate type (e.g. IsolateHandle).
-  pub fn new(isolate: &Isolate) -> Scope<'s, Self> {
-    Scope::new_root(isolate as *const _ as *mut Isolate)
-  }
-
-  pub(crate) fn get_raw_isolate_(&self) -> *mut Isolate {
-    self.isolate
-  }
-}
-
-unsafe impl<'s> ScopeDefinition<'s> for Locker {
-  type Args = *mut Isolate;
-
-  unsafe fn enter_scope(buf: *mut Self, isolate: *mut Isolate) {
-    v8__Locker__CONSTRUCT(buf, isolate)
-  }
-}
-
-impl Drop for Locker {
-  fn drop(&mut self) {
-    unsafe { v8__Locker__DESTRUCT(self) }
-  }
-}
-
 /// Stack-allocated class which sets the execution context for all operations
 /// executed within a local scope.
 pub struct ContextScope {

--- a/src/scope_traits.rs
+++ b/src/scope_traits.rs
@@ -2,6 +2,7 @@
 
 use crate::scope::Entered;
 use crate::scope::Escapable;
+use crate::snapshot::SnapshotCreator;
 use crate::CallbackScope;
 use crate::Context;
 use crate::ContextScope;
@@ -10,7 +11,6 @@ use crate::FunctionCallbackInfo;
 use crate::HandleScope;
 use crate::Isolate;
 use crate::Local;
-use crate::Locker;
 use crate::Message;
 use crate::Object;
 use crate::PropertyCallbackInfo;
@@ -62,6 +62,12 @@ pub(crate) mod internal {
     }
   }
 
+  impl<'s> GetRawIsolate for SnapshotCreator {
+    fn get_raw_isolate(&self) -> *mut Isolate {
+      self.get_isolate()
+    }
+  }
+
   impl<'s, S> GetRawIsolate for Entered<'_, S>
   where
     S: GetRawIsolate,
@@ -80,12 +86,6 @@ pub(crate) mod internal {
   impl<'s> GetRawIsolate for ContextScope {
     fn get_raw_isolate(&self) -> *mut Isolate {
       unsafe { self.get_captured_context() }.get_raw_isolate()
-    }
-  }
-
-  impl GetRawIsolate for Locker {
-    fn get_raw_isolate(&self) -> *mut Isolate {
-      self.get_raw_isolate_()
     }
   }
 

--- a/src/scope_traits.rs
+++ b/src/scope_traits.rs
@@ -2,7 +2,6 @@
 
 use crate::scope::Entered;
 use crate::scope::Escapable;
-use crate::snapshot::SnapshotCreator;
 use crate::CallbackScope;
 use crate::Context;
 use crate::ContextScope;
@@ -59,12 +58,6 @@ pub(crate) mod internal {
   impl<'s> GetRawIsolate for Local<'s, Message> {
     fn get_raw_isolate(&self) -> *mut Isolate {
       (&**self).get_raw_isolate()
-    }
-  }
-
-  impl<'s> GetRawIsolate for SnapshotCreator {
-    fn get_raw_isolate(&self) -> *mut Isolate {
-      self.get_isolate()
     }
   }
 

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -1,5 +1,6 @@
 // Copyright 2019-2020 the Deno authors. All rights reserved. MIT license.
 //! For compiling scripts.
+use crate::InIsolate;
 use crate::Isolate;
 use crate::Local;
 use crate::Module;
@@ -77,11 +78,11 @@ pub enum NoCacheReason {
 /// Corresponds to the ParseModule abstract operation in the ECMAScript
 /// specification.
 pub fn compile_module<'a>(
-  isolate: &Isolate,
+  scope: &mut impl InIsolate,
   source: Source,
 ) -> Option<Local<'a, Module>> {
   compile_module2(
-    isolate,
+    scope,
     source,
     CompileOptions::NoCompileOptions,
     NoCacheReason::NoReason,
@@ -90,14 +91,14 @@ pub fn compile_module<'a>(
 
 /// Same as compile_module with more options.
 pub fn compile_module2<'a>(
-  isolate: &Isolate,
+  scope: &mut impl InIsolate,
   source: Source,
   options: CompileOptions,
   no_cache_reason: NoCacheReason,
 ) -> Option<Local<'a, Module>> {
   unsafe {
     Local::from_raw(v8__ScriptCompiler__CompileModule(
-      isolate,
+      scope.isolate(),
       &source,
       options,
       no_cache_reason,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,4 +1,5 @@
 use crate::external_references::ExternalReferences;
+use crate::scope::ScopeDefinition;
 use crate::support::int;
 use crate::support::intptr_t;
 use crate::Context;
@@ -17,9 +18,7 @@ extern "C" {
     external_references: *const intptr_t,
   );
   fn v8__SnapshotCreator__DESTRUCT(this: &mut SnapshotCreator);
-  fn v8__SnapshotCreator__GetIsolate(
-    this: &mut SnapshotCreator,
-  ) -> &mut Isolate;
+  fn v8__SnapshotCreator__GetIsolate(this: &SnapshotCreator) -> &mut Isolate;
   fn v8__SnapshotCreator__CreateBlob(
     this: *mut SnapshotCreator,
     function_code_handling: FunctionCodeHandling,
@@ -117,6 +116,11 @@ impl Drop for SnapshotCreator {
   }
 }
 
+unsafe impl<'s> ScopeDefinition<'s> for SnapshotCreator {
+  type Args = ();
+  unsafe fn enter_scope(_: *mut Self, _: Self::Args) {}
+}
+
 impl SnapshotCreator {
   /// Set the default context to be included in the snapshot blob.
   /// The snapshot will not contain the global proxy, and we expect one or a
@@ -153,7 +157,7 @@ impl SnapshotCreator {
   }
 
   /// Returns the isolate prepared by the snapshot creator.
-  pub fn get_isolate(&mut self) -> &Isolate {
+  pub fn get_isolate(&self) -> &mut Isolate {
     unsafe { v8__SnapshotCreator__GetIsolate(self) }
   }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -151,6 +151,8 @@ impl SnapshotCreator {
   }
 
   /// Returns the isolate prepared by the snapshot creator.
+  // TODO(ry) Fix this clippy error - it's an actual problem.
+  #[allow(clippy::mut_from_ref)]
   pub fn get_isolate(&self) -> &mut Isolate {
     unsafe { v8__SnapshotCreator__GetIsolate(self) }
   }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -149,11 +149,4 @@ impl SnapshotCreator {
     let isolate_ptr = v8__SnapshotCreator__GetIsolate(self);
     crate::isolate::new_owned_isolate(isolate_ptr)
   }
-
-  /// Returns the isolate prepared by the snapshot creator.
-  // TODO(ry) Fix this clippy error - it's an actual problem.
-  #[allow(clippy::mut_from_ref)]
-  pub fn get_isolate(&self) -> &mut Isolate {
-    unsafe { v8__SnapshotCreator__GetIsolate(self) }
-  }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,5 +1,4 @@
 use crate::external_references::ExternalReferences;
-use crate::scope::ScopeDefinition;
 use crate::support::int;
 use crate::support::intptr_t;
 use crate::Context;
@@ -114,11 +113,6 @@ impl Drop for SnapshotCreator {
   fn drop(&mut self) {
     unsafe { v8__SnapshotCreator__DESTRUCT(self) };
   }
-}
-
-unsafe impl<'s> ScopeDefinition<'s> for SnapshotCreator {
-  type Args = ();
-  unsafe fn enter_scope(_: *mut Self, _: Self::Args) {}
 }
 
 impl SnapshotCreator {

--- a/tests/compile_fail/handle_scope_escape_lifetime.rs
+++ b/tests/compile_fail/handle_scope_escape_lifetime.rs
@@ -2,8 +2,8 @@
 use rusty_v8 as v8;
 
 pub fn main() {
-  let mut locker = v8::Locker::new(mock());
-  let mut hs0 = v8::HandleScope::new(locker.enter());
+  let mut isolate = v8::Isolate::new(mock());
+  let mut hs0 = v8::HandleScope::new(&mut isolate);
   let hs0 = hs0.enter();
 
   let _fail = {

--- a/tests/compile_fail/handle_scope_lifetimes.rs
+++ b/tests/compile_fail/handle_scope_lifetimes.rs
@@ -2,8 +2,8 @@
 use rusty_v8 as v8;
 
 pub fn main() {
-  let mut locker = v8::Locker::new(mock());
-  let mut root_hs = v8::HandleScope::new(locker.enter());
+  let mut isolate = v8::Isolate::new(mock());
+  let mut root_hs = v8::HandleScope::new(&mut isolate);
   let root_hs = root_hs.enter();
 
   {

--- a/tests/compile_fail/try_catch_lifetimes.rs
+++ b/tests/compile_fail/try_catch_lifetimes.rs
@@ -2,7 +2,7 @@
 use rusty_v8 as v8;
 
 pub fn main() {
-  let mut scope: v8::Scope<v8::HandleScope, v8::Locker> = mock();
+  let mut scope: v8::Scope<v8::HandleScope, v8::Isolate> = mock();
   let scope = scope.enter();
   let context: v8::Local<v8::Context> = mock();
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -498,14 +498,12 @@ fn terminate_execution() {
   }
 }
 
-// TODO(ry) Need thread safe IsolateHandle implemented to fix this test.
-/*
 #[test]
 fn request_interrupt_small_scripts() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
+  let mut isolate = v8::Isolate::new(params);
   {
     let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
@@ -521,12 +519,13 @@ fn request_interrupt_small_scripts() {
       assert_eq!(data, std::ptr::null_mut());
       CALL_COUNT.fetch_add(1, Ordering::SeqCst);
     }
-    isolate.request_interrupt(callback, std::ptr::null_mut());
+    scope
+      .isolate()
+      .request_interrupt(callback, std::ptr::null_mut());
     eval(scope, context, "(function(x){return x;})(1);");
     assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 1);
   }
 }
-*/
 
 #[test]
 fn add_message_listener() {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -452,46 +452,11 @@ fn throw_exception() {
 }
 
 #[test]
-fn thread_safe_handle_drop_after_isolate() {
-  let _setup_guard = setup();
-  let mut params = v8::Isolate::create_params();
-  params.set_array_buffer_allocator(v8::new_default_allocator());
-  let mut isolate = v8::Isolate::new(params);
-  let handle = isolate.thread_safe_handle();
-  // We can call it twice.
-  let handle_ = isolate.thread_safe_handle();
-  // Check that handle is Send and Sync.
-  fn f<S: Send + Sync>(_: S) {}
-  f(handle_);
-  // All methods on IsolateHandle should return false after the isolate is
-  // dropped.
-  drop(isolate);
-  assert_eq!(false, handle.terminate_execution());
-  assert_eq!(false, handle.cancel_terminate_execution());
-  assert_eq!(false, handle.is_execution_terminating());
-  static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
-  extern "C" fn callback(
-    _isolate: &mut v8::Isolate,
-    data: *mut std::ffi::c_void,
-  ) {
-    assert_eq!(data, std::ptr::null_mut());
-    CALL_COUNT.fetch_add(1, Ordering::SeqCst);
-  }
-  assert_eq!(
-    false,
-    handle.request_interrupt(callback, std::ptr::null_mut())
-  );
-  assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 0);
-}
-
-// TODO(ry) This test should use threads
-#[test]
 fn terminate_execution() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
   let mut isolate = v8::Isolate::new(params);
-  let handle = isolate.thread_safe_handle();
   // Originally run fine.
   {
     let mut hs = v8::HandleScope::new(&mut isolate);
@@ -504,7 +469,7 @@ fn terminate_execution() {
     assert!(result.same_value(true_val));
   }
   // Terminate.
-  handle.terminate_execution();
+  isolate.terminate_execution();
   // Below run should fail with terminated knowledge.
   {
     let mut hs = v8::HandleScope::new(&mut isolate);
@@ -519,7 +484,7 @@ fn terminate_execution() {
     assert!(tc.has_terminated());
   }
   // Cancel termination.
-  handle.cancel_terminate_execution();
+  isolate.cancel_terminate_execution();
   // Works again.
   {
     let mut hs = v8::HandleScope::new(&mut isolate);
@@ -533,14 +498,14 @@ fn terminate_execution() {
   }
 }
 
-// TODO(ry) This test should use threads
+// TODO(ry) Need thread safe IsolateHandle implemented to fix this test.
+/*
 #[test]
 fn request_interrupt_small_scripts() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let mut isolate = v8::Isolate::new(params);
-  let handle = isolate.thread_safe_handle();
+  let isolate = v8::Isolate::new(params);
   {
     let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
@@ -556,11 +521,12 @@ fn request_interrupt_small_scripts() {
       assert_eq!(data, std::ptr::null_mut());
       CALL_COUNT.fetch_add(1, Ordering::SeqCst);
     }
-    handle.request_interrupt(callback, std::ptr::null_mut());
+    isolate.request_interrupt(callback, std::ptr::null_mut());
     eval(scope, context, "(function(x){return x;})(1);");
     assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 1);
   }
 }
+*/
 
 #[test]
 fn add_message_listener() {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1443,8 +1443,7 @@ fn compile_specifier_as_module_resolve_callback<'a>(
   let scope = hs.enter();
   let origin = mock_script_origin(scope, "module.js");
   let source = v8::script_compiler::Source::new(specifier, &origin);
-  let module =
-    v8::script_compiler::compile_module(scope.isolate(), source).unwrap();
+  let module = v8::script_compiler::compile_module(scope, source).unwrap();
   Some(scope.escape(module))
 }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -459,12 +459,10 @@ fn thread_safe_handle_drop_after_isolate() {
   let mut isolate = v8::Isolate::new(params);
   let handle = isolate.thread_safe_handle();
   // We can call it twice.
-  /* TODO(ry)
   let handle_ = isolate.thread_safe_handle();
   // Check that handle is Send and Sync.
   fn f<S: Send + Sync>(_: S) {}
   f(handle_);
-  */
   // All methods on IsolateHandle should return false after the isolate is
   // dropped.
   drop(isolate);

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -39,11 +39,9 @@ fn handle_scope_nested() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope0 = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope0);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope1 = hs.enter();
     {
       let mut hs = v8::HandleScope::new(scope1);
@@ -58,11 +56,9 @@ fn handle_scope_numbers() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope0 = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope0);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope1 = hs.enter();
     let l1 = v8::Integer::new(scope1, -123);
     let l2 = v8::Integer::new_from_unsigned(scope1, 456);
@@ -84,9 +80,7 @@ fn global_handles() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   let mut g1 = v8::Global::<v8::String>::new();
   let mut g2 = v8::Global::<v8::Integer>::new();
   let mut g3 = v8::Global::<v8::Integer>::new();
@@ -94,7 +88,7 @@ fn global_handles() {
   let g5 = v8::Global::<v8::Script>::new();
   let mut g6 = v8::Global::<v8::Integer>::new();
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let l1 = v8::String::new(scope, "bla").unwrap();
     let l2 = v8::Integer::new(scope, 123);
@@ -106,7 +100,7 @@ fn global_handles() {
     g6.set(scope, l6);
   }
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     assert!(!g1.is_empty());
     assert_eq!(g1.get(scope).unwrap().to_rust_string_lossy(scope), "bla");
@@ -121,13 +115,13 @@ fn global_handles() {
     g6.reset(scope);
     assert_eq!(num.value(), 100);
   }
-  g1.reset(scope);
+  g1.reset(&mut isolate);
   assert!(g1.is_empty());
-  g2.reset(scope);
+  g2.reset(&mut isolate);
   assert!(g2.is_empty());
-  g3.reset(scope);
+  g3.reset(&mut isolate);
   assert!(g3.is_empty());
-  _g4.reset(scope);
+  _g4.reset(&mut isolate);
   assert!(_g4.is_empty());
   assert!(g5.is_empty());
 }
@@ -137,11 +131,9 @@ fn test_string() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let reference = "Hello 🦕 world!";
     let local = v8::String::new(scope, reference).unwrap();
@@ -150,7 +142,7 @@ fn test_string() {
     assert_eq!(reference, local.to_rust_string_lossy(scope));
   }
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let local = v8::String::empty(scope);
     assert_eq!(0, local.length());
@@ -158,7 +150,7 @@ fn test_string() {
     assert_eq!("", local.to_rust_string_lossy(scope));
   }
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let local =
       v8::String::new_from_utf8(scope, b"", v8::NewStringType::Normal).unwrap();
@@ -174,11 +166,9 @@ fn escapable_handle_scope() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope0 = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope0);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope1 = hs.enter();
     // After dropping EscapableHandleScope, we should be able to
     // read escaped values.
@@ -219,14 +209,12 @@ fn microtasks() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
 
-  scope.isolate().run_microtasks();
+  isolate.run_microtasks();
 
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -256,11 +244,9 @@ fn array_buffer() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -305,11 +291,9 @@ fn array_buffer_with_shared_backing_store() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
 
     let context = v8::Context::new(scope);
@@ -389,11 +373,9 @@ fn try_catch() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -448,11 +430,9 @@ fn throw_exception() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -472,16 +452,51 @@ fn throw_exception() {
 }
 
 #[test]
+fn thread_safe_handle_drop_after_isolate() {
+  let _setup_guard = setup();
+  let mut params = v8::Isolate::create_params();
+  params.set_array_buffer_allocator(v8::new_default_allocator());
+  let mut isolate = v8::Isolate::new(params);
+  let handle = isolate.thread_safe_handle();
+  // We can call it twice.
+  /* TODO(ry)
+  let handle_ = isolate.thread_safe_handle();
+  // Check that handle is Send and Sync.
+  fn f<S: Send + Sync>(_: S) {}
+  f(handle_);
+  */
+  // All methods on IsolateHandle should return false after the isolate is
+  // dropped.
+  drop(isolate);
+  assert_eq!(false, handle.terminate_execution());
+  assert_eq!(false, handle.cancel_terminate_execution());
+  assert_eq!(false, handle.is_execution_terminating());
+  static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+  extern "C" fn callback(
+    _isolate: &mut v8::Isolate,
+    data: *mut std::ffi::c_void,
+  ) {
+    assert_eq!(data, std::ptr::null_mut());
+    CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+  }
+  assert_eq!(
+    false,
+    handle.request_interrupt(callback, std::ptr::null_mut())
+  );
+  assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 0);
+}
+
+// TODO(ry) This test should use threads
+#[test]
 fn terminate_execution() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
+  let handle = isolate.thread_safe_handle();
   // Originally run fine.
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -491,10 +506,10 @@ fn terminate_execution() {
     assert!(result.same_value(true_val));
   }
   // Terminate.
-  isolate.terminate_execution();
+  handle.terminate_execution();
   // Below run should fail with terminated knowledge.
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -506,10 +521,10 @@ fn terminate_execution() {
     assert!(tc.has_terminated());
   }
   // Cancel termination.
-  isolate.cancel_terminate_execution();
+  handle.cancel_terminate_execution();
   // Works again.
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -520,16 +535,16 @@ fn terminate_execution() {
   }
 }
 
+// TODO(ry) This test should use threads
 #[test]
 fn request_interrupt_small_scripts() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
+  let handle = isolate.thread_safe_handle();
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -543,7 +558,7 @@ fn request_interrupt_small_scripts() {
       assert_eq!(data, std::ptr::null_mut());
       CALL_COUNT.fetch_add(1, Ordering::SeqCst);
     }
-    isolate.request_interrupt(callback, std::ptr::null_mut());
+    handle.request_interrupt(callback, std::ptr::null_mut());
     eval(scope, context, "(function(x){return x;})(1);");
     assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 1);
   }
@@ -597,10 +612,8 @@ fn add_message_listener() {
   }
   isolate.add_message_listener(check_message_0);
 
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -644,17 +657,15 @@ fn set_host_initialize_import_meta_object_callback() {
   }
   isolate.set_host_initialize_import_meta_object_callback(callback);
 
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
     let scope = cs.enter();
     let source = mock_source(scope, "google.com", "import.meta;");
     let mut module =
-      v8::script_compiler::compile_module(&isolate, source).unwrap();
+      v8::script_compiler::compile_module(scope, source).unwrap();
     let result =
       module.instantiate_module(context, unexpected_module_resolve_callback);
     assert!(result.is_some());
@@ -674,11 +685,9 @@ fn script_compile_and_run() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -697,12 +706,10 @@ fn script_origin() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
 
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -790,11 +797,9 @@ fn test_primitives() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let null = v8::null(scope);
     assert!(!null.is_undefined());
@@ -825,10 +830,8 @@ fn exception() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
-  let mut hs = v8::HandleScope::new(scope);
+  let mut isolate = v8::Isolate::new(params);
+  let mut hs = v8::HandleScope::new(&mut isolate);
   let scope = hs.enter();
   let context = v8::Context::new(scope);
   let mut cs = v8::ContextScope::new(scope, context);
@@ -854,10 +857,8 @@ fn create_message_argument_lifetimes() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
-  let mut hs = v8::HandleScope::new(scope);
+  let mut isolate = v8::Isolate::new(params);
+  let mut hs = v8::HandleScope::new(&mut isolate);
   let scope = hs.enter();
   let context = v8::Context::new(scope);
   let mut cs = v8::ContextScope::new(scope, context);
@@ -893,11 +894,9 @@ fn json() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -919,11 +918,9 @@ fn object_template() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let object_templ = v8::ObjectTemplate::new(scope);
     let function_templ = v8::FunctionTemplate::new(scope, fortytwo_callback);
@@ -971,11 +968,9 @@ fn object_template_from_function_template() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let mut function_templ =
       v8::FunctionTemplate::new(scope, fortytwo_callback);
@@ -1002,11 +997,9 @@ fn object() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1039,11 +1032,9 @@ fn array() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1073,11 +1064,9 @@ fn create_data_property() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1112,10 +1101,8 @@ fn object_set_accessor() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
-  let mut hs = v8::HandleScope::new(scope);
+  let mut isolate = v8::Isolate::new(params);
+  let mut hs = v8::HandleScope::new(&mut isolate);
   let scope = hs.enter();
   let context = v8::Context::new(scope);
   let mut cs = v8::ContextScope::new(scope, context);
@@ -1172,11 +1159,9 @@ fn promise_resolved() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1208,11 +1193,9 @@ fn promise_rejected() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1285,12 +1268,10 @@ fn function() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
 
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1346,10 +1327,8 @@ fn set_promise_reject_callback() {
   params.set_array_buffer_allocator(v8::new_default_allocator());
   let mut isolate = v8::Isolate::new(params);
   isolate.set_promise_reject_callback(promise_reject_callback);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1403,10 +1382,8 @@ fn script_compiler_source() {
   params.set_array_buffer_allocator(v8::new_default_allocator());
   let mut isolate = v8::Isolate::new(params);
   isolate.set_promise_reject_callback(promise_reject_callback);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1417,7 +1394,7 @@ fn script_compiler_source() {
     let source =
       v8::script_compiler::Source::new(v8_str(scope, source), &script_origin);
 
-    let result = v8::script_compiler::compile_module(&isolate, source);
+    let result = v8::script_compiler::compile_module(scope, source);
     assert!(result.is_some());
   }
 }
@@ -1427,11 +1404,9 @@ fn module_instantiation_failures1() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1446,7 +1421,7 @@ fn module_instantiation_failures1() {
     let source = v8::script_compiler::Source::new(source_text, &origin);
 
     let mut module =
-      v8::script_compiler::compile_module(&isolate, source).unwrap();
+      v8::script_compiler::compile_module(scope, source).unwrap();
     assert_eq!(v8::ModuleStatus::Uninstantiated, module.get_status());
     assert_eq!(2, module.get_module_requests_length());
 
@@ -1514,11 +1489,9 @@ fn module_evaluation() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1533,7 +1506,7 @@ fn module_evaluation() {
     let source = v8::script_compiler::Source::new(source_text, &origin);
 
     let mut module =
-      v8::script_compiler::compile_module(&isolate, source).unwrap();
+      v8::script_compiler::compile_module(scope, source).unwrap();
     assert_eq!(v8::ModuleStatus::Uninstantiated, module.get_status());
 
     let result = module.instantiate_module(
@@ -1559,11 +1532,9 @@ fn primitive_array() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1596,11 +1567,9 @@ fn equality() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1619,11 +1588,9 @@ fn array_buffer_view() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1654,22 +1621,24 @@ fn snapshot_creator() {
   // the value 3.
   let startup_data = {
     let mut snapshot_creator = v8::SnapshotCreator::new(None);
-    let isolate = snapshot_creator.get_isolate();
-    let mut locker = v8::Locker::new(&isolate);
-    let scope = locker.enter();
     {
-      let mut hs = v8::HandleScope::new(scope);
+      // TODO(ry) this shouldn't be necessary. workaround unfinished business in
+      // the scope type system.
+      let mut isolate = unsafe { snapshot_creator.get_owned_isolate() };
+
+      let mut hs = v8::HandleScope::new(&mut isolate);
       let scope = hs.enter();
+
       let context = v8::Context::new(scope);
       let mut cs = v8::ContextScope::new(scope, context);
       let scope = cs.enter();
-
       let source = v8::String::new(scope, "a = 1 + 2").unwrap();
       let mut script =
         v8::Script::compile(scope, context, source, None).unwrap();
       script.run(scope, context).unwrap();
 
       snapshot_creator.set_default_context(context);
+      std::mem::forget(isolate); // TODO(ry) this shouldn't be necessary.
     }
 
     snapshot_creator
@@ -1683,11 +1652,9 @@ fn snapshot_creator() {
     let mut params = v8::Isolate::create_params();
     params.set_array_buffer_allocator(v8::new_default_allocator());
     params.set_snapshot_blob(&startup_data);
-    let isolate = v8::Isolate::new(params);
-    let mut locker = v8::Locker::new(&isolate);
-    let scope = locker.enter();
+    let mut isolate = v8::Isolate::new(params);
     {
-      let mut hs = v8::HandleScope::new(scope);
+      let mut hs = v8::HandleScope::new(&mut isolate);
       let scope = hs.enter();
       let context = v8::Context::new(scope);
       let mut cs = v8::ContextScope::new(scope, context);
@@ -1720,11 +1687,12 @@ fn external_references() {
   let startup_data = {
     let mut snapshot_creator =
       v8::SnapshotCreator::new(Some(&EXTERNAL_REFERENCES));
-    let isolate = snapshot_creator.get_isolate();
-    let mut locker = v8::Locker::new(&isolate);
-    let scope = locker.enter();
     {
-      let mut hs = v8::HandleScope::new(scope);
+      // TODO(ry) this shouldn't be necessary. workaround unfinished business in
+      // the scope type system.
+      let mut isolate = unsafe { snapshot_creator.get_owned_isolate() };
+
+      let mut hs = v8::HandleScope::new(&mut isolate);
       let scope = hs.enter();
       let context = v8::Context::new(scope);
       let mut cs = v8::ContextScope::new(scope, context);
@@ -1740,6 +1708,8 @@ fn external_references() {
       global.set(context, v8_str(scope, "F").into(), function.into());
 
       snapshot_creator.set_default_context(context);
+
+      std::mem::forget(isolate); // TODO(ry) this shouldn't be necessary.
     }
 
     snapshot_creator
@@ -1754,11 +1724,9 @@ fn external_references() {
     params.set_array_buffer_allocator(v8::new_default_allocator());
     params.set_snapshot_blob(&startup_data);
     params.set_external_references(&EXTERNAL_REFERENCES);
-    let isolate = v8::Isolate::new(params);
-    let mut locker = v8::Locker::new(&isolate);
-    let scope = locker.enter();
+    let mut isolate = v8::Isolate::new(params);
     {
-      let mut hs = v8::HandleScope::new(scope);
+      let mut hs = v8::HandleScope::new(&mut isolate);
       let scope = hs.enter();
       let context = v8::Context::new(scope);
       let mut cs = v8::ContextScope::new(scope, context);
@@ -1799,11 +1767,9 @@ fn uint8_array() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1853,10 +1819,8 @@ fn dynamic_import() {
   }
   isolate.set_host_import_module_dynamically_callback(dynamic_import_cb);
 
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1879,11 +1843,9 @@ fn shared_array_buffer() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -1950,11 +1912,9 @@ fn value_checker() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -2123,11 +2083,9 @@ fn try_from_local() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let context = v8::Context::new(scope);
     let mut cs = v8::ContextScope::new(scope, context);
@@ -2357,19 +2315,17 @@ fn inspector_dispatch_protocol_message() {
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
   let mut isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
 
   use v8::inspector::*;
+  let mut default_client = ClientCounter::new();
+  let mut inspector = V8Inspector::create(&mut isolate, &mut default_client);
 
-  let mut hs = v8::HandleScope::new(scope);
+  let mut hs = v8::HandleScope::new(&mut isolate);
   let scope = hs.enter();
   let context = v8::Context::new(scope);
   let mut cs = v8::ContextScope::new(scope, context);
   let _scope = cs.enter();
 
-  let mut default_client = ClientCounter::new();
-  let mut inspector = V8Inspector::create(&mut isolate, &mut default_client);
   let name = b"";
   let name_view = StringView::from(&name[..]);
   inspector.context_created(context, 1, &name_view);
@@ -2394,19 +2350,17 @@ fn inspector_schedule_pause_on_next_statement() {
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
   let mut isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
 
   use v8::inspector::*;
+  let mut client = ClientCounter::new();
+  let mut inspector = V8Inspector::create(&mut isolate, &mut client);
 
-  let mut hs = v8::HandleScope::new(scope);
+  let mut hs = v8::HandleScope::new(&mut isolate);
   let scope = hs.enter();
   let context = v8::Context::new(scope);
   let mut cs = v8::ContextScope::new(scope, context);
   let scope = cs.enter();
 
-  let mut client = ClientCounter::new();
-  let mut inspector = V8Inspector::create(&mut isolate, &mut client);
   let mut channel = ChannelCounter::new();
   let state = b"{}";
   let state_view = StringView::from(&state[..]);
@@ -2460,8 +2414,6 @@ fn inspector_console_api_message() {
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
   let mut isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
 
   use v8::inspector::*;
 
@@ -2502,14 +2454,15 @@ fn inspector_console_api_message() {
     }
   }
 
-  let mut hs = v8::HandleScope::new(scope);
+  let mut client = Client::new();
+  let mut inspector = V8Inspector::create(&mut isolate, &mut client);
+
+  let mut hs = v8::HandleScope::new(&mut isolate);
   let scope = hs.enter();
   let context = v8::Context::new(scope);
   let mut cs = v8::ContextScope::new(scope, context);
   let scope = cs.enter();
 
-  let mut client = Client::new();
-  let mut inspector = V8Inspector::create(&mut isolate, &mut client);
   let name = b"";
   let name_view = StringView::from(&name[..]);
   inspector.context_created(context, 1, &name_view);
@@ -2528,11 +2481,9 @@ fn context_from_object_template() {
   let _setup_guard = setup();
   let mut params = v8::Isolate::create_params();
   params.set_array_buffer_allocator(v8::new_default_allocator());
-  let isolate = v8::Isolate::new(params);
-  let mut locker = v8::Locker::new(&isolate);
-  let scope = locker.enter();
+  let mut isolate = v8::Isolate::new(params);
   {
-    let mut hs = v8::HandleScope::new(scope);
+    let mut hs = v8::HandleScope::new(&mut isolate);
     let scope = hs.enter();
     let object_templ = v8::ObjectTemplate::new(scope);
     let function_templ = v8::FunctionTemplate::new(scope, fortytwo_callback);


### PR DESCRIPTION
This patch clarifies that v8::Isolate is a single threaded creature
which can only be accessed from other threads in special circumstances.
To ensure optimal operation in Deno, we remove v8::Locker, which ought
to be unnecessary when a thread is dedicated to each Isolate and the
Isolates never move between threads.

There are valid use-cases for v8::Locker, and we hope to address them in
future revisions.