### PR TITLE
Allow configuring ModifyCodeGenerationFromStrings callback

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -173,6 +173,13 @@ void v8__Isolate__SetHostImportModuleDynamicallyCallback(
       HostImportModuleDynamicallyCallback);
 }
 
+void v8__Isolate__SetModifyCodeGenerationFromStringsCallback(
+  v8::Isolate* isolate,
+  v8::ModifyCodeGenerationFromStringsCallback callback
+) {
+  isolate->SetModifyCodeGenerationFromStringsCallback(callback);
+}
+
 bool v8__Isolate__AddMessageListener(v8::Isolate* isolate,
                                      v8::MessageCallback callback) {
   return isolate->AddMessageListener(callback);

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -654,3 +654,25 @@ impl DerefMut for OwnedIsolate {
     unsafe { self.cxx_isolate.as_mut() }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn block_eval() {
+    extern "C" fn block_code_execution(
+      _ctx: Local<Context>,
+      _src: Local<Value>,
+    ) -> ModifyCodeGenerationFromStringsResult<'static> {
+      ModifyCodeGenerationFromStringsResult {
+        codegen_allowed: false,
+        modified_source: None,
+      }
+    }
+
+    let mut isolate = Isolate::new(CreateParams::default());
+    isolate
+      .set_modify_code_generation_from_strings_callback(block_code_execution);
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,8 @@ pub use isolate::HostInitializeImportMetaObjectCallback;
 pub use isolate::Isolate;
 pub use isolate::IsolateHandle;
 pub use isolate::MessageCallback;
+pub use isolate::ModifyCodeGenerationFromStringsCallback;
+pub use isolate::ModifyCodeGenerationFromStringsResult;
 pub use isolate::NearHeapLimitCallback;
 pub use isolate::OwnedIsolate;
 pub use isolate::PromiseRejectCallback;


### PR DESCRIPTION
This allows modifying whether JS is allowed to dynamically execute JS via `eval` or the `Function` constructor. This is useful in sandboxed environments when executing untrusted code.

I hope the way I defined the callback is correct. Please see
- https://v8docs.nodesource.com/node-14.1/d5/dda/classv8_1_1_isolate.html#a01ef69d6fd2d0eb43edf7245a0f31199
- https://v8docs.nodesource.com/node-14.1/d2/dc3/namespacev8.html#a4502d34e1886b964761899c245138d66

for more information on the v8 definition of the types.