### PR TITLE
Add support for LowMemoryNotification

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -119,6 +119,10 @@ void v8__Isolate__Enter(v8::Isolate* isolate) { isolate->Enter(); }
 
 void v8__Isolate__Exit(v8::Isolate* isolate) { isolate->Exit(); }
 
+void v8__Isolate__LowMemoryNotification(v8::Isolate* isolate) {
+  isolate->LowMemoryNotification();
+}
+
 void v8__Isolate__GetHeapStatistics(v8::Isolate* isolate,
                                     v8::HeapStatistics* s) {
   isolate->GetHeapStatistics(s);

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -369,7 +369,7 @@ impl Isolate {
 
   /// Optional notification that the system is running low on memory.
   /// V8 uses these notifications to attempt to free memory.
-  pub fn trigger_low_memory_notification(&mut self) {
+  pub fn low_memory_notification(&mut self) {
     unsafe { v8__Isolate__LowMemoryNotification(self) }
   }
 

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -105,6 +105,7 @@ extern "C" {
   fn v8__Isolate__GetNumberOfDataSlots(this: *const Isolate) -> u32;
   fn v8__Isolate__Enter(this: *mut Isolate);
   fn v8__Isolate__Exit(this: *mut Isolate);
+  fn v8__Isolate__LowMemoryNotification(isolate: *mut Isolate);
   fn v8__Isolate__GetHeapStatistics(this: *mut Isolate, s: *mut HeapStatistics);
   fn v8__Isolate__SetCaptureStackTraceForUncaughtExceptions(
     this: *mut Isolate,
@@ -364,6 +365,12 @@ impl Isolate {
   /// Requires: self == Isolate::GetCurrent().
   pub(crate) fn exit_isolate(&mut self) {
     unsafe { v8__Isolate__Exit(self) }
+  }
+
+  /// Optional notification that the system is running low on memory.
+  /// V8 uses these notifications to attempt to free memory.
+  pub fn low_memory_notification(&mut self) {
+    unsafe { v8__Isolate__LowMemoryNotification(self) }
   }
 
   /// Get statistics about the heap memory usage.

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -369,7 +369,7 @@ impl Isolate {
 
   /// Optional notification that the system is running low on memory.
   /// V8 uses these notifications to attempt to free memory.
-  pub fn low_memory_notification(&mut self) {
+  pub fn trigger_low_memory_notification(&mut self) {
     unsafe { v8__Isolate__LowMemoryNotification(self) }
   }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3417,7 +3417,7 @@ fn heap_statistics() {
 #[test]
 fn low_memory_notification() {
   let mut isolate = v8::Isolate::new(Default::default());
-  isolate.trigger_low_memory_notification();
+  isolate.low_memory_notification();
 }
 
 fn synthetic_evaluation_steps<'a>(

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3417,7 +3417,7 @@ fn heap_statistics() {
 #[test]
 fn low_memory_notification() {
   let mut isolate = v8::Isolate::new(Default::default());
-  isolate.low_memory_notification();
+  isolate.trigger_low_memory_notification();
 }
 
 fn synthetic_evaluation_steps<'a>(

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3414,6 +3414,12 @@ fn heap_statistics() {
   assert_ne!(s.number_of_native_contexts(), 0);
 }
 
+#[test]
+fn low_memory_notification() {
+  let mut isolate = v8::Isolate::new(Default::default());
+  isolate.low_memory_notification();
+}
+
 fn synthetic_evaluation_steps<'a>(
   context: v8::Local<'a, v8::Context>,
   module: v8::Local<v8::Module>,


### PR DESCRIPTION
This PR adds the bindings for LowMemoryNotification which has been left out of #440.