### PR TITLE
break module snapshoting

### DIFF
--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2887,6 +2887,7 @@ fn module_snapshot() {
       let source_text = v8::String::new(
         scope,
         "import 'globalThis.b = 42';\n\
+         globalThis.c = () => { return 1+1 }\n\
          globalThis.a = 3",
       )
       .unwrap();


### PR DESCRIPTION
Fails with
```

#
# Fatal error in ../../../../v8/src/snapshot/context-serializer.cc, line 195
# Debug check failed: !o.IsScript().
#
#
#
#FailureMessage Object: 0x70000f07a8f0
==== C stack trace ===============================

    0   test_api-27bc62e5a45d899d           0x0000000104d2ac33 v8::base::debug::StackTrace::StackTrace() + 19
    1   test_api-27bc62e5a45d899d           0x000000010582c54b v8::platform::(anonymous namespace)::PrintStackTrace() + 59
    2   test_api-27bc62e5a45d899d           0x0000000104d20851 V8_Fatal(char const*, int, char const*, ...) + 337
    3   test_api-27bc62e5a45d899d           0x0000000104d1ffb5 v8::base::(anonymous namespace)::DefaultDcheckHandler(char const*, int, char const*) + 21
    4   test_api-27bc62e5a45d899d           0x0000000104a76377 v8::internal::ContextSerializer::ShouldBeInTheStartupObjectCache(v8::internal::HeapObject) + 471
    5   test_api-27bc62e5a45d899d           0x0000000104a75cc7 v8::internal::ContextSerializer::SerializeObject(v8::internal::HeapObject) + 215
    6   test_api-27bc62e5a45d899d           0x0000000104aa3b64 v8::internal::Serializer::ObjectSerializer::VisitPointers(v8::internal::HeapObject, v8::internal::CompressedMaybeObjectSlot, v8::internal::CompressedMaybeObjectSlot) + 420
    7   test_api-27bc62e5a45d899d           0x0000000104aa32b9 v8::internal::Serializer::ObjectSerializer::SerializeContent(v8::internal::Map, int) + 233
    8   test_api-27bc62e5a45d899d           0x0000000104aa23eb v8::internal::Serializer::ObjectSerializer::SerializeObject() + 379
    9   test_api-27bc62e5a45d899d           0x0000000104aa30ff v8::internal::Serializer::ObjectSerializer::Serialize() + 607
    10  test_api-27bc62e5a45d899d           0x0000000104a75f02 v8::internal::ContextSerializer::SerializeObject(v8::internal::HeapObject) + 786
    11  test_api-27bc62e5a45d899d           0x0000000104aa3b64 v8::internal::Serializer::ObjectSerializer::VisitPointers(v8::internal::HeapObject, v8::internal::CompressedMaybeObjectSlot, v8::internal::CompressedMaybeObjectSlot) + 420
    12  test_api-27bc62e5a45d899d           0x0000000104aa32b9 v8::internal::Serializer::ObjectSerializer::SerializeContent(v8::internal::Map, int) + 233
    13  test_api-27bc62e5a45d899d           0x0000000104aa23eb v8::internal::Serializer::ObjectSerializer::SerializeObject() + 379
    14  test_api-27bc62e5a45d899d           0x0000000104aa30ff v8::internal::Serializer::ObjectSerializer::Serialize() + 607
    15  test_api-27bc62e5a45d899d           0x0000000104a75f02 v8::internal::ContextSerializer::SerializeObject(v8::internal::HeapObject) + 786
    16  test_api-27bc62e5a45d899d           0x0000000104aa3b64 v8::internal::Serializer::ObjectSerializer::VisitPointers(v8::internal::HeapObject, v8::internal::CompressedMaybeObjectSlot, v8::internal::CompressedMaybeObjectSlot) + 420
    17  test_api-27bc62e5a45d899d           0x0000000104aa32b9 v8::internal::Serializer::ObjectSerializer::SerializeContent(v8::internal::Map, int) + 233
    18  test_api-27bc62e5a45d899d           0x0000000104aa23eb v8::internal::Serializer::ObjectSerializer::SerializeObject() + 379
    19  test_api-27bc62e5a45d899d           0x0000000104aa30ff v8::internal::Serializer::ObjectSerializer::Serialize() + 607
    20  test_api-27bc62e5a45d899d           0x0000000104a75f02 v8::internal::ContextSerializer::SerializeObject(v8::internal::HeapObject) + 786
    21  test_api-27bc62e5a45d899d           0x0000000104aa3b64 v8::internal::Serializer::ObjectSerializer::VisitPointers(v8::internal::HeapObject, v8::internal::CompressedMaybeObjectSlot, v8::internal::CompressedMaybeObjectSlot) + 420
    22  test_api-27bc62e5a45d899d           0x0000000104aa32b9 v8::internal::Serializer::ObjectSerializer::SerializeContent(v8::internal::Map, int) + 233
    23  test_api-27bc62e5a45d899d           0x0000000104aa23eb v8::internal::Serializer::ObjectSerializer::SerializeObject() + 379
    24  test_api-27bc62e5a45d899d           0x0000000104aa30ff v8::internal::Serializer::ObjectSerializer::Serialize() + 607
    25  test_api-27bc62e5a45d899d           0x0000000104a75f02 v8::internal::ContextSerializer::SerializeObject(v8::internal::HeapObject) + 786
    26  test_api-27bc62e5a45d899d           0x0000000104aa3b64 v8::internal::Serializer::ObjectSerializer::VisitPointers(v8::internal::HeapObject, v8::internal::CompressedMaybeObjectSlot, v8::internal::CompressedMaybeObjectSlot) + 420
    27  test_api-27bc62e5a45d899d           0x0000000104aa32b9 v8::internal::Serializer::ObjectSerializer::SerializeContent(v8::internal::Map, int) + 233
    28  test_api-27bc62e5a45d899d           0x0000000104aa23eb v8::internal::Serializer::ObjectSerializer::SerializeObject() + 379
    29  test_api-27bc62e5a45d899d           0x0000000104aa30ff v8::internal::Serializer::ObjectSerializer::Serialize() + 607
    30  test_api-27bc62e5a45d899d           0x0000000104a75f02 v8::internal::ContextSerializer::SerializeObject(v8::internal::HeapObject) + 786
    31  test_api-27bc62e5a45d899d           0x0000000104aa3b64 v8::internal::Serializer::ObjectSerializer::VisitPointers(v8::internal::HeapObject, v8::internal::CompressedMaybeObjectSlot, v8::internal::CompressedMaybeObjectSlot) + 420
    32  test_api-27bc62e5a45d899d           0x0000000104aa32b9 v8::internal::Serializer::ObjectSerializer::SerializeContent(v8::internal::Map, int) + 233
    33  test_api-27bc62e5a45d899d           0x0000000104aa23eb v8::internal::Serializer::ObjectSerializer::SerializeObject() + 379
    34  test_api-27bc62e5a45d899d           0x0000000104aa30ff v8::internal::Serializer::ObjectSerializer::Serialize() + 607
    35  test_api-27bc62e5a45d899d           0x0000000104a75f02 v8::internal::ContextSerializer::SerializeObject(v8::internal::HeapObject) + 786
    36  test_api-27bc62e5a45d899d           0x0000000104aa3b64 v8::internal::Serializer::ObjectSerializer::VisitPointers(v8::internal::HeapObject, v8::internal::CompressedMaybeObjectSlot, v8::internal::CompressedMaybeObjectSlot) + 420
    37  test_api-27bc62e5a45d899d           0x0000000104aa32b9 v8::internal::Serializer::ObjectSerializer::SerializeContent(v8::internal::Map, int) + 233
    38  test_api-27bc62e5a45d899d           0x0000000104aa23eb v8::internal::Serializer::ObjectSerializer::SerializeObject() + 379
    39  test_api-27bc62e5a45d899d           0x0000000104aa30ff v8::internal::Serializer::ObjectSerializer::Serialize() + 607
    40  test_api-27bc62e5a45d899d           0x0000000104a75f02 v8::internal::ContextSerializer::SerializeObject(v8::internal::HeapObject) + 786
    41  test_api-27bc62e5a45d899d           0x0000000104aa3b64 v8::internal::Serializer::ObjectSerializer::VisitPointers(v8::internal::HeapObject, v8::internal::CompressedMaybeObjectSlot, v8::internal::CompressedMaybeObjectSlot) + 420
    42  test_api-27bc62e5a45d899d           0x0000000104aa32b9 v8::internal::Serializer::ObjectSerializer::SerializeContent(v8::internal::Map, int) + 233
    43  test_api-27bc62e5a45d899d           0x0000000104aa23eb v8::internal::Serializer::ObjectSerializer::SerializeObject() + 379
    44  test_api-27bc62e5a45d899d           0x0000000104aa30ff v8::internal::Serializer::ObjectSerializer::Serialize() + 607
    45  test_api-27bc62e5a45d899d           0x0000000104a75f02 v8::internal::ContextSerializer::SerializeObject(v8::internal::HeapObject) + 786
    46  test_api-27bc62e5a45d899d           0x0000000104aa3b64 v8::internal::Serializer::ObjectSerializer::VisitPointers(v8::internal::HeapObject, v8::internal::CompressedMaybeObjectSlot, v8::internal::CompressedMaybeObjectSlot) + 420
    47  test_api-27bc62e5a45d899d           0x00000001047fd8bd void v8::internal::CallIterateBody::apply<v8::internal::NativeContext::BodyDescriptor, v8::internal::ObjectVisitor>(v8::internal::Map, v8::internal::HeapObject, int, v8::internal::ObjectVisitor*) + 61
    48  test_api-27bc62e5a45d899d           0x0000000104aa32b9 v8::internal::Serializer::ObjectSerializer::SerializeContent(v8::internal::Map, int) + 233
    49  test_api-27bc62e5a45d899d           0x0000000104aa23eb v8::internal::Serializer::ObjectSerializer::SerializeObject() + 379
    50  test_api-27bc62e5a45d899d           0x0000000104aa30ff v8::internal::Serializer::ObjectSerializer::Serialize() + 607
    51  test_api-27bc62e5a45d899d           0x0000000104a75f02 v8::internal::ContextSerializer::SerializeObject(v8::internal::HeapObject) + 786
    52  test_api-27bc62e5a45d899d           0x0000000104a9f7c9 v8::internal::Serializer::VisitRootPointers(v8::internal::Root, char const*, v8::internal::FullObjectSlot, v8::internal::FullObjectSlot) + 41
    53  test_api-27bc62e5a45d899d           0x0000000104a75658 v8::internal::ContextSerializer::Serialize(v8::internal::Context*, v8::internal::PerThreadAssertScopeDebugOnly<(v8::internal::PerThreadAssertType)0, false> const&) + 776
    54  test_api-27bc62e5a45d899d           0x0000000104aaa16c v8::internal::Snapshot::Create(v8::internal::Isolate*, std::__1::vector<v8::internal::Context, std::__1::allocator<v8::internal::Context> >*, std::__1::vector<v8::SerializeInternalFieldsCallback, std::__1::allocator<v8::SerializeInternalFieldsCallback> > const&, v8::internal::PerThreadAssertScopeDebugOnly<(v8::internal::PerThreadAssertType)0, false> const&, v8::base::Flags<v8::internal::Snapshot::SerializerFlag, int>) + 684
    55  test_api-27bc62e5a45d899d           0x0000000104126709 v8::SnapshotCreator::CreateBlob(v8::SnapshotCreator::FunctionCodeHandling) + 3865
    56  test_api-27bc62e5a45d899d           0x00000001040efd81 rusty_v8::snapshot::SnapshotCreator::create_blob::h65e566249f716651 + 97
    57  test_api-27bc62e5a45d899d           0x0000000104084e01 test_api::module_snapshot::h9efb134deaf6d098 + 2785
    58  test_api-27bc62e5a45d899d           0x00000001040343e1 _ZN8test_api15module_snapshot28_$u7b$$u7b$closure$u7d$$u7d$17hc2c8ec3da31a1a03E + 17
    59  test_api-27bc62e5a45d899d           0x0000000104035e11 core::ops::function::FnOnce::call_once::h27feb7623ecb8d7a + 17
    60  test_api-27bc62e5a45d899d           0x00000001040c8743 _ZN4test8run_test14run_test_inner28_$u7b$$u7b$closure$u7d$$u7d$17hb06286a6fd21965cE + 819
    61  test_api-27bc62e5a45d899d           0x00000001040a296b std::sys_common::backtrace::__rust_begin_short_backtrace::h465bc1b93103a8cd + 43
```