### PR TITLE
Add v8::Function::new_with_data to attach associated data

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -970,6 +970,12 @@ v8::Function* v8__Function__New(v8::Local<v8::Context> context,
   return maybe_local_to_ptr(v8::Function::New(context, callback));
 }
 
+v8::Function* v8__Function__NewWithData(v8::Local<v8::Context> context,
+                                v8::FunctionCallback callback,
+                                v8::Local<v8::Value> data) {
+  return maybe_local_to_ptr(v8::Function::New(context, callback, data));
+}
+
 v8::Value* v8__Function__Call(v8::Function* self,
                               v8::Local<v8::Context> context,
                               v8::Local<v8::Value> recv, int argc,
@@ -1015,6 +1021,11 @@ int v8__FunctionCallbackInfo__Length(
 v8::Value* v8__FunctionCallbackInfo__GetArgument(
     const v8::FunctionCallbackInfo<v8::Value>& self, int i) {
   return local_to_ptr(self[i]);
+}
+
+v8::Value* v8__FunctionCallbackInfo__Data(
+    const v8::FunctionCallbackInfo<v8::Value>& self) {
+  return local_to_ptr(self.Data());
 }
 
 void v8__ReturnValue__Set(v8::ReturnValue<v8::Value>& self,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1336,6 +1336,17 @@ fn fortytwo_callback(
   rv.set(v8::Integer::new(scope, 42).into());
 }
 
+fn data_is_true_callback(
+  _scope: v8::FunctionCallbackScope,
+  args: v8::FunctionCallbackArguments,
+  _rv: v8::ReturnValue,
+) {
+  let data = args.data();
+  assert!(data.is_some());
+  let data = data.unwrap();
+  assert!(data.is_true());
+}
+
 #[test]
 fn function() {
   let _setup_guard = setup();
@@ -1373,6 +1384,18 @@ fn function() {
     let value_str = value.to_string(scope).unwrap();
     let rust_str = value_str.to_rust_string_lossy(scope);
     assert_eq!(rust_str, "Hello callback!".to_string());
+    // create a function with associated data
+    let true_data = v8::Boolean::new(scope, true);
+    let function = v8::Function::new_with_data(
+      scope,
+      context,
+      true_data.into(),
+      data_is_true_callback,
+    )
+    .expect("Unable to create function with data");
+    function
+      .call(scope, context, recv, &[])
+      .expect("Function call failed");
   }
 }
 


### PR DESCRIPTION
This is useful to attach associated data to a function, such that it could be retrieved in the function later

(This is helpful for creating function wrapper around another given JS function without explicitly saving e.g. persistent handles)