### PR TITLE
[WIP] Add ICU support in embedded v8.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "third_party/zlib"]
 	path = third_party/zlib
 	url = https://chromium.googlesource.com/chromium/src/third_party/zlib.git
+[submodule "third_party/icu"]
+	path = third_party/icu
+	url = https://chromium.googlesource.com/chromium/deps/icu

--- a/.gn
+++ b/.gn
@@ -28,7 +28,7 @@ default_args = {
 
   # https://cs.chromium.org/chromium/src/docs/ccache_mac.md
   clang_use_chrome_plugins = false
-  v8_enable_i18n_support = false
+  v8_enable_i18n_support = true
   v8_monolithic = false
   v8_use_external_startup_data = false
   v8_use_snapshot = true


### PR DESCRIPTION
This is PR for https://github.com/denoland/deno/issues/1968  Add ICU support in embedded v8.  Please note this PR is still work in progress.  Following changes are made in this PR.

* Add submodule third_part/icu@ f2223961702f00a8833874b0560d615a2cc42738
* Set v8_enable_i18n_support = true in .gn for ICU support.

We need have following change to submodule icu.

* Set icu_use_data_file = false in third_party/icu/config.gni
* (Mac build fix) third_party/icu/config/mac/BUILD.gn b/config/mac/BUILD.gn
* (Windows build fix) third_party/icu/scripts/make_data_assembly.py

Would you mind to suggest how I should modify submodule code with current build ecosystem?  Apply patch from build.rs or fork the original repository and apply the patch to it?