### PR TITLE
Add 'CallbackScope<()>' that doesn't assume an entered Context 

### DIFF
--- a/src/promise.rs
+++ b/src/promise.rs
@@ -200,6 +200,7 @@ pub enum PromiseRejectEvent {
   PromiseResolveAfterResolved,
 }
 
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct PromiseRejectMessage<'msg>([usize; 3], PhantomData<&'msg ()>);
 


### PR DESCRIPTION
Certain callbacks (e.g. `WasmLoadSourceMapCallback`) expect the
embedder to return a local handle (a `Local<String>` in this case), but
do not provide a `Local<Context>` as an argument, nor does it provide
any other argument that we might obtain a context from. This is not
unexpected - WASM execution as such is not tied to a context, and a
`Local<String>` can be created without a context too because it's a
primitive value that has no JavaScript prototype.