### PR TITLE
Simplify .gn to reduce size of static lib

### DIFF
--- a/.gn
+++ b/.gn
@@ -29,6 +29,7 @@ default_args = {
   clang_use_chrome_plugins = false
   v8_enable_i18n_support = false
   v8_monolithic = false
+  v8_use_external_startup_data = false
   v8_use_snapshot = true
   is_component_build = false
 }

--- a/.gn
+++ b/.gn
@@ -19,33 +19,14 @@ secondary_source = "//v8/"
 default_args = {
   linux_use_bundled_binutils = false
 
-  # TODO(ry) We may want to turn on CFI at some point. Disabling for simplicity
-  # for now. See http://clang.llvm.org/docs/ControlFlowIntegrity.html
-  is_cfi = false
   use_dummy_lastchange = true
   treat_warnings_as_errors = true
 
+  # TODO(ry) remove
+  v8_imminent_deprecation_warnings = false
+
   # https://cs.chromium.org/chromium/src/docs/ccache_mac.md
   clang_use_chrome_plugins = false
-  v8_enable_gdbjit = false
   v8_enable_i18n_support = false
-  v8_enable_shared_ro_heap = false  # See #2624
-  v8_imminent_deprecation_warnings = false
   v8_monolithic = false
-  v8_untrusted_code_mitigations = false
-  v8_use_external_startup_data = false
-  v8_use_snapshot = true
-  v8_postmortem_support = true  # for https://github.com/nodejs/llnode/
-
-  # We don't want to require downloading the binary executable
-  # tools/clang/dsymutil.
-  enable_dsyms = false
-
-  # TODO(ry) Remove this so debug builds can link faster. Currently removing
-  # this breaks cargo build in debug mode in OSX.
-  is_component_build = false
-
-  # Without this the linker produces an invalid executable on some Windows
-  # systems. It's unclear why that happens.
-  symbol_level = 1
 }

--- a/.gn
+++ b/.gn
@@ -32,5 +32,5 @@ default_args = {
   v8_use_external_startup_data = false
   v8_use_snapshot = true
   is_component_build = false
-  symbol_level = 0
+  symbol_level = 1
 }

--- a/.gn
+++ b/.gn
@@ -32,4 +32,5 @@ default_args = {
   v8_use_external_startup_data = false
   v8_use_snapshot = true
   is_component_build = false
+  symbol_level = 0
 }

--- a/.gn
+++ b/.gn
@@ -29,4 +29,5 @@ default_args = {
   clang_use_chrome_plugins = false
   v8_enable_i18n_support = false
   v8_monolithic = false
+  is_component_build = false
 }

--- a/.gn
+++ b/.gn
@@ -29,5 +29,6 @@ default_args = {
   clang_use_chrome_plugins = false
   v8_enable_i18n_support = false
   v8_monolithic = false
+  v8_use_snapshot = true
   is_component_build = false
 }


### PR DESCRIPTION
We noticed that the [static lib binaries](https://github.com/denoland/rusty_v8/releases/tag/v0.3.6) were quite large. 176mb for mac/debug.

We aren't sure what exactly is causing this, but I thought by simplifying the `.gn` file we might discover something. With these changes I get:
```
> ls -lh target/debug/gn_out/obj/librusty_v8.a
-rw-r--r--  1 rld  staff   940K Mar 16 18:54 target/debug/gn_out/obj/librusty_v8.a
```