### PR TITLE
fix retry process for download_file

### DIFF
--- a/tools/download_file.py
+++ b/tools/download_file.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import argparse
 import os
 import sys
+import time
 
 try:
     from urllib2 import HTTPError, URLError, urlopen


### PR DESCRIPTION
It just minor fixes to download_file.py. 
I experienced a script aborting while retrying the download. It can be reproduced as follows:

```bash
❯ /usr/local/bin/python  ./tools/download_file.py --url https://httpstat.us/403 --filename test.html

Downloading https://httpstat.us/403...
HTTP Error 403: Forbidden
Retrying in 5 s ...
Traceback (most recent call last):
  File "./tools/download_file.py", line 63, in <module>
    sys.exit(main())
  File "./tools/download_file.py", line 58, in main
    DownloadUrl(args.url, f)
  File "./tools/download_file.py", line 48, in DownloadUrl
    time.sleep(retry_wait_s)
NameError: global name 'time' is not defined
```