### PR TITLE
Make get_data and set_data private

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -188,26 +188,23 @@ impl Isolate {
 
   /// Associate embedder-specific data with the isolate. |slot| has to be
   /// between 0 and GetNumberOfDataSlots() - 1.
-  pub unsafe fn set_data(&mut self, slot: u32, ptr: *mut c_void) {
+  unsafe fn set_data(&mut self, slot: u32, ptr: *mut c_void) {
     v8__Isolate__SetData(self, slot + 1, ptr)
   }
 
   /// Retrieve embedder-specific data from the isolate.
   /// Returns NULL if SetData has never been called for the given |slot|.
-  pub fn get_data(&self, slot: u32) -> *mut c_void {
+  fn get_data(&self, slot: u32) -> *mut c_void {
     unsafe { v8__Isolate__GetData(self, slot + 1) }
   }
 
   /// Returns the maximum number of available embedder data slots. Valid slots
   /// are in the range of 0 - GetNumberOfDataSlots() - 1.
-  pub fn get_number_of_data_slots(&self) -> u32 {
+  fn get_number_of_data_slots(&self) -> u32 {
     unsafe { v8__Isolate__GetNumberOfDataSlots(self) - 1 }
   }
 
-  /// Safe alternative to Isolate::get_data
-  ///
-  /// Warning: will be renamed to get_data_mut() after original unsafe version
-  /// is removed.
+  /// Get mutable reference to embedder data.
   pub fn get_slot_mut<T: 'static>(&self) -> Option<RefMut<T>> {
     let cell = self.get_annex().slots.get(&TypeId::of::<T>())?;
     let ref_mut = cell.try_borrow_mut().ok()?;
@@ -218,10 +215,7 @@ impl Isolate {
     Some(ref_mut)
   }
 
-  /// Safe alternative to Isolate::get_data
-  ///
-  /// Warning: will be renamed to get_data() after original unsafe version is
-  /// removed.
+  /// Get reference to embedder data.
   pub fn get_slot<T: 'static>(&self) -> Option<Ref<T>> {
     let cell = self.get_annex().slots.get(&TypeId::of::<T>())?;
     let r = cell.try_borrow().ok()?;
@@ -231,8 +225,6 @@ impl Isolate {
     }))
   }
 
-  /// Safe alternative to Isolate::set_data
-  ///
   /// Use with Isolate::get_slot and Isolate::get_slot_mut to associate state
   /// with an Isolate.
   ///
@@ -244,9 +236,6 @@ impl Isolate {
   /// Returns true if value was set without replacing an existing value.
   ///
   /// The value will be dropped when the isolate is dropped.
-  ///
-  /// Warning: will be renamed to set_data() after original unsafe version is
-  /// removed.
   pub fn set_slot<T: 'static>(&mut self, value: T) -> bool {
     self
       .get_annex_mut()

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2801,22 +2801,6 @@ fn context_from_object_template() {
 }
 
 #[test]
-fn get_and_set_data() {
-  let _setup_guard = setup();
-  let mut isolate = v8::Isolate::new(Default::default());
-  let nslots = isolate.get_number_of_data_slots();
-  assert!(nslots > 0);
-  for slot in 0..nslots {
-    let b = Box::new(123 as i32);
-    let ptr = Box::into_raw(b);
-    unsafe { isolate.set_data(slot, ptr as *mut std::ffi::c_void) };
-    let ptr = isolate.get_data(slot) as *mut i32;
-    let b = unsafe { Box::from_raw(ptr) };
-    assert_eq!(*b, 123);
-  }
-}
-
-#[test]
 fn take_heap_snapshot() {
   let _setup_guard = setup();
   let mut isolate = v8::Isolate::new(Default::default());


### PR DESCRIPTION
deno no longer depends on these https://github.com/denoland/deno/commit/d4b05dd89e94ed1bba5b24c683da0a895f2ce597

Let's prevent future trouble by not allowing unsafe embedder data.