### PR TITLE
improve error message.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -132,7 +132,7 @@ fn platform() -> &'static str {
 fn download_ninja_gn_binaries() {
   let root = env::current_dir().unwrap();
   let out_dir = env::var_os("OUT_DIR").expect(
-    "OUT_DIR expected target/debug//build/rusty_v8-xxxxxxxxxxxxxxxx/out/.",
+    "The 'OUT_DIR' environment is not set (it should be something like 'target/debug/rusty_v8-{hash}').",
   );
   let out_dir_abs = root.join(out_dir);
   // This would be target/debug or target/release

--- a/build.rs
+++ b/build.rs
@@ -131,8 +131,9 @@ fn platform() -> &'static str {
 
 fn download_ninja_gn_binaries() {
   let root = env::current_dir().unwrap();
-  // target/debug//build/rusty_v8-d9e5a424d4f96994/out/
-  let out_dir = env::var_os("OUT_DIR").unwrap();
+  let out_dir = env::var_os("OUT_DIR").expect(
+    "OUT_DIR expected target/debug//build/rusty_v8-xxxxxxxxxxxxxxxx/out/.",
+  );
   let out_dir_abs = root.join(out_dir);
   // This would be target/debug or target/release
   let target_dir = out_dir_abs


### PR DESCRIPTION
This is likely to be more user-friendly than the unwrap method.