### PR TITLE
Allow managing V8 heap limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -43,7 +43,7 @@ name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -53,7 +53,7 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_gn 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "trybuild 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -76,14 +76,14 @@ name = "serde_derive"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.55"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -93,10 +93,10 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -122,9 +122,9 @@ name = "thiserror-impl"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -158,7 +158,7 @@ name = "which"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -195,14 +195,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
-"checksum proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+"checksum libc 0.2.73 (registry+https://github.com/rust-lang/crates.io-index)" = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
+"checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 "checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 "checksum serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
-"checksum serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
-"checksum syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+"checksum serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)" = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+"checksum syn 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 "checksum thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ exclude = [
 
 [dependencies]
 lazy_static = "1.4.0"
-libc = "0.2.71"
+libc = "0.2.73"
 bitflags = "1.2.1"
 
 [build-dependencies]

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -178,6 +178,18 @@ bool v8__Isolate__AddMessageListener(v8::Isolate* isolate,
   return isolate->AddMessageListener(callback);
 }
 
+void v8__Isolate__AddNearHeapLimitCallback(v8::Isolate* isolate,
+                                           v8::NearHeapLimitCallback callback,
+                                           void* data) {
+  isolate.AddNearHeapLimitCallback(callback, data);
+}
+
+void v8__Isolate__RemoveNearHeapLimitCallback(
+    v8::Isolate* isolate, v8::NearHeapLimitCallback callback,
+    size_t heap_limit) {
+  isolate.RemoveNearHeapLimitCallback(callback, heap_limit);
+}
+
 const v8::Value* v8__Isolate__ThrowException(v8::Isolate* isolate,
                                              const v8::Value& exception) {
   return local_to_ptr(isolate->ThrowException(ptr_to_local(&exception)));

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -220,7 +220,7 @@ void v8__ResourceConstraints__ConfigureDefaultsFromHeapSize(
     v8::ResourceConstraints* constraints, size_t initial_heap_size_in_bytes,
     size_t maximum_heap_size_in_bytes) {
   constraints->ConfigureDefaultsFromHeapSize(initial_heap_size_in_bytes,
-                                             maximum_heap_size_in_bytes)
+                                             maximum_heap_size_in_bytes);
 }
 
 void v8__HandleScope__CONSTRUCT(uninit_t<v8::HandleScope>* buf,

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -181,13 +181,13 @@ bool v8__Isolate__AddMessageListener(v8::Isolate* isolate,
 void v8__Isolate__AddNearHeapLimitCallback(v8::Isolate* isolate,
                                            v8::NearHeapLimitCallback callback,
                                            void* data) {
-  isolate.AddNearHeapLimitCallback(callback, data);
+  isolate->AddNearHeapLimitCallback(callback, data);
 }
 
 void v8__Isolate__RemoveNearHeapLimitCallback(
     v8::Isolate* isolate, v8::NearHeapLimitCallback callback,
     size_t heap_limit) {
-  isolate.RemoveNearHeapLimitCallback(callback, heap_limit);
+  isolate->RemoveNearHeapLimitCallback(callback, heap_limit);
 }
 
 const v8::Value* v8__Isolate__ThrowException(v8::Isolate* isolate,
@@ -219,8 +219,8 @@ size_t v8__Isolate__CreateParams__SIZEOF() {
 void v8__ResourceConstraints__ConfigureDefaultsFromHeapSize(
     v8::ResourceConstraints* constraints, size_t initial_heap_size_in_bytes,
     size_t maximum_heap_size_in_bytes) {
-  constraints.ConfigureDefaultsFromHeapSize(initial_heap_size_in_bytes,
-                                            maximum_heap_size_in_bytes)
+  constraints->ConfigureDefaultsFromHeapSize(initial_heap_size_in_bytes,
+                                             maximum_heap_size_in_bytes)
 }
 
 void v8__HandleScope__CONSTRUCT(uninit_t<v8::HandleScope>* buf,

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -204,6 +204,13 @@ size_t v8__Isolate__CreateParams__SIZEOF() {
   return sizeof(v8::Isolate::CreateParams);
 }
 
+void v8__ResourceConstraints__ConfigureDefaultsFromHeapSize(
+    v8::ResourceConstraints* constraints, size_t initial_heap_size_in_bytes,
+    size_t maximum_heap_size_in_bytes) {
+  constraints.ConfigureDefaultsFromHeapSize(initial_heap_size_in_bytes,
+                                            maximum_heap_size_in_bytes)
+}
+
 void v8__HandleScope__CONSTRUCT(uninit_t<v8::HandleScope>* buf,
                                 v8::Isolate* isolate) {
   construct_in_place<v8::HandleScope>(buf, isolate);

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -762,11 +762,10 @@ MaybeBool v8__Object__SetAccessor(const v8::Object& self,
       ptr_to_local(&context), ptr_to_local(&key), getter));
 }
 
-MaybeBool v8__Object__SetAccessorWithSetter(const v8::Object& self,
-                                            const v8::Context& context,
-                                            const v8::Name& key,
-                                            v8::AccessorNameGetterCallback getter,
-                                            v8::AccessorNameSetterCallback setter) {
+MaybeBool v8__Object__SetAccessorWithSetter(
+    const v8::Object& self, const v8::Context& context, const v8::Name& key,
+    v8::AccessorNameGetterCallback getter,
+    v8::AccessorNameSetterCallback setter) {
   return maybe_to_maybe_bool(ptr_to_local(&self)->SetAccessor(
       ptr_to_local(&context), ptr_to_local(&key), getter, setter));
 }

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -364,17 +364,16 @@ impl Isolate {
   /// Add a callback to invoke in case the heap size is close to the heap limit.
   /// If multiple callbacks are added, only the most recently added callback is
   /// invoked.
+  //
+  // this in itself is safe because `data` will be passed to the callback
+  // without being dereferenced
+  #[allow(clippy::not_unsafe_ptr_arg_deref)]
   pub fn add_near_heap_limit_callback(
     &mut self,
     callback: NearHeapLimitCallback,
     data: *mut c_void,
   ) {
-    // this in itself is safe because `data` will be passed to the callback
-    // without being dereferenced
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    unsafe {
-      v8__Isolate__AddNearHeapLimitCallback(self, callback, data)
-    };
+    unsafe { v8__Isolate__AddNearHeapLimitCallback(self, callback, data) };
   }
 
   /// Remove the given callback and restore the heap limit to the

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -69,6 +69,12 @@ pub type HostImportModuleDynamicallyCallback = extern "C" fn(
 pub type InterruptCallback =
   extern "C" fn(isolate: &mut Isolate, data: *mut c_void);
 
+pub type NearHeapLimitCallback = extern "C" fn(
+  data: *mut c_void,
+  current_heap_limit: usize,
+  initial_heap_limit: usize,
+) -> usize;
+
 extern "C" {
   fn v8__Isolate__New(params: *const raw::CreateParams) -> *mut Isolate;
   fn v8__Isolate__Dispose(this: *mut Isolate);
@@ -86,6 +92,16 @@ extern "C" {
     isolate: *mut Isolate,
     callback: MessageCallback,
   ) -> bool;
+  fn v8__Isolate__AddNearHeapLimitCallback(
+    isolate: *mut Isolate,
+    callback: NearHeapLimitCallback,
+    data: *mut c_void,
+  );
+  fn v8__Isolate__RemoveNearHeapLimitCallback(
+    isolate: *mut Isolate,
+    callback: NearHeapLimitCallback,
+    heap_limit: usize,
+  );
   fn v8__Isolate__SetPromiseRejectCallback(
     isolate: *mut Isolate,
     callback: PromiseRejectCallback,
@@ -343,6 +359,40 @@ impl Isolate {
     unsafe {
       v8__Isolate__SetHostImportModuleDynamicallyCallback(self, callback)
     }
+  }
+
+  /// Add a callback to invoke in case the heap size is close to the heap limit.
+  /// If multiple callbacks are added, only the most recently added callback is
+  /// invoked.
+  ///
+  /// # Safety
+  ///
+  /// Don't pass a null-pointer for the callback!
+  /// Make sure the callback only casts `data` to the type the `data` argument
+  /// here.
+  pub unsafe fn add_near_heap_limit_callback(
+    &mut self,
+    callback: NearHeapLimitCallback,
+    data: *mut c_void,
+  ) {
+    v8__Isolate__AddNearHeapLimitCallback(self, callback, data)
+  }
+
+  /// Remove the given callback and restore the heap limit to the
+  /// given limit. If the given limit is zero, then it is ignored.
+  /// If the current heap size is greater than the given limit,
+  /// then the heap limit is restored to the minimal limit that
+  /// is possible for the current heap size.
+  ///
+  /// # Safety
+  ///
+  /// Don't pass a null-pointer for the callback!
+  pub unsafe fn remove_near_heap_limit_callback(
+    &mut self,
+    callback: NearHeapLimitCallback,
+    heap_limit: usize,
+  ) {
+    v8__Isolate__RemoveNearHeapLimitCallback(self, callback, heap_limit)
   }
 
   /// Runs the default MicrotaskQueue until it gets empty.

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -364,10 +364,7 @@ impl Isolate {
   /// Add a callback to invoke in case the heap size is close to the heap limit.
   /// If multiple callbacks are added, only the most recently added callback is
   /// invoked.
-  //
-  // this in itself is safe because `data` will be passed to the callback
-  // without being dereferenced
-  #[allow(clippy::not_unsafe_ptr_arg_deref)]
+  #[allow(clippy::not_unsafe_ptr_arg_deref)] // False positive.
   pub fn add_near_heap_limit_callback(
     &mut self,
     callback: NearHeapLimitCallback,
@@ -376,11 +373,10 @@ impl Isolate {
     unsafe { v8__Isolate__AddNearHeapLimitCallback(self, callback, data) };
   }
 
-  /// Remove the given callback and restore the heap limit to the
-  /// given limit. If the given limit is zero, then it is ignored.
-  /// If the current heap size is greater than the given limit,
-  /// then the heap limit is restored to the minimal limit that
-  /// is possible for the current heap size.
+  /// Remove the given callback and restore the heap limit to the given limit.
+  /// If the given limit is zero, then it is ignored. If the current heap size
+  /// is greater than the given limit, then the heap limit is restored to the
+  /// minimal limit that is possible for the current heap size.
   pub fn remove_near_heap_limit_callback(
     &mut self,
     callback: NearHeapLimitCallback,

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -364,18 +364,12 @@ impl Isolate {
   /// Add a callback to invoke in case the heap size is close to the heap limit.
   /// If multiple callbacks are added, only the most recently added callback is
   /// invoked.
-  ///
-  /// # Safety
-  ///
-  /// Don't pass a null-pointer for the callback!
-  /// Make sure the callback only casts `data` to the type the `data` argument
-  /// here.
-  pub unsafe fn add_near_heap_limit_callback(
+  pub fn add_near_heap_limit_callback(
     &mut self,
     callback: NearHeapLimitCallback,
     data: *mut c_void,
   ) {
-    v8__Isolate__AddNearHeapLimitCallback(self, callback, data)
+    unsafe { v8__Isolate__AddNearHeapLimitCallback(self, callback, data) };
   }
 
   /// Remove the given callback and restore the heap limit to the
@@ -383,16 +377,14 @@ impl Isolate {
   /// If the current heap size is greater than the given limit,
   /// then the heap limit is restored to the minimal limit that
   /// is possible for the current heap size.
-  ///
-  /// # Safety
-  ///
-  /// Don't pass a null-pointer for the callback!
-  pub unsafe fn remove_near_heap_limit_callback(
+  pub fn remove_near_heap_limit_callback(
     &mut self,
     callback: NearHeapLimitCallback,
     heap_limit: usize,
   ) {
-    v8__Isolate__RemoveNearHeapLimitCallback(self, callback, heap_limit)
+    unsafe {
+      v8__Isolate__RemoveNearHeapLimitCallback(self, callback, heap_limit)
+    };
   }
 
   /// Runs the default MicrotaskQueue until it gets empty.

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -369,7 +369,12 @@ impl Isolate {
     callback: NearHeapLimitCallback,
     data: *mut c_void,
   ) {
-    unsafe { v8__Isolate__AddNearHeapLimitCallback(self, callback, data) };
+    // this in itself is safe because `data` will be passed to the callback
+    // without being dereferenced
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    unsafe {
+      v8__Isolate__AddNearHeapLimitCallback(self, callback, data)
+    };
   }
 
   /// Remove the given callback and restore the heap limit to the

--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -114,6 +114,14 @@ impl CreateParams {
     self
   }
 
+  pub fn heap_limits(mut self, min: usize, max: usize) -> Self {
+    self
+      .raw
+      .constraints
+      .configure_defaults_from_heap_size(min, max);
+    self
+  }
+
   fn set_fallback_defaults(mut self) -> Self {
     if self.raw.array_buffer_allocator_shared.is_null() {
       self = self.array_buffer_allocator(array_buffer::new_default_allocator());

--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -201,4 +201,28 @@ pub(crate) mod raw {
     initial_young_generation_size_: usize,
     stack_limit_: *mut u32,
   }
+
+  extern "C" {
+    fn v8__ResourceConstraints__ConfigureDefaultsFromHeapSize(
+      constraints: *mut ResourceConstraints,
+      initial_heap_size_in_bytes: usize,
+      maximum_heap_size_in_bytes: usize,
+    );
+  }
+
+  impl ResourceConstraints {
+    pub fn configure_defaults_from_heap_size(
+      &mut self,
+      initial_heap_size_in_bytes: usize,
+      maximum_heap_size_in_bytes: usize,
+    ) {
+      unsafe {
+        v8__ResourceConstraints__ConfigureDefaultsFromHeapSize(
+          self,
+          initial_heap_size_in_bytes,
+          maximum_heap_size_in_bytes,
+        )
+      };
+    }
+  }
 }

--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -115,10 +115,17 @@ impl CreateParams {
   }
 
   /// Configures the constraints with reasonable default values based on the
-  /// provided heap size limit.
+  /// provided lower and upper bounds.
+  ///
+  /// By default V8 starts with a small heap and dynamically grows it to match
+  /// the set of live objects. This may lead to ineffective garbage collections
+  /// at startup if the live set is large. Setting the initial heap size avoids
+  /// such garbage collections. Note that this does not affect young generation
+  /// garbage collections.
   ///
   /// When the heap size approaches `max`, V8 will perform series of
-  /// garbage collections and invoke the *NearHeapLimitCallback*.
+  /// garbage collections and invoke the
+  /// [NearHeapLimitCallback](struct.Isolate.html#method.add_near_heap_limit_callback).
   /// If the garbage collections do not help and the callback does not
   /// increase the limit, then V8 will crash with V8::FatalProcessOutOfMemory.
   ///
@@ -126,13 +133,13 @@ impl CreateParams {
   ///
   /// # Arguments
   ///
-  /// * `min` - Lower bound for when to do garbage collections
-  /// * `max` - The hard limit for the heap size.
-  pub fn heap_limits(mut self, min: usize, max: usize) -> Self {
+  /// * `initial` - The initial heap size or zero in bytes
+  /// * `max` - The hard limit for the heap size in bytes
+  pub fn heap_limits(mut self, initial: usize, max: usize) -> Self {
     self
       .raw
       .constraints
-      .configure_defaults_from_heap_size(min, max);
+      .configure_defaults_from_heap_size(initial, max);
     self
   }
 

--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -114,6 +114,20 @@ impl CreateParams {
     self
   }
 
+  /// Configures the constraints with reasonable default values based on the
+  /// provided heap size limit.
+  ///
+  /// When the heap size approaches `max`, V8 will perform series of
+  /// garbage collections and invoke the *NearHeapLimitCallback*.
+  /// If the garbage collections do not help and the callback does not
+  /// increase the limit, then V8 will crash with V8::FatalProcessOutOfMemory.
+  ///
+  /// The heap size includes both the young and the old generation.
+  ///
+  /// # Arguments
+  ///
+  /// * `min` - Lower bound for when to do garbage collections
+  /// * `max` - The hard limit for the heap size.
   pub fn heap_limits(mut self, min: usize, max: usize) -> Self {
     self
       .raw

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub use isolate::HostInitializeImportMetaObjectCallback;
 pub use isolate::Isolate;
 pub use isolate::IsolateHandle;
 pub use isolate::MessageCallback;
+pub use isolate::NearHeapLimitCallback;
 pub use isolate::OwnedIsolate;
 pub use isolate::PromiseRejectCallback;
 pub use isolate_create_params::CreateParams;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -9,8 +9,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use rusty_v8 as v8;
-// TODO(piscisaureus): Ideally there would be no need to import this trait.
 use std::ffi::c_void;
+// TODO(piscisaureus): Ideally there would be no need to import this trait.
 use v8::MapFnTo;
 
 lazy_static! {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3351,7 +3351,6 @@ fn heap_limits() {
     for i in 0..1000000 {
       assert!(v8::String::new(scope, "HelloWorld").is_some());
       if test_state.near_limit_callback_called {
-        eprintln!("reached at: {}", i);
         break;
       }
     }


### PR DESCRIPTION
*Applies to https://github.com/denoland/deno/issues/6916*

V8 allows setting the `max_old_generation_size` and `max_young_generation_size` create parameters through a handy helper: https://chromium.googlesource.com/v8/v8/+/e423f0040333dd3ab410b3c6cab5b71a4f75fa6a/include/v8.h#6409

This PR also exposes the methods to register a callback when the limit is reached, so a crash of V8 can be avoided.