### PR TITLE
Downgrade V8 to 8.6.334

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "rusty_v8"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_gn 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_v8"
-version = "0.8.0"
+version = "0.8.1"
 description = "Rust bindings to V8"
 readme = "README.md"
 authors = ["the Deno authors"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rusty V8 Binding
 
-V8 Version: 8.6.334, 2020-08-08
+V8 Version: 8.6.334
 
 [![ci](https://github.com/denoland/rusty_v8/workflows/ci/badge.svg?branch=master)](https://github.com/denoland/rusty_v8/actions)
 [![crates](https://img.shields.io/crates/v/rusty_v8.svg)](https://crates.io/crates/rusty_v8)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rusty V8 Binding
 
-V8 Version: 8.6.337, 2020-08-05
+V8 Version: 8.6.334, 2020-08-08
 
 [![ci](https://github.com/denoland/rusty_v8/workflows/ci/badge.svg?branch=master)](https://github.com/denoland/rusty_v8/actions)
 [![crates](https://img.shields.io/crates/v/rusty_v8.svg)](https://crates.io/crates/rusty_v8)


### PR DESCRIPTION
to exclude https://chromium-review.googlesource.com/c/v8/v8/+/2280100 (0c837e8342dff02294d34d1866c9fcdbd89ffc9f)

experiencing hangs due to this CL in Deno when trying to upgrade to rusty_v8 0.8.0
https://github.com/denoland/deno/pull/6980