### PR TITLE
Make to_local() take a closure that returns a raw pointer

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -240,21 +240,24 @@ impl ArrayBuffer {
     scope: &mut impl ToLocal<'sc>,
     byte_length: usize,
   ) -> Local<'sc, ArrayBuffer> {
-    let isolate = scope.isolate();
-    let ptr =
-      unsafe { v8__ArrayBuffer__New__with_byte_length(isolate, byte_length) };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe {
+      scope.to_local(|scope| {
+        v8__ArrayBuffer__New__with_byte_length(scope.isolate(), byte_length)
+      })
+    }
+    .unwrap()
   }
 
   pub fn with_backing_store<'sc>(
     scope: &mut impl ToLocal<'sc>,
     backing_store: &SharedRef<BackingStore>,
   ) -> Local<'sc, ArrayBuffer> {
-    let isolate = scope.isolate();
-    let ptr = unsafe {
-      v8__ArrayBuffer__New__with_backing_store(isolate, backing_store)
-    };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe {
+      scope.to_local(|scope| {
+        v8__ArrayBuffer__New__with_backing_store(scope.isolate(), backing_store)
+      })
+    }
+    .unwrap()
   }
 
   /// Data length in bytes.

--- a/src/array_buffer_view.rs
+++ b/src/array_buffer_view.rs
@@ -26,7 +26,7 @@ impl ArrayBufferView {
     &self,
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, ArrayBuffer>> {
-    unsafe { scope.to_local(v8__ArrayBufferView__Buffer(self)) }
+    unsafe { scope.to_local(|_| v8__ArrayBufferView__Buffer(self)) }
   }
 
   /// Size of a view in bytes.

--- a/src/context.rs
+++ b/src/context.rs
@@ -23,8 +23,10 @@ impl Context {
   /// Creates a new context.
   pub fn new<'sc>(scope: &mut impl ToLocal<'sc>) -> Local<'sc, Context> {
     // TODO: optional arguments;
-    let ptr = unsafe { v8__Context__New(scope.isolate(), null(), null()) };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe {
+      scope.to_local(|scope| v8__Context__New(scope.isolate(), null(), null()))
+    }
+    .unwrap()
   }
 
   /// Creates a new context using the object template as the template for
@@ -33,8 +35,10 @@ impl Context {
     scope: &mut impl ToLocal<'sc>,
     templ: Local<ObjectTemplate>,
   ) -> Local<'sc, Context> {
-    let ptr = unsafe { v8__Context__New(scope.isolate(), &*templ, null()) };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe {
+      scope.to_local(|scope| v8__Context__New(scope.isolate(), &*templ, null()))
+    }
+    .unwrap()
   }
 
   /// Returns the global proxy object.
@@ -51,7 +55,7 @@ impl Context {
     &self,
     scope: &mut impl ToLocal<'sc>,
   ) -> Local<'sc, Object> {
-    unsafe { scope.to_local(v8__Context__Global(self)) }.unwrap()
+    unsafe { scope.to_local(|_| v8__Context__Global(self)) }.unwrap()
   }
 
   /// Enter this context.  After entering a context, all code compiled

--- a/src/function.rs
+++ b/src/function.rs
@@ -245,7 +245,7 @@ where
   fn mapping() -> Self {
     let f = |info: *const FunctionCallbackInfo| {
       let scope: FunctionCallbackScope =
-        &mut crate::scope::Entered::new_root(info as *mut FunctionCallbackInfo);
+        &mut crate::scope::Scope::new_root(info as *mut FunctionCallbackInfo);
       let args = FunctionCallbackArguments::from_function_callback_info(info);
       let rv = ReturnValue::from_function_callback_info(info);
       (F::get())(scope, args, rv);
@@ -272,7 +272,7 @@ where
   fn mapping() -> Self {
     let f = |key: Local<Name>, info: *const PropertyCallbackInfo| {
       let scope: PropertyCallbackScope =
-        &mut crate::scope::Entered::new_root(info as *mut PropertyCallbackInfo);
+        &mut crate::scope::Scope::new_root(info as *mut PropertyCallbackInfo);
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
       (F::get())(scope, key, args, rv);

--- a/src/function.rs
+++ b/src/function.rs
@@ -96,7 +96,7 @@ impl<'cb> ReturnValue<'cb> {
     &mut self,
     scope: &mut impl ToLocal<'sc>,
   ) -> Local<'sc, Value> {
-    unsafe { scope.to_local(v8__ReturnValue__Get(self)) }.unwrap()
+    unsafe { scope.to_local(|_| v8__ReturnValue__Get(self)) }.unwrap()
   }
 }
 
@@ -291,7 +291,7 @@ impl Function {
     callback: impl MapFnTo<FunctionCallback>,
   ) -> Option<Local<'sc, Function>> {
     unsafe {
-      scope.to_local(v8__Function__New(&*context, callback.map_fn_to()))
+      scope.to_local(|_| v8__Function__New(&*context, callback.map_fn_to()))
     }
   }
 
@@ -304,11 +304,9 @@ impl Function {
     callback: impl MapFnTo<FunctionCallback>,
   ) -> Option<Local<'sc, Function>> {
     unsafe {
-      scope.to_local(v8__Function__NewWithData(
-        &*context,
-        callback.map_fn_to(),
-        &*data,
-      ))
+      scope.to_local(|_| {
+        v8__Function__NewWithData(&*context, callback.map_fn_to(), &*data)
+      })
     }
   }
 
@@ -323,7 +321,8 @@ impl Function {
     let argc = int::try_from(args.len()).unwrap();
     let argv = args.as_ptr();
     unsafe {
-      scope.to_local(v8__Function__Call(self, &*context, &*recv, argc, argv))
+      scope
+        .to_local(|_| v8__Function__Call(self, &*context, &*recv, argc, argv))
     }
   }
 }

--- a/src/global.rs
+++ b/src/global.rs
@@ -74,13 +74,13 @@ impl<T> Global<T> {
     &self,
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, T>> {
-    let isolate = scope.isolate();
-    self.check_isolate(isolate);
+    self.check_isolate(scope.isolate());
     self
       .value
       .map(|g| g.as_ptr() as *const Data)
-      .map(|g| unsafe { v8__Local__New(isolate, g) })
-      .and_then(|l| unsafe { scope.to_local(l as *const T) })
+      .and_then(|g| unsafe {
+        scope.to_local(|scope| v8__Local__New(scope.isolate(), g) as *const T)
+      })
   }
 
   /// If non-empty, destroy the underlying storage cell

--- a/src/handle_scope.rs
+++ b/src/handle_scope.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2020 the Deno authors. All rights reserved. MIT license.
 
 use crate::isolate::Isolate;
-use crate::scope::Scope;
+use crate::scope::ScopeData;
 use crate::scope::ScopeDefinition;
 use crate::scope_traits::ToLocalOrReturnsLocal;
 use crate::Data;
@@ -38,12 +38,12 @@ extern "C" {
 pub struct HandleScope([usize; 3]);
 
 impl<'s> HandleScope {
-  pub fn new<P>(parent: &'s mut P) -> Scope<'s, Self, P>
+  pub fn new<P>(parent: &'s mut P) -> ScopeData<'s, Self, P>
   where
     P: InIsolate,
   {
     let isolate: *mut Isolate = parent.isolate();
-    Scope::new(isolate, parent)
+    ScopeData::new(isolate, parent)
   }
 }
 
@@ -66,12 +66,12 @@ impl Drop for HandleScope {
 pub struct EscapableHandleScope([usize; 4]);
 
 impl<'s> EscapableHandleScope {
-  pub fn new<'p: 's, P>(parent: &'s mut P) -> Scope<'s, Self, P>
+  pub fn new<'p: 's, P>(parent: &'s mut P) -> ScopeData<'s, Self, P>
   where
     P: ToLocalOrReturnsLocal<'p>,
   {
     let isolate: *mut Isolate = parent.isolate();
-    Scope::new(isolate, parent)
+    ScopeData::new(isolate, parent)
   }
 
   /// Pushes the value into the previous scope and returns a handle to it.

--- a/src/json.rs
+++ b/src/json.rs
@@ -24,7 +24,7 @@ pub fn parse<'sc>(
   context: Local<'_, Context>,
   json_string: Local<'_, String>,
 ) -> Option<Local<'sc, Value>> {
-  unsafe { scope.to_local(v8__JSON__Parse(&*context, &*json_string)) }
+  unsafe { scope.to_local(|_| v8__JSON__Parse(&*context, &*json_string)) }
 }
 
 /// Tries to stringify the JSON-serializable object `json_object` and returns
@@ -34,5 +34,5 @@ pub fn stringify<'sc>(
   context: Local<'sc, Context>,
   json_object: Local<'sc, Value>,
 ) -> Option<Local<'sc, String>> {
-  unsafe { scope.to_local(v8__JSON__Stringify(&*context, &*json_object)) }
+  unsafe { scope.to_local(|_| v8__JSON__Stringify(&*context, &*json_object)) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! object that is directly accessible, which guarantees that all interactions
 //! with the Isolate are safe.
 //!
-//! A Scope as such is not a trait (there is currently an internal
+//! A ScopeData as such is not a trait (there is currently an internal
 //! ScopeDefinition trait but that's only there to make implementation easier).
 //!
 //! Rather, there are a number of traits that are implemented for the scopes
@@ -46,7 +46,7 @@
 //! ToLocal (I might rename that) is implemented for all Scopes in which new
 //! Local handles can be created and it sets the appropriate lifetime on them.
 //!
-//! Furthermore, many callbacks will receive receive an appropriate Scope object
+//! Furthermore, many callbacks will receive receive an appropriate ScopeData object
 //! as their first argument, which 'encodes' the the state the isolate is in
 //! when the callback is called. E.g. a FunctionCallbackScope implements
 //! InIsolate + and ToLocal (it acts as a HandleScope).
@@ -149,7 +149,7 @@ pub use scope::CallbackScope;
 pub use scope::ContextScope;
 pub use scope::FunctionCallbackScope;
 pub use scope::PropertyCallbackScope;
-pub use scope::Scope;
+pub use scope::ScopeData;
 pub use scope_traits::*;
 pub use script::ScriptOrigin;
 pub use snapshot::FunctionCodeHandling;

--- a/src/module.rs
+++ b/src/module.rs
@@ -226,6 +226,6 @@ impl Module {
     scope: &mut impl ToLocal<'sc>,
     context: Local<Context>,
   ) -> Option<Local<'sc, Value>> {
-    unsafe { scope.to_local(v8__Module__Evaluate(&*self, &*context)) }
+    unsafe { scope.to_local(|_| v8__Module__Evaluate(&*self, &*context)) }
   }
 }

--- a/src/number.rs
+++ b/src/number.rs
@@ -20,8 +20,8 @@ impl Number {
     scope: &mut impl ToLocal<'sc>,
     value: f64,
   ) -> Local<'sc, Number> {
-    let local = unsafe { v8__Number__New(scope.isolate(), value) };
-    unsafe { scope.to_local(local) }.unwrap()
+    unsafe { scope.to_local(|scope| v8__Number__New(scope.isolate(), value)) }
+      .unwrap()
   }
 
   pub fn value(&self) -> f64 {
@@ -34,16 +34,19 @@ impl Integer {
     scope: &mut impl ToLocal<'sc>,
     value: i32,
   ) -> Local<'sc, Integer> {
-    let local = unsafe { v8__Integer__New(scope.isolate(), value) };
-    unsafe { scope.to_local(local) }.unwrap()
+    unsafe { scope.to_local(|scope| v8__Integer__New(scope.isolate(), value)) }
+      .unwrap()
   }
 
   pub fn new_from_unsigned<'sc>(
     scope: &mut impl ToLocal<'sc>,
     value: u32,
   ) -> Local<'sc, Integer> {
-    let local = unsafe { v8__Integer__NewFromUnsigned(scope.isolate(), value) };
-    unsafe { scope.to_local(local) }.unwrap()
+    unsafe {
+      scope
+        .to_local(|scope| v8__Integer__NewFromUnsigned(scope.isolate(), value))
+    }
+    .unwrap()
   }
 
   pub fn value(&self) -> i64 {

--- a/src/object.rs
+++ b/src/object.rs
@@ -94,8 +94,7 @@ extern "C" {
 impl Object {
   /// Creates an empty object.
   pub fn new<'sc>(scope: &mut impl ToLocal<'sc>) -> Local<'sc, Object> {
-    let ptr = unsafe { v8__Object__New(scope.isolate()) };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe { scope.to_local(|scope| v8__Object__New(scope.isolate())) }.unwrap()
   }
 
   /// Creates a JavaScript object with the given properties, and the given
@@ -113,15 +112,17 @@ impl Object {
     let names = Local::slice_into_raw(names);
     let values = Local::slice_into_raw(values);
     unsafe {
-      let object = v8__Object__New__with_prototype_and_properties(
-        scope.isolate(),
-        &*prototype_or_null,
-        names.as_ptr(),
-        values.as_ptr(),
-        names.len(),
-      );
-      scope.to_local(object).unwrap()
+      scope.to_local(|scope| {
+        v8__Object__New__with_prototype_and_properties(
+          scope.isolate(),
+          &*prototype_or_null,
+          names.as_ptr(),
+          values.as_ptr(),
+          names.len(),
+        )
+      })
     }
+    .unwrap()
   }
 
   /// Set only return Just(true) or Empty(), so if it should never fail, use
@@ -198,10 +199,7 @@ impl Object {
     context: Local<Context>,
     key: Local<Value>,
   ) -> Option<Local<'a, Value>> {
-    unsafe {
-      let ptr = v8__Object__Get(self, &*context, &*key);
-      scope.to_local(ptr)
-    }
+    unsafe { scope.to_local(|_| v8__Object__Get(self, &*context, &*key)) }
   }
 
   pub fn get_index<'a>(
@@ -210,10 +208,7 @@ impl Object {
     context: Local<Context>,
     index: u32,
   ) -> Option<Local<'a, Value>> {
-    unsafe {
-      let ptr = v8__Object__GetIndex(self, &*context, index);
-      scope.to_local(ptr)
-    }
+    unsafe { scope.to_local(|_| v8__Object__GetIndex(self, &*context, index)) }
   }
 
   /// Get the prototype object. This does not skip objects marked to be
@@ -222,10 +217,7 @@ impl Object {
     &self,
     scope: &mut impl ToLocal<'a>,
   ) -> Option<Local<'a, Value>> {
-    unsafe {
-      let ptr = v8__Object__GetPrototype(self);
-      scope.to_local(ptr)
-    }
+    unsafe { scope.to_local(|_| v8__Object__GetPrototype(self)) }
   }
 
   /// Note: SideEffectType affects the getter only, not the setter.
@@ -255,10 +247,7 @@ impl Object {
     &self,
     scope: &mut impl ToLocal<'a>,
   ) -> Local<'a, Context> {
-    unsafe {
-      let ptr = v8__Object__CreationContext(self);
-      scope.to_local(ptr).unwrap()
-    }
+    unsafe { scope.to_local(|_| v8__Object__CreationContext(self)) }.unwrap()
   }
 
   /// This function has the same functionality as GetPropertyNames but the
@@ -269,7 +258,9 @@ impl Object {
     scope: &mut impl ToLocal<'sc>,
     context: Local<Context>,
   ) -> Option<Local<'sc, Array>> {
-    unsafe { scope.to_local(v8__Object__GetOwnPropertyNames(self, &*context)) }
+    unsafe {
+      scope.to_local(|_| v8__Object__GetOwnPropertyNames(self, &*context))
+    }
   }
 
   /// Returns an array containing the names of the filtered properties of this
@@ -281,7 +272,7 @@ impl Object {
     scope: &mut impl ToLocal<'sc>,
     context: Local<Context>,
   ) -> Option<Local<'sc, Array>> {
-    unsafe { scope.to_local(v8__Object__GetPropertyNames(self, &*context)) }
+    unsafe { scope.to_local(|_| v8__Object__GetPropertyNames(self, &*context)) }
   }
 }
 
@@ -292,8 +283,8 @@ impl Array {
     scope: &mut impl ToLocal<'sc>,
     length: i32,
   ) -> Local<'sc, Array> {
-    let ptr = unsafe { v8__Array__New(scope.isolate(), length) };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe { scope.to_local(|scope| v8__Array__New(scope.isolate(), length)) }
+      .unwrap()
   }
 
   /// Creates a JavaScript array out of a Local<Value> array with a known length.
@@ -305,14 +296,16 @@ impl Array {
       return Self::new(scope, 0);
     }
     let elements = Local::slice_into_raw(elements);
-    let ptr = unsafe {
-      v8__Array__New_with_elements(
-        scope.isolate(),
-        elements.as_ptr(),
-        elements.len(),
-      )
-    };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe {
+      scope.to_local(|scope| {
+        v8__Array__New_with_elements(
+          scope.isolate(),
+          elements.as_ptr(),
+          elements.len(),
+        )
+      })
+    }
+    .unwrap()
   }
 
   pub fn length(&self) -> u32 {
@@ -330,7 +323,6 @@ impl Map {
     &self,
     scope: &mut impl ToLocal<'sc>,
   ) -> Local<'sc, Array> {
-    let ptr = unsafe { v8__Map__As__Array(self) };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe { scope.to_local(|_| v8__Map__As__Array(self)) }.unwrap()
   }
 }

--- a/src/primitive_array.rs
+++ b/src/primitive_array.rs
@@ -33,9 +33,12 @@ impl PrimitiveArray {
     scope: &mut impl ToLocal<'sc>,
     length: usize,
   ) -> Local<'sc, PrimitiveArray> {
-    let ptr =
-      unsafe { v8__PrimitiveArray__New(scope.isolate(), length as int) };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe {
+      scope.to_local(|scope| {
+        v8__PrimitiveArray__New(scope.isolate(), length as int)
+      })
+    }
+    .unwrap()
   }
 
   pub fn length(&self) -> usize {
@@ -58,8 +61,11 @@ impl PrimitiveArray {
     scope: &mut impl ToLocal<'sc>,
     index: usize,
   ) -> Local<'sc, Primitive> {
-    let ptr =
-      unsafe { v8__PrimitiveArray__Get(self, scope.isolate(), index as int) };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe {
+      scope.to_local(|scope| {
+        v8__PrimitiveArray__Get(self, scope.isolate(), index as int)
+      })
+    }
+    .unwrap()
   }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -12,13 +12,11 @@ extern "C" {
 }
 
 pub fn null<'sc>(scope: &mut impl ToLocal<'sc>) -> Local<'sc, Primitive> {
-  let ptr = unsafe { v8__Null(scope.isolate()) };
-  unsafe { scope.to_local(ptr) }.unwrap()
+  unsafe { scope.to_local(|scope| v8__Null(scope.isolate())) }.unwrap()
 }
 
 pub fn undefined<'sc>(scope: &mut impl ToLocal<'sc>) -> Local<'sc, Primitive> {
-  let ptr = unsafe { v8__Undefined(scope.isolate()) };
-  unsafe { scope.to_local(ptr) }.unwrap()
+  unsafe { scope.to_local(|scope| v8__Undefined(scope.isolate())) }.unwrap()
 }
 
 impl Boolean {
@@ -26,7 +24,7 @@ impl Boolean {
     scope: &mut impl ToLocal<'sc>,
     value: bool,
   ) -> Local<'sc, Boolean> {
-    let ptr = unsafe { v8__Boolean__New(scope.isolate(), value) };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe { scope.to_local(|scope| v8__Boolean__New(scope.isolate(), value)) }
+      .unwrap()
   }
 }

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -83,7 +83,7 @@ impl Promise {
     &self,
     scope: &mut impl ToLocal<'sc>,
   ) -> Local<'sc, Value> {
-    unsafe { scope.to_local(v8__Promise__Result(&*self)) }.unwrap()
+    unsafe { scope.to_local(|_| v8__Promise__Result(&*self)) }.unwrap()
   }
 
   /// Register a rejection handler with a promise.
@@ -95,7 +95,9 @@ impl Promise {
     context: Local<Context>,
     handler: Local<Function>,
   ) -> Option<Local<'sc, Promise>> {
-    unsafe { scope.to_local(v8__Promise__Catch(&*self, &*context, &*handler)) }
+    unsafe {
+      scope.to_local(|_| v8__Promise__Catch(&*self, &*context, &*handler))
+    }
   }
 
   /// Register a resolution handler with a promise.
@@ -107,7 +109,9 @@ impl Promise {
     context: Local<Context>,
     handler: Local<Function>,
   ) -> Option<Local<'sc, Promise>> {
-    unsafe { scope.to_local(v8__Promise__Then(&*self, &*context, &*handler)) }
+    unsafe {
+      scope.to_local(|_| v8__Promise__Then(&*self, &*context, &*handler))
+    }
   }
 
   /// Register a resolution/rejection handler with a promise.
@@ -122,12 +126,9 @@ impl Promise {
     on_rejected: Local<Function>,
   ) -> Option<Local<'sc, Promise>> {
     unsafe {
-      scope.to_local(v8__Promise__Then2(
-        &*self,
-        &*context,
-        &*on_fulfilled,
-        &*on_rejected,
-      ))
+      scope.to_local(|_| {
+        v8__Promise__Then2(&*self, &*context, &*on_fulfilled, &*on_rejected)
+      })
     }
   }
 }
@@ -138,7 +139,7 @@ impl PromiseResolver {
     scope: &mut impl ToLocal<'sc>,
     context: Local<'sc, Context>,
   ) -> Option<Local<'sc, PromiseResolver>> {
-    unsafe { scope.to_local(v8__Promise__Resolver__New(&*context)) }
+    unsafe { scope.to_local(|_| v8__Promise__Resolver__New(&*context)) }
   }
 
   /// Extract the associated promise.
@@ -146,7 +147,7 @@ impl PromiseResolver {
     &self,
     scope: &mut impl ToLocal<'sc>,
   ) -> Local<'sc, Promise> {
-    unsafe { scope.to_local(v8__Promise__Resolver__GetPromise(&*self)) }
+    unsafe { scope.to_local(|_| v8__Promise__Resolver__GetPromise(&*self)) }
       .unwrap()
   }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -25,8 +25,7 @@ impl Proxy {
     handler: Local<Object>,
   ) -> Option<Local<'sc, Proxy>> {
     unsafe {
-      let ptr = v8__Proxy__New(&*context, &*target, &*handler);
-      scope.to_local(ptr)
+      scope.to_local(|_| v8__Proxy__New(&*context, &*target, &*handler))
     }
   }
 
@@ -34,14 +33,14 @@ impl Proxy {
     &mut self,
     scope: &mut impl ToLocal<'sc>,
   ) -> Local<'sc, Value> {
-    unsafe { scope.to_local(v8__Proxy__GetHandler(&*self)) }.unwrap()
+    unsafe { scope.to_local(|_| v8__Proxy__GetHandler(&*self)) }.unwrap()
   }
 
   pub fn get_target<'sc>(
     &mut self,
     scope: &mut impl ToLocal<'sc>,
   ) -> Local<'sc, Value> {
-    unsafe { scope.to_local(v8__Proxy__GetTarget(&*self)) }.unwrap()
+    unsafe { scope.to_local(|_| v8__Proxy__GetTarget(&*self)) }.unwrap()
   }
 
   pub fn is_revoked(&mut self) -> bool {

--- a/src/scope_traits.rs
+++ b/src/scope_traits.rs
@@ -151,21 +151,24 @@ extern "C" {
 /// When scope implements this trait, this means that Local handles can be
 /// created inside it.
 pub trait ToLocal<'s>: InIsolate {
-  unsafe fn to_local<T>(&mut self, ptr: *const T) -> Option<Local<'s, T>> {
-    Local::from_raw(ptr)
+  unsafe fn to_local<T, F: FnOnce(&mut Self) -> *const T>(
+    &mut self,
+    f: F,
+  ) -> Option<Local<'s, T>> {
+    Local::from_raw(f(self))
   }
 
   fn get_current_context(&mut self) -> Option<Local<'s, Context>> {
     unsafe {
-      let ptr = v8__Isolate__GetCurrentContext(self.isolate());
-      self.to_local(ptr)
+      self.to_local(|scope| v8__Isolate__GetCurrentContext(scope.isolate()))
     }
   }
 
   fn get_entered_or_microtask_context(&mut self) -> Option<Local<'s, Context>> {
     unsafe {
-      let ptr = v8__Isolate__GetEnteredOrMicrotaskContext(self.isolate());
-      self.to_local(ptr)
+      self.to_local(|scope| {
+        v8__Isolate__GetEnteredOrMicrotaskContext(scope.isolate())
+      })
     }
   }
 }

--- a/src/scope_traits.rs
+++ b/src/scope_traits.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2020 the Deno authors. All rights reserved. MIT license.
 
-use crate::scope::Entered;
 use crate::scope::Escapable;
+use crate::scope::Scope;
 use crate::CallbackScope;
 use crate::Context;
 use crate::ContextScope;
@@ -61,7 +61,7 @@ pub(crate) mod internal {
     }
   }
 
-  impl<'s, S> GetRawIsolate for Entered<'_, S>
+  impl<'s, S> GetRawIsolate for Scope<'_, S>
   where
     S: GetRawIsolate,
   {
@@ -132,7 +132,7 @@ pub trait InIsolate {
   fn isolate(&mut self) -> &mut Isolate;
 }
 
-impl<'s, S, P> InIsolate for Entered<'s, S, P>
+impl<'s, S, P> InIsolate for Scope<'s, S, P>
 where
   S: internal::GetRawIsolate,
 {
@@ -173,11 +173,11 @@ pub trait ToLocal<'s>: InIsolate {
   }
 }
 
-impl<'s> ToLocal<'s> for Entered<'s, FunctionCallbackInfo> {}
-impl<'s> ToLocal<'s> for Entered<'s, PropertyCallbackInfo> {}
-impl<'s, P> ToLocal<'s> for Entered<'s, HandleScope, P> {}
-impl<'s, P> ToLocal<'s> for Entered<'s, EscapableHandleScope, P> {}
-impl<'s, 'p: 's, P> ToLocal<'p> for Entered<'s, ContextScope, P> where
+impl<'s> ToLocal<'s> for Scope<'s, FunctionCallbackInfo> {}
+impl<'s> ToLocal<'s> for Scope<'s, PropertyCallbackInfo> {}
+impl<'s, P> ToLocal<'s> for Scope<'s, HandleScope, P> {}
+impl<'s, P> ToLocal<'s> for Scope<'s, EscapableHandleScope, P> {}
+impl<'s, 'p: 's, P> ToLocal<'p> for Scope<'s, ContextScope, P> where
   P: ToLocal<'p>
 {
 }
@@ -185,7 +185,7 @@ impl<'s, 'p: 's, P> ToLocal<'p> for Entered<'s, ContextScope, P> where
 pub trait ToLocalOrReturnsLocal<'s>: InIsolate {}
 impl<'s, E> ToLocalOrReturnsLocal<'s> for E where E: ToLocal<'s> {}
 impl<'s, 'p: 's> ToLocalOrReturnsLocal<'p>
-  for Entered<'s, CallbackScope<Escapable>>
+  for Scope<'s, CallbackScope<Escapable>>
 {
 }
 
@@ -193,7 +193,7 @@ pub trait EscapeLocal<'s, 'p: 's>: ToLocal<'s> {
   fn escape<T>(&mut self, local: Local<T>) -> Local<'p, T>;
 }
 
-impl<'s, 'p: 's, P> EscapeLocal<'s, 'p> for Entered<'s, EscapableHandleScope, P>
+impl<'s, 'p: 's, P> EscapeLocal<'s, 'p> for Scope<'s, EscapableHandleScope, P>
 where
   P: ToLocalOrReturnsLocal<'p>,
 {
@@ -202,7 +202,7 @@ where
   }
 }
 
-impl<'s, 'p: 's, P> EscapeLocal<'s, 'p> for Entered<'s, ContextScope, P>
+impl<'s, 'p: 's, P> EscapeLocal<'s, 'p> for Scope<'s, ContextScope, P>
 where
   P: EscapeLocal<'s, 'p>,
 {
@@ -211,7 +211,7 @@ where
   }
 }
 
-impl<'s, 'p: 's, P> EscapeLocal<'s, 'p> for Entered<'s, HandleScope, P>
+impl<'s, 'p: 's, P> EscapeLocal<'s, 'p> for Scope<'s, HandleScope, P>
 where
   P: EscapeLocal<'s, 'p>,
 {
@@ -220,9 +220,9 @@ where
   }
 }
 
-// TODO(piscisaureus): move the impls for Entered to a more sensible spot.
+// TODO(piscisaureus): move the impls for Scope to a more sensible spot.
 
-impl<'s, S, P> Entered<'s, S, P>
+impl<'s, S, P> Scope<'s, S, P>
 where
   Self: InIsolate,
 {
@@ -231,7 +231,7 @@ where
   }
 }
 
-impl<'s, 'p: 's, S, P> Entered<'s, S, P>
+impl<'s, 'p: 's, S, P> Scope<'s, S, P>
 where
   Self: ToLocal<'p>,
 {
@@ -252,7 +252,7 @@ where
   }
 }
 
-impl<'s, 'p: 's, S, P> Entered<'s, S, P>
+impl<'s, 'p: 's, S, P> Scope<'s, S, P>
 where
   Self: EscapeLocal<'s, 'p>,
 {

--- a/src/script.rs
+++ b/src/script.rs
@@ -48,14 +48,15 @@ impl Script {
     source: Local<String>,
     origin: Option<&ScriptOrigin>,
   ) -> Option<Local<'sc, Script>> {
-    let ptr = unsafe {
-      v8__Script__Compile(
-        &*context,
-        &*source,
-        origin.map(|r| r as *const _).unwrap_or(null()),
-      )
-    };
-    unsafe { scope.to_local(ptr) }
+    unsafe {
+      scope.to_local(|_| {
+        v8__Script__Compile(
+          &*context,
+          &*source,
+          origin.map(|r| r as *const _).unwrap_or(null()),
+        )
+      })
+    }
   }
 
   /// Runs the script returning the resulting value. It will be run in the
@@ -66,7 +67,7 @@ impl Script {
     scope: &mut impl ToLocal<'sc>,
     context: Local<Context>,
   ) -> Option<Local<'sc, Value>> {
-    unsafe { scope.to_local(v8__Script__Run(self, &*context)) }
+    unsafe { scope.to_local(|_| v8__Script__Run(self, &*context)) }
   }
 }
 

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -97,12 +97,13 @@ pub fn compile_module2<'sc>(
   no_cache_reason: NoCacheReason,
 ) -> Option<Local<'sc, Module>> {
   unsafe {
-    let ptr = v8__ScriptCompiler__CompileModule(
-      scope.isolate(),
-      &mut source,
-      options,
-      no_cache_reason,
-    );
-    scope.to_local(ptr)
+    scope.to_local(|scope| {
+      v8__ScriptCompiler__CompileModule(
+        scope.isolate(),
+        &mut source,
+        options,
+        no_cache_reason,
+      )
+    })
   }
 }

--- a/src/shared_array_buffer.rs
+++ b/src/shared_array_buffer.rs
@@ -50,11 +50,12 @@ impl SharedArrayBuffer {
     byte_length: usize,
   ) -> Option<Local<'sc, SharedArrayBuffer>> {
     unsafe {
-      let ptr = v8__SharedArrayBuffer__New__with_byte_length(
-        scope.isolate(),
-        byte_length,
-      );
-      scope.to_local(ptr)
+      scope.to_local(|scope| {
+        v8__SharedArrayBuffer__New__with_byte_length(
+          scope.isolate(),
+          byte_length,
+        )
+      })
     }
   }
 
@@ -62,11 +63,15 @@ impl SharedArrayBuffer {
     scope: &mut impl ToLocal<'sc>,
     backing_store: &SharedRef<BackingStore>,
   ) -> Local<'sc, SharedArrayBuffer> {
-    let isolate = scope.isolate();
-    let ptr = unsafe {
-      v8__SharedArrayBuffer__New__with_backing_store(isolate, backing_store)
-    };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe {
+      scope.to_local(|scope| {
+        v8__SharedArrayBuffer__New__with_backing_store(
+          scope.isolate(),
+          backing_store,
+        )
+      })
+    }
+    .unwrap()
   }
 
   /// Data length in bytes.

--- a/src/string.rs
+++ b/src/string.rs
@@ -64,10 +64,10 @@ bitflags! {
 
 impl String {
   pub fn empty<'sc>(scope: &mut impl ToLocal<'sc>) -> Local<'sc, String> {
-    let ptr = unsafe { v8__String__Empty(scope.isolate()) };
     // FIXME(bnoordhuis) v8__String__Empty() is infallible so there
     // is no need to box up the result, only to unwrap it again.
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe { scope.to_local(|scope| v8__String__Empty(scope.isolate())) }
+      .unwrap()
   }
 
   pub fn new_from_utf8<'sc>(
@@ -78,15 +78,17 @@ impl String {
     if buffer.is_empty() {
       return Some(Self::empty(scope));
     }
-    let ptr = unsafe {
-      v8__String__NewFromUtf8(
-        scope.isolate(),
-        buffer.as_ptr() as *const char,
-        new_type,
-        buffer.len().try_into().ok()?,
-      )
-    };
-    unsafe { scope.to_local(ptr) }
+    let buffer_len = buffer.len().try_into().ok()?;
+    unsafe {
+      scope.to_local(|scope| {
+        v8__String__NewFromUtf8(
+          scope.isolate(),
+          buffer.as_ptr() as *const char,
+          new_type,
+          buffer_len,
+        )
+      })
+    }
   }
 
   /// Returns the number of characters (UTF-16 code units) in this string.

--- a/src/template.rs
+++ b/src/template.rs
@@ -70,10 +70,12 @@ impl FunctionTemplate {
     scope: &mut impl ToLocal<'sc>,
     callback: impl MapFnTo<FunctionCallback>,
   ) -> Local<'sc, FunctionTemplate> {
-    let ptr = unsafe {
-      v8__FunctionTemplate__New(scope.isolate(), callback.map_fn_to())
-    };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe {
+      scope.to_local(|scope| {
+        v8__FunctionTemplate__New(scope.isolate(), callback.map_fn_to())
+      })
+    }
+    .unwrap()
   }
 
   /// Returns the unique function instance in the current execution context.
@@ -83,7 +85,7 @@ impl FunctionTemplate {
     context: Local<Context>,
   ) -> Option<Local<'sc, Function>> {
     unsafe {
-      scope.to_local(v8__FunctionTemplate__GetFunction(&*self, &*context))
+      scope.to_local(|_| v8__FunctionTemplate__GetFunction(&*self, &*context))
     }
   }
 
@@ -98,9 +100,12 @@ impl FunctionTemplate {
 impl ObjectTemplate {
   /// Creates an object template.
   pub fn new<'sc>(scope: &mut impl ToLocal<'sc>) -> Local<'sc, ObjectTemplate> {
-    let ptr =
-      unsafe { v8__ObjectTemplate__New(scope.isolate(), std::ptr::null()) };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe {
+      scope.to_local(|scope| {
+        v8__ObjectTemplate__New(scope.isolate(), std::ptr::null())
+      })
+    }
+    .unwrap()
   }
 
   /// Creates an object template from a function template.
@@ -108,8 +113,10 @@ impl ObjectTemplate {
     scope: &mut impl ToLocal<'sc>,
     templ: Local<FunctionTemplate>,
   ) -> Local<'sc, ObjectTemplate> {
-    let ptr = unsafe { v8__ObjectTemplate__New(scope.isolate(), &*templ) };
-    unsafe { scope.to_local(ptr) }.unwrap()
+    unsafe {
+      scope.to_local(|scope| v8__ObjectTemplate__New(scope.isolate(), &*templ))
+    }
+    .unwrap()
   }
 
   /// Creates a new instance of this object template.
@@ -118,7 +125,8 @@ impl ObjectTemplate {
     scope: &mut impl ToLocal<'a>,
     context: Local<Context>,
   ) -> Option<Local<'a, Object>> {
-    let ptr = unsafe { v8__ObjectTemplate__NewInstance(self, &*context) };
-    unsafe { scope.to_local(ptr) }
+    unsafe {
+      scope.to_local(|_| v8__ObjectTemplate__NewInstance(self, &*context))
+    }
   }
 }

--- a/src/try_catch.rs
+++ b/src/try_catch.rs
@@ -64,7 +64,7 @@ pub struct TryCatchScope<'tc>(TryCatchState<'tc>);
 enum TryCatchState<'tc> {
   New { isolate: *mut Isolate },
   Uninit(MaybeUninit<TryCatch<'tc>>),
-  Entered(TryCatch<'tc>),
+  Scope(TryCatch<'tc>),
 }
 
 impl<'tc> TryCatch<'tc> {
@@ -229,12 +229,12 @@ impl<'tc> TryCatchScope<'tc> {
     TryCatch::construct(buf, isolate);
 
     *state = match take(state) {
-      Uninit(b) => Entered(unsafe { b.assume_init() }),
+      Uninit(b) => Scope(unsafe { b.assume_init() }),
       _ => unreachable!(),
     };
 
     match state {
-      Entered(v) => v,
+      Scope(v) => v,
       _ => unreachable!(),
     }
   }

--- a/src/try_catch.rs
+++ b/src/try_catch.rs
@@ -119,7 +119,7 @@ impl<'tc> TryCatch<'tc> {
     &self,
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, Value>> {
-    unsafe { scope.to_local(v8__TryCatch__Exception(&self.0)) }
+    unsafe { scope.to_local(|_| v8__TryCatch__Exception(&self.0)) }
   }
 
   /// Returns the message associated with this exception. If there is
@@ -131,7 +131,7 @@ impl<'tc> TryCatch<'tc> {
     &self,
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, Message>> {
-    unsafe { scope.to_local(v8__TryCatch__Message(&self.0)) }
+    unsafe { scope.to_local(|_| v8__TryCatch__Message(&self.0)) }
   }
 
   /// Returns the .stack property of the thrown object. If no .stack
@@ -141,7 +141,7 @@ impl<'tc> TryCatch<'tc> {
     scope: &mut impl ToLocal<'sc>,
     context: Local<Context>,
   ) -> Option<Local<'sc, Value>> {
-    unsafe { scope.to_local(v8__TryCatch__StackTrace(&self.0, &*context)) }
+    unsafe { scope.to_local(|_| v8__TryCatch__StackTrace(&self.0, &*context)) }
   }
 
   /// Clears any exceptions that may have been caught by this try/catch block.

--- a/src/uint8_array.rs
+++ b/src/uint8_array.rs
@@ -19,6 +19,8 @@ impl Uint8Array {
     byte_offset: usize,
     length: usize,
   ) -> Option<Local<'sc, Uint8Array>> {
-    unsafe { scope.to_local(v8__Uint8Array__New(&*buf, byte_offset, length)) }
+    unsafe {
+      scope.to_local(|_| v8__Uint8Array__New(&*buf, byte_offset, length))
+    }
   }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -424,7 +424,7 @@ impl Value {
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, BigInt>> {
     scope.get_current_context().and_then(|context| unsafe {
-      scope.to_local(v8__Value__ToBigInt(self, &*context))
+      scope.to_local(|_| v8__Value__ToBigInt(self, &*context))
     })
   }
 
@@ -433,7 +433,7 @@ impl Value {
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, Number>> {
     scope.get_current_context().and_then(|context| unsafe {
-      scope.to_local(v8__Value__ToNumber(self, &*context))
+      scope.to_local(|_| v8__Value__ToNumber(self, &*context))
     })
   }
 
@@ -442,7 +442,7 @@ impl Value {
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, String>> {
     scope.get_current_context().and_then(|context| unsafe {
-      scope.to_local(v8__Value__ToString(self, &*context))
+      scope.to_local(|_| v8__Value__ToString(self, &*context))
     })
   }
 
@@ -451,7 +451,7 @@ impl Value {
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, String>> {
     scope.get_current_context().and_then(|context| unsafe {
-      scope.to_local(v8__Value__ToDetailString(self, &*context))
+      scope.to_local(|_| v8__Value__ToDetailString(self, &*context))
     })
   }
 
@@ -460,7 +460,7 @@ impl Value {
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, Object>> {
     scope.get_current_context().and_then(|context| unsafe {
-      scope.to_local(v8__Value__ToObject(self, &*context))
+      scope.to_local(|_| v8__Value__ToObject(self, &*context))
     })
   }
 
@@ -469,7 +469,7 @@ impl Value {
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, Integer>> {
     scope.get_current_context().and_then(|context| unsafe {
-      scope.to_local(v8__Value__ToInteger(self, &*context))
+      scope.to_local(|_| v8__Value__ToInteger(self, &*context))
     })
   }
 
@@ -478,7 +478,7 @@ impl Value {
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, Uint32>> {
     scope.get_current_context().and_then(|context| unsafe {
-      scope.to_local(v8__Value__ToUint32(self, &*context))
+      scope.to_local(|_| v8__Value__ToUint32(self, &*context))
     })
   }
 
@@ -487,7 +487,7 @@ impl Value {
     scope: &mut impl ToLocal<'sc>,
   ) -> Option<Local<'sc, Int32>> {
     scope.get_current_context().and_then(|context| unsafe {
-      scope.to_local(v8__Value__ToInt32(self, &*context))
+      scope.to_local(|_| v8__Value__ToInt32(self, &*context))
     })
   }
 

--- a/tests/compile_fail/handle_scope_escape_to_nowhere.stderr
+++ b/tests/compile_fail/handle_scope_escape_to_nowhere.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `rusty_v8::scope::Entered<'_, rusty_v8::scope::CallbackScope>: rusty_v8::scope_traits::ToLocal<'_>` is not satisfied
+error[E0277]: the trait bound `rusty_v8::scope::Scope<'_, rusty_v8::scope::CallbackScope>: rusty_v8::scope_traits::ToLocal<'_>` is not satisfied
   --> $DIR/handle_scope_escape_to_nowhere.rs:7:43
    |
 7  |   let _hs = v8::EscapableHandleScope::new(cs.enter());
-   |                                           ^^^^^^^^^^ the trait `rusty_v8::scope_traits::ToLocal<'_>` is not implemented for `rusty_v8::scope::Entered<'_, rusty_v8::scope::CallbackScope>`
+   |                                           ^^^^^^^^^^ the trait `rusty_v8::scope_traits::ToLocal<'_>` is not implemented for `rusty_v8::scope::Scope<'_, rusty_v8::scope::CallbackScope>`
    | 
   ::: $WORKSPACE/src/handle_scope.rs:71:8
    |
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `rusty_v8::scope::Entered<'_, rusty_v8::scope::Cal
    |        ------------------------- required by this bound in `rusty_v8::handle_scope::EscapableHandleScope::new`
    |
    = help: the following implementations were found:
-             <rusty_v8::scope::Entered<'s, rusty_v8::function::FunctionCallbackInfo> as rusty_v8::scope_traits::ToLocal<'s>>
-             <rusty_v8::scope::Entered<'s, rusty_v8::function::PropertyCallbackInfo> as rusty_v8::scope_traits::ToLocal<'s>>
-             <rusty_v8::scope::Entered<'s, rusty_v8::handle_scope::EscapableHandleScope, P> as rusty_v8::scope_traits::ToLocal<'s>>
-             <rusty_v8::scope::Entered<'s, rusty_v8::handle_scope::HandleScope, P> as rusty_v8::scope_traits::ToLocal<'s>>
-             <rusty_v8::scope::Entered<'s, rusty_v8::scope::ContextScope, P> as rusty_v8::scope_traits::ToLocal<'p>>
-   = note: required because of the requirements on the impl of `rusty_v8::scope_traits::ToLocalOrReturnsLocal<'_>` for `rusty_v8::scope::Entered<'_, rusty_v8::scope::CallbackScope>`
+             <rusty_v8::scope::Scope<'s, rusty_v8::function::FunctionCallbackInfo> as rusty_v8::scope_traits::ToLocal<'s>>
+             <rusty_v8::scope::Scope<'s, rusty_v8::function::PropertyCallbackInfo> as rusty_v8::scope_traits::ToLocal<'s>>
+             <rusty_v8::scope::Scope<'s, rusty_v8::handle_scope::EscapableHandleScope, P> as rusty_v8::scope_traits::ToLocal<'s>>
+             <rusty_v8::scope::Scope<'s, rusty_v8::handle_scope::HandleScope, P> as rusty_v8::scope_traits::ToLocal<'s>>
+             <rusty_v8::scope::Scope<'s, rusty_v8::scope::ContextScope, P> as rusty_v8::scope_traits::ToLocal<'p>>
+   = note: required because of the requirements on the impl of `rusty_v8::scope_traits::ToLocalOrReturnsLocal<'_>` for `rusty_v8::scope::Scope<'_, rusty_v8::scope::CallbackScope>`


### PR DESCRIPTION
This makes it possible to add a run-time check that verifies that the
specified closure is actually the one that contains the local handle.