### PR TITLE
Add bindings for `Object`/`Value` items

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -752,6 +752,30 @@ const v8::Array* v8__Object__GetPropertyNames(const v8::Object* self,
       ptr_to_local(self)->GetPropertyNames(ptr_to_local(context)));
 }
 
+MaybeBool v8__Object__Has(const v8::Object& self, const v8::Context& context,
+                          const v8::Value& key) {
+  return maybe_to_maybe_bool(
+      ptr_to_local(&self)->Has(ptr_to_local(&context), ptr_to_local(&key)));
+}
+
+MaybeBool v8__Object__HasIndex(const v8::Object& self,
+                               const v8::Context& context, uint32_t index) {
+  return maybe_to_maybe_bool(
+      ptr_to_local(&self)->Has(ptr_to_local(&context), index));
+}
+
+MaybeBool v8__Object__Delete(const v8::Object& self, const v8::Context& context,
+                             const v8::Value& key) {
+  return maybe_to_maybe_bool(
+      ptr_to_local(&self)->Delete(ptr_to_local(&context), ptr_to_local(&key)));
+}
+
+MaybeBool v8__Object__DeleteIndex(const v8::Object& self,
+                                  const v8::Context& context, uint32_t index) {
+  return maybe_to_maybe_bool(
+      ptr_to_local(&self)->Delete(ptr_to_local(&context), index));
+}
+
 const v8::Array* v8__Array__New(v8::Isolate* isolate, int length) {
   return local_to_ptr(v8::Array::New(isolate, length));
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -473,6 +473,11 @@ const v8::Object* v8__Value__ToObject(const v8::Value& self,
   return maybe_local_to_ptr(self.ToObject(ptr_to_local(&context)));
 }
 
+const v8::Boolean* v8__Value__ToBoolean(const v8::Value& self,
+                                        v8::Isolate* isolate) {
+  return local_to_ptr(self.ToBoolean(isolate));
+}
+
 void v8__Value__NumberValue(const v8::Value& self, const v8::Context& context,
                             v8::Maybe<double>* out) {
   *out = self.NumberValue(ptr_to_local(&context));
@@ -491,6 +496,10 @@ void v8__Value__Uint32Value(const v8::Value& self, const v8::Context& context,
 void v8__Value__Int32Value(const v8::Value& self, const v8::Context& context,
                            v8::Maybe<int32_t>* out) {
   *out = self.Int32Value(ptr_to_local(&context));
+}
+
+bool v8__Value__BooleanValue(const v8::Value& self, v8::Isolate* isolate) {
+  return self.BooleanValue(isolate);
 }
 
 const v8::Primitive* v8__Null(v8::Isolate* isolate) {

--- a/src/object.rs
+++ b/src/object.rs
@@ -79,6 +79,26 @@ extern "C" {
     this: *const Object,
     context: *const Context,
   ) -> *const Array;
+  fn v8__Object__Has(
+    this: *const Object,
+    context: *const Context,
+    key: *const Value,
+  ) -> MaybeBool;
+  fn v8__Object__HasIndex(
+    this: *const Object,
+    context: *const Context,
+    index: u32,
+  ) -> MaybeBool;
+  fn v8__Object__Delete(
+    this: *const Object,
+    context: *const Context,
+    key: *const Value,
+  ) -> MaybeBool;
+  fn v8__Object__DeleteIndex(
+    this: *const Object,
+    context: *const Context,
+    index: u32,
+  ) -> MaybeBool;
 
   fn v8__Array__New(isolate: *mut Isolate, length: int) -> *const Array;
   fn v8__Array__New_with_elements(
@@ -310,6 +330,54 @@ impl Object {
         v8__Object__GetPropertyNames(self, sd.get_current_context())
       })
     }
+  }
+
+  // Calls the abstract operation HasProperty(O, P) described in ECMA-262,
+  // 7.3.10. Returns true, if the object has the property, either own or on the
+  // prototype chain. Interceptors, i.e., PropertyQueryCallbacks, are called if
+  // present.
+  //
+  // This function has the same side effects as JavaScript's variable in object.
+  // For example, calling this on a revoked proxy will throw an exception.
+  //
+  // Note: This function converts the key to a name, which possibly calls back
+  // into JavaScript.
+  pub fn has<'s>(
+    &self,
+    scope: &mut HandleScope<'s>,
+    key: Local<Value>,
+  ) -> Option<bool> {
+    unsafe { v8__Object__Has(self, &*scope.get_current_context(), &*key) }
+      .into()
+  }
+
+  pub fn has_index<'s>(
+    &self,
+    scope: &mut HandleScope<'s>,
+    index: u32,
+  ) -> Option<bool> {
+    unsafe { v8__Object__HasIndex(self, &*scope.get_current_context(), index) }
+      .into()
+  }
+
+  pub fn delete<'s>(
+    &self,
+    scope: &mut HandleScope<'s>,
+    key: Local<Value>,
+  ) -> Option<bool> {
+    unsafe { v8__Object__Delete(self, &*scope.get_current_context(), &*key) }
+      .into()
+  }
+
+  pub fn delete_index<'s>(
+    &self,
+    scope: &mut HandleScope<'s>,
+    index: u32,
+  ) -> Option<bool> {
+    unsafe {
+      v8__Object__DeleteIndex(self, &*scope.get_current_context(), index)
+    }
+    .into()
   }
 }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2070,6 +2070,8 @@ fn value_checker() {
     assert!(value != v8::undefined(scope));
     assert!(value != v8::Boolean::new(scope, false));
     assert!(value != v8::Integer::new(scope, 0));
+    assert!(value.to_boolean(scope) == v8::Boolean::new(scope, false));
+    assert!(!value.boolean_value(scope));
 
     let value = eval(scope, "true").unwrap();
     assert!(value.is_boolean());
@@ -2083,6 +2085,7 @@ fn value_checker() {
     assert!(v8::Global::new(scope, value) == eval(scope, "!false").unwrap());
     assert!(v8::Global::new(scope, value) != eval(scope, "1").unwrap());
     assert!(value != v8::Boolean::new(scope, false));
+    assert!(value.boolean_value(scope));
 
     let value = eval(scope, "false").unwrap();
     assert!(value.is_boolean());
@@ -2099,6 +2102,7 @@ fn value_checker() {
     assert!(value != v8::null(scope));
     assert!(value != v8::undefined(scope));
     assert!(value != v8::Integer::new(scope, 0));
+    assert!(!value.boolean_value(scope));
 
     let value = eval(scope, "'name'").unwrap();
     assert!(value.is_name());
@@ -2108,6 +2112,8 @@ fn value_checker() {
     assert!(value == v8::String::new(scope, "name").unwrap());
     assert!(value != v8::String::new(scope, "name\0").unwrap());
     assert!(value != v8::Object::new(scope));
+    assert!(value.to_boolean(scope) == v8::Boolean::new(scope, true));
+    assert!(value.boolean_value(scope));
 
     let value = eval(scope, "Symbol()").unwrap();
     assert!(value.is_name());

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1190,6 +1190,12 @@ fn object() {
     assert!(!object_.is_null_or_undefined());
     let id = object_.get_identity_hash();
     assert_ne!(id, 0);
+
+    assert!(object.has(scope, n1.into()).unwrap());
+    let n_unused = v8::String::new(scope, "unused").unwrap().into();
+    assert!(!object.has(scope, n_unused).unwrap());
+    assert!(object.delete(scope, n1.into()).unwrap());
+    assert!(!object.has(scope, n1.into()).unwrap());
   }
 }
 
@@ -1230,6 +1236,10 @@ fn array() {
     let maybe_v2 = array.get_index(scope, 1);
     assert!(maybe_v2.is_some());
     assert!(maybe_v2.unwrap().same_value(s2.into()));
+
+    assert!(array.has_index(scope, 1).unwrap());
+    assert!(array.delete_index(scope, 1).unwrap());
+    assert!(!array.has_index(scope, 1).unwrap());
   }
 }
 


### PR DESCRIPTION
I was attempting to rewrite my `mini-v8` crate using `rusty_v8` and saw that a few necessary bindings were missing for my purposes. Thanks for your hard work!