### PR TITLE
Allow creating snapshot based on other snapshot

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1420,8 +1420,10 @@ bool v8__Proxy__IsRevoked(const v8::Proxy& self) {
 void v8__Proxy__Revoke(const v8::Proxy& self) { ptr_to_local(&self)->Revoke(); }
 
 void v8__SnapshotCreator__CONSTRUCT(uninit_t<v8::SnapshotCreator>* buf,
-                                    const intptr_t* external_references) {
-  construct_in_place<v8::SnapshotCreator>(buf, external_references);
+                                    const intptr_t* external_references,
+                                    v8::StartupData* startup_data) {
+  construct_in_place<v8::SnapshotCreator>(buf, external_references,
+                                          startup_data);
 }
 
 void v8__SnapshotCreator__DESTRUCT(v8::SnapshotCreator* self) {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -86,9 +86,9 @@ impl SnapshotCreator {
   ) -> Self {
     let mut snapshot_creator: MaybeUninit<Self> = MaybeUninit::uninit();
     let external_references_ptr =
-      external_references.map_or_else(|| std::ptr::null(), |er| er.as_ptr());
+      external_references.map_or_else(std::ptr::null, |er| er.as_ptr());
     let startup_data_ptr = startup_data
-      .map_or_else(|| std::ptr::null_mut(), |sd| Box::into_raw(Box::new(sd)));
+      .map_or_else(std::ptr::null_mut, |sd| Box::into_raw(Box::new(sd)));
     unsafe {
       v8__SnapshotCreator__CONSTRUCT(
         &mut snapshot_creator,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -82,13 +82,13 @@ impl SnapshotCreator {
   /// The isolate is created from scratch.
   pub fn new(
     external_references: Option<&'static ExternalReferences>,
-    startup_data: Option<StartupData>,
+    startup_data: Option<&mut StartupData>,
   ) -> Self {
     let mut snapshot_creator: MaybeUninit<Self> = MaybeUninit::uninit();
     let external_references_ptr =
       external_references.map_or_else(std::ptr::null, |er| er.as_ptr());
-    let startup_data_ptr = startup_data
-      .map_or_else(std::ptr::null_mut, |sd| Box::into_raw(Box::new(sd)));
+    let startup_data_ptr =
+      startup_data.map_or_else(std::ptr::null_mut, |sd| sd as *mut StartupData);
     unsafe {
       v8__SnapshotCreator__CONSTRUCT(
         &mut snapshot_creator,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3320,7 +3320,7 @@ fn snapshot_from_snapshot() {
   let _setup_guard = setup();
 
   // Create a snapshot for loading later
-  let init_data = {
+  let mut init_data = {
     let mut snapshot_creator = v8::SnapshotCreator::new(None, None);
     // TODO(ry) this shouldn't be necessary. workaround unfinished business in
     // the scope type system.
@@ -3349,7 +3349,8 @@ fn snapshot_from_snapshot() {
   // Make another snapshot using the previous snapshot as a base
   // Increase 'a' by 4
   let startup_data = {
-    let mut snapshot_creator = v8::SnapshotCreator::new(None, Some(init_data));
+    let mut snapshot_creator =
+      v8::SnapshotCreator::new(None, Some(&mut init_data));
     // TODO(ry) this shouldn't be necessary. workaround unfinished business in
     // the scope type system.
     let mut isolate = unsafe { snapshot_creator.get_owned_isolate() };


### PR DESCRIPTION
Introduces the ability to initialize the isolate that the `SnapshotCreator` creates with an optional snapshot blob, just as it's possible on a regular isolate.

This is a small breaking change. If you prefer it to be not breaking, I can introduce a second constructor instead.