### PR TITLE
add some binding, and add some new feature to external

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1274,6 +1274,11 @@ const v8::Object* v8__FunctionCallbackInfo__This(
   return local_to_ptr(self.This());
 }
 
+const v8::Object* v8__FunctionCallbackInfo__Holder(
+    const v8::FunctionCallbackInfo<v8::Value>& self) {
+  return local_to_ptr(self.Holder());
+}
+
 int v8__FunctionCallbackInfo__Length(
     const v8::FunctionCallbackInfo<v8::Value>& self) {
   return self.Length();
@@ -1578,6 +1583,11 @@ v8::Value* v8__PropertyCallbackInfo__GetReturnValue(
 const v8::Object* v8__PropertyCallbackInfo__This(
     const v8::PropertyCallbackInfo<v8::Value>& self) {
   return local_to_ptr(self.This());
+}
+
+const v8::Object* v8__PropertyCallbackInfo__Holder(
+    const v8::PropertyCallbackInfo<v8::Value>& self) {
+  return local_to_ptr(self.Holder());
 }
 
 const v8::Proxy* v8__Proxy__New(const v8::Context& context,

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -547,6 +547,11 @@ const v8::Boolean* v8__Value__ToBoolean(const v8::Value& self,
   return local_to_ptr(self.ToBoolean(isolate));
 }
 
+const v8::External* v8__Value__ToExternal(v8::Value& self,
+                                        v8::Isolate* isolate) {
+  return v8::External::Cast(&self);
+}
+
 void v8__Value__NumberValue(const v8::Value& self, const v8::Context& context,
                             v8::Maybe<double>* out) {
   *out = self.NumberValue(ptr_to_local(&context));

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1255,6 +1255,10 @@ void v8__FunctionTemplate__SetClassName(const v8::FunctionTemplate& self,
   ptr_to_local(&self)->SetClassName(ptr_to_local(&name));
 }
 
+const v8::ObjectTemplate* v8__FunctionTemplate__InstanceTemplate(const v8::FunctionTemplate& self) {
+  return local_to_ptr(ptr_to_local(&self)->InstanceTemplate());
+}
+
 v8::Isolate* v8__FunctionCallbackInfo__GetIsolate(
     const v8::FunctionCallbackInfo<v8::Value>& self) {
   return self.GetIsolate();

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1255,6 +1255,10 @@ void v8__FunctionTemplate__SetClassName(const v8::FunctionTemplate& self,
   ptr_to_local(&self)->SetClassName(ptr_to_local(&name));
 }
 
+const v8::ObjectTemplate* v8__FunctionTemplate__PrototypeTemplate(const v8::FunctionTemplate& self) {
+  return local_to_ptr(ptr_to_local(&self)->PrototypeTemplate());
+}
+
 const v8::ObjectTemplate* v8__FunctionTemplate__InstanceTemplate(const v8::FunctionTemplate& self) {
   return local_to_ptr(ptr_to_local(&self)->InstanceTemplate());
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -825,6 +825,10 @@ const v8::Value* v8__Object__GetPrototype(const v8::Object& self) {
   return local_to_ptr(ptr_to_local(&self)->GetPrototype());
 }
 
+const v8::Value* v8__Object__GetInternalField(const v8::Object& self, uint32_t index) {
+  return local_to_ptr(ptr_to_local(&self)->GetInternalField(index));
+}
+
 MaybeBool v8__Object__Set(const v8::Object& self, const v8::Context& context,
                           const v8::Value& key, const v8::Value& value) {
   return maybe_to_maybe_bool(ptr_to_local(&self)->Set(
@@ -843,6 +847,12 @@ MaybeBool v8__Object__SetPrototype(const v8::Object& self,
                                    const v8::Value& prototype) {
   return maybe_to_maybe_bool(ptr_to_local(&self)->SetPrototype(
       ptr_to_local(&context), ptr_to_local(&prototype)));
+}
+
+void v8__Object__SetInternalField(const v8::Object& self,
+                                   uint32_t index,
+                                   const v8::Value& value) {
+  return ptr_to_local(&self)->SetInternalField(index, ptr_to_local(&value));
 }
 
 MaybeBool v8__Object__CreateDataProperty(const v8::Object& self,

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -830,10 +830,6 @@ const v8::Value* v8__Object__GetPrototype(const v8::Object& self) {
   return local_to_ptr(ptr_to_local(&self)->GetPrototype());
 }
 
-const v8::Value* v8__Object__GetInternalField(const v8::Object& self, uint32_t index) {
-  return local_to_ptr(ptr_to_local(&self)->GetInternalField(index));
-}
-
 MaybeBool v8__Object__Set(const v8::Object& self, const v8::Context& context,
                           const v8::Value& key, const v8::Value& value) {
   return maybe_to_maybe_bool(ptr_to_local(&self)->Set(
@@ -852,12 +848,6 @@ MaybeBool v8__Object__SetPrototype(const v8::Object& self,
                                    const v8::Value& prototype) {
   return maybe_to_maybe_bool(ptr_to_local(&self)->SetPrototype(
       ptr_to_local(&context), ptr_to_local(&prototype)));
-}
-
-void v8__Object__SetInternalField(const v8::Object& self,
-                                   uint32_t index,
-                                   const v8::Value& value) {
-  return ptr_to_local(&self)->SetInternalField(index, ptr_to_local(&value));
 }
 
 MaybeBool v8__Object__CreateDataProperty(const v8::Object& self,

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -548,7 +548,7 @@ const v8::Boolean* v8__Value__ToBoolean(const v8::Value& self,
 }
 
 const v8::External* v8__Value__ToExternal(v8::Value& self,
-                                        v8::Isolate* isolate) {
+                                          v8::Isolate* isolate) {
   return v8::External::Cast(&self);
 }
 
@@ -1260,7 +1260,8 @@ void v8__FunctionTemplate__SetClassName(const v8::FunctionTemplate& self,
   ptr_to_local(&self)->SetClassName(ptr_to_local(&name));
 }
 
-const v8::ObjectTemplate* v8__FunctionTemplate__PrototypeTemplate(const v8::FunctionTemplate& self) {
+const v8::ObjectTemplate* v8__FunctionTemplate__PrototypeTemplate(
+      const v8::FunctionTemplate& self) {
   return local_to_ptr(ptr_to_local(&self)->PrototypeTemplate());
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -143,7 +143,14 @@ impl<'s> FunctionCallbackArguments<'s> {
     }
   }
 
-  /// Returns the instance of function template.
+  /// If the callback was created without a Signature, this is the same
+  /// value as This(). If there is a signature, and the signature didn't match
+  /// This() but one of its hidden prototypes, this will be the respective
+  /// hidden prototype.
+  ///
+  /// Note that this is not the prototype of This() on which the accessor
+  /// referencing this callback was found (which in V8 internally is often
+  /// referred to as holder [sic]).
   pub fn holder(&self) -> Local<'s, Object> {
     unsafe {
       Local::from_raw(v8__FunctionCallbackInfo__Holder(self.info)).unwrap()
@@ -231,7 +238,14 @@ impl<'s> PropertyCallbackArguments<'s> {
       Local::from_raw(v8__PropertyCallbackInfo__This(self.info)).unwrap()
     }
   }
-  /// Returns the instance of function template.
+
+  /// Returns the object in the prototype chain of the receiver that has the
+  /// interceptor. Suppose you have `x` and its prototype is `y`, and `y`
+  /// has an interceptor. Then `info.This()` is `x` and `info.Holder()` is `y`.
+  /// The Holder() could be a hidden object (the global object, rather
+  /// than the global proxy).
+  ///  
+  /// For security reasons, do not pass the object back into the runtime.
   pub fn holder(&self) -> Local<'s, Object> {
     unsafe {
       Local::from_raw(v8__PropertyCallbackInfo__Holder(self.info)).unwrap()

--- a/src/function.rs
+++ b/src/function.rs
@@ -39,6 +39,9 @@ extern "C" {
   fn v8__FunctionCallbackInfo__This(
     this: *const FunctionCallbackInfo,
   ) -> *const Object;
+  fn v8__FunctionCallbackInfo__Holder(
+    this: *const FunctionCallbackInfo,
+  ) -> *const Object;
   fn v8__FunctionCallbackInfo__Length(this: *const FunctionCallbackInfo)
     -> int;
   fn v8__FunctionCallbackInfo__GetArgument(
@@ -53,6 +56,9 @@ extern "C" {
     this: *const PropertyCallbackInfo,
   ) -> *mut Value;
   fn v8__PropertyCallbackInfo__This(
+    this: *const PropertyCallbackInfo,
+  ) -> *const Object;
+  fn v8__PropertyCallbackInfo__Holder(
     this: *const PropertyCallbackInfo,
   ) -> *const Object;
 
@@ -137,6 +143,13 @@ impl<'s> FunctionCallbackArguments<'s> {
     }
   }
 
+  /// Returns the instance of function template.
+  pub fn holder(&self) -> Local<'s, Object> {
+    unsafe {
+      Local::from_raw(v8__FunctionCallbackInfo__Holder(self.info)).unwrap()
+    }
+  }
+
   /// Returns the data argument specified when creating the callback.
   pub fn data(&self) -> Option<Local<'s, Value>> {
     unsafe { Local::from_raw(v8__FunctionCallbackInfo__Data(self.info)) }
@@ -216,6 +229,12 @@ impl<'s> PropertyCallbackArguments<'s> {
   pub fn this(&self) -> Local<'s, Object> {
     unsafe {
       Local::from_raw(v8__PropertyCallbackInfo__This(self.info)).unwrap()
+    }
+  }
+  /// Returns the instance of function template.
+  pub fn holder(&self) -> Local<'s, Object> {
+    unsafe {
+      Local::from_raw(v8__PropertyCallbackInfo__Holder(self.info)).unwrap()
     }
   }
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -48,6 +48,7 @@ extern "C" {
     index: u32,
   ) -> *const Value;
   fn v8__Object__GetPrototype(this: *const Object) -> *const Value;
+  fn v8__Object__GetInternalField(this: *const Object, index: u32) -> *const Value;
   fn v8__Object__Set(
     this: *const Object,
     context: *const Context,
@@ -65,6 +66,11 @@ extern "C" {
     context: *const Context,
     prototype: *const Value,
   ) -> MaybeBool;
+  fn v8__Object__SetInternalField(
+    this: *const Object,
+    index: u32,
+    value: *const Value,
+  );
   fn v8__Object__CreateDataProperty(
     this: *const Object,
     context: *const Context,
@@ -206,6 +212,17 @@ impl Object {
     .into()
   }
 
+  /// Set internal field value. Should be used with ObjectTemplate::SetInternalFieldCount.
+  pub fn set_internal_field(
+    &self,
+    index: u32,
+    value: Local<Value>,
+  ) {
+    unsafe {
+      v8__Object__SetInternalField(self, index, &*value)
+    }
+  }
+
   /// Implements CreateDataProperty (ECMA-262, 7.3.4).
   ///
   /// Defines a configurable, writable, enumerable property with the given value
@@ -285,6 +302,14 @@ impl Object {
     scope: &mut HandleScope<'s>,
   ) -> Option<Local<'s, Value>> {
     unsafe { scope.cast_local(|_| v8__Object__GetPrototype(self)) }
+  }
+
+  pub fn get_internal_field<'s>(
+    &self,
+    scope: &mut HandleScope<'s>,
+    index: u32
+  ) -> Option<Local<'s, Value>> {
+    unsafe { scope.cast_local(|_| v8__Object__GetInternalField(self, index)) }
   }
 
   /// Note: SideEffectType affects the getter only, not the setter.

--- a/src/object.rs
+++ b/src/object.rs
@@ -48,7 +48,6 @@ extern "C" {
     index: u32,
   ) -> *const Value;
   fn v8__Object__GetPrototype(this: *const Object) -> *const Value;
-  fn v8__Object__GetInternalField(this: *const Object, index: u32) -> *const Value;
   fn v8__Object__Set(
     this: *const Object,
     context: *const Context,
@@ -66,11 +65,6 @@ extern "C" {
     context: *const Context,
     prototype: *const Value,
   ) -> MaybeBool;
-  fn v8__Object__SetInternalField(
-    this: *const Object,
-    index: u32,
-    value: *const Value,
-  );
   fn v8__Object__CreateDataProperty(
     this: *const Object,
     context: *const Context,
@@ -212,17 +206,6 @@ impl Object {
     .into()
   }
 
-  /// Set internal field value. Should be used with ObjectTemplate::SetInternalFieldCount.
-  pub fn set_internal_field(
-    &self,
-    index: u32,
-    value: Local<Value>,
-  ) {
-    unsafe {
-      v8__Object__SetInternalField(self, index, &*value)
-    }
-  }
-
   /// Implements CreateDataProperty (ECMA-262, 7.3.4).
   ///
   /// Defines a configurable, writable, enumerable property with the given value
@@ -302,14 +285,6 @@ impl Object {
     scope: &mut HandleScope<'s>,
   ) -> Option<Local<'s, Value>> {
     unsafe { scope.cast_local(|_| v8__Object__GetPrototype(self)) }
-  }
-
-  pub fn get_internal_field<'s>(
-    &self,
-    scope: &mut HandleScope<'s>,
-    index: u32
-  ) -> Option<Local<'s, Value>> {
-    unsafe { scope.cast_local(|_| v8__Object__GetInternalField(self, index)) }
   }
 
   /// Note: SideEffectType affects the getter only, not the setter.

--- a/src/template.rs
+++ b/src/template.rs
@@ -37,6 +37,9 @@ extern "C" {
     this: *const FunctionTemplate,
     name: *const String,
   );
+  fn v8__FunctionTemplate__PrototypeTemplate(
+    this: *const FunctionTemplate
+  ) -> *const ObjectTemplate;
   fn v8__FunctionTemplate__InstanceTemplate(
     this: *const FunctionTemplate
   ) -> *const ObjectTemplate;
@@ -106,6 +109,18 @@ impl FunctionTemplate {
   /// FunctionTemplate as its constructor.
   pub fn set_class_name(&self, name: Local<String>) {
     unsafe { v8__FunctionTemplate__SetClassName(self, &*name) };
+  }
+
+  pub fn prototype_template<'s>(
+    &self,
+    scope: &mut HandleScope<'s>,
+  ) -> Local<'s, ObjectTemplate> {
+    unsafe {
+      scope.cast_local(|_| {
+        v8__FunctionTemplate__PrototypeTemplate(self)
+      })
+    }
+    .unwrap()
   }
 
   pub fn instance_template<'s>(

--- a/src/template.rs
+++ b/src/template.rs
@@ -111,6 +111,8 @@ impl FunctionTemplate {
     unsafe { v8__FunctionTemplate__SetClassName(self, &*name) };
   }
 
+  /// A PrototypeTemplate is the template used to create the prototype object
+  /// of the function created by this template.
   pub fn prototype_template<'s>(
     &self,
     scope: &mut HandleScope<'s>,
@@ -121,6 +123,7 @@ impl FunctionTemplate {
     .unwrap()
   }
 
+  /// Get the InstanceTemplate.
   pub fn instance_template<'s>(
     &self,
     scope: &mut HandleScope<'s>,

--- a/src/template.rs
+++ b/src/template.rs
@@ -37,6 +37,9 @@ extern "C" {
     this: *const FunctionTemplate,
     name: *const String,
   );
+  fn v8__FunctionTemplate__InstanceTemplate(
+    this: *const FunctionTemplate
+  ) -> *const ObjectTemplate;
 
   fn v8__ObjectTemplate__New(
     isolate: *mut Isolate,
@@ -103,6 +106,18 @@ impl FunctionTemplate {
   /// FunctionTemplate as its constructor.
   pub fn set_class_name(&self, name: Local<String>) {
     unsafe { v8__FunctionTemplate__SetClassName(self, &*name) };
+  }
+
+  pub fn instance_template<'s>(
+    &self,
+    scope: &mut HandleScope<'s>,
+  ) -> Local<'s, ObjectTemplate> {
+    unsafe {
+      scope.cast_local(|_| {
+        v8__FunctionTemplate__InstanceTemplate(self)
+      })
+    }
+    .unwrap()
   }
 }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -38,10 +38,10 @@ extern "C" {
     name: *const String,
   );
   fn v8__FunctionTemplate__PrototypeTemplate(
-    this: *const FunctionTemplate
+    this: *const FunctionTemplate,
   ) -> *const ObjectTemplate;
   fn v8__FunctionTemplate__InstanceTemplate(
-    this: *const FunctionTemplate
+    this: *const FunctionTemplate,
   ) -> *const ObjectTemplate;
 
   fn v8__ObjectTemplate__New(
@@ -116,9 +116,7 @@ impl FunctionTemplate {
     scope: &mut HandleScope<'s>,
   ) -> Local<'s, ObjectTemplate> {
     unsafe {
-      scope.cast_local(|_| {
-        v8__FunctionTemplate__PrototypeTemplate(self)
-      })
+      scope.cast_local(|_| v8__FunctionTemplate__PrototypeTemplate(self))
     }
     .unwrap()
   }
@@ -128,9 +126,7 @@ impl FunctionTemplate {
     scope: &mut HandleScope<'s>,
   ) -> Local<'s, ObjectTemplate> {
     unsafe {
-      scope.cast_local(|_| {
-        v8__FunctionTemplate__InstanceTemplate(self)
-      })
+      scope.cast_local(|_| v8__FunctionTemplate__InstanceTemplate(self))
     }
     .unwrap()
   }

--- a/src/value.rs
+++ b/src/value.rs
@@ -545,16 +545,6 @@ impl Value {
     .unwrap()
   }
 
-  pub fn to_external<'s>(
-    &self,
-    scope: &mut HandleScope<'s, ()>,
-  ) -> Local<'s, External> {
-    unsafe {
-      scope.cast_local(|sd| v8__Value__ToExternal(self, sd.get_isolate_ptr()))
-    }
-    .unwrap()
-  }
-
   pub fn number_value<'s>(&self, scope: &mut HandleScope<'s>) -> Option<f64> {
     let mut out = Maybe::<f64>::default();
     unsafe {

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,6 +2,7 @@ use crate::support::Maybe;
 use crate::BigInt;
 use crate::Boolean;
 use crate::Context;
+use crate::External;
 use crate::HandleScope;
 use crate::Int32;
 use crate::Integer;
@@ -108,6 +109,10 @@ extern "C" {
     this: *const Value,
     isolate: *mut Isolate,
   ) -> *const Boolean;
+  fn v8__Value__ToExternal(
+    this: *const Value,
+    isolate: *mut Isolate,
+  ) -> *const External;
 
   fn v8__Value__NumberValue(
     this: *const Value,
@@ -536,6 +541,16 @@ impl Value {
   ) -> Local<'s, Boolean> {
     unsafe {
       scope.cast_local(|sd| v8__Value__ToBoolean(self, sd.get_isolate_ptr()))
+    }
+    .unwrap()
+  }
+
+  pub fn to_external<'s>(
+    &self,
+    scope: &mut HandleScope<'s, ()>,
+  ) -> Local<'s, External> {
+    unsafe {
+      scope.cast_local(|sd| v8__Value__ToExternal(self, sd.get_isolate_ptr()))
     }
     .unwrap()
   }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1247,7 +1247,9 @@ fn instance_template_of_function_template() {
     inst_templ.set(inst_func_name.into(), inst_func_templ.into());
     let function = function_templ.get_function(scope).unwrap();
     let name = v8::String::new(scope, "f").unwrap();
-    context.global(scope).set(scope, name.into(), function.into());
+    context
+      .global(scope)
+      .set(scope, name.into(), function.into());
     let actual = eval(scope, "new f().inst_func()").unwrap();
     let expected = v8::Integer::new(scope, 42);
     assert!(expected.strict_equals(actual));
@@ -1269,8 +1271,11 @@ fn prototype_template_of_function_template() {
     proto_templ.set(proto_func_name.into(), proto_func_templ.into());
     let function = function_templ.get_function(scope).unwrap();
     let name = v8::String::new(scope, "f").unwrap();
-    context.global(scope).set(scope, name.into(), function.into());
-    let actual = eval(scope, "new f().proto_func() + f.prototype.proto_func()").unwrap();
+    context
+      .global(scope)
+      .set(scope, name.into(), function.into());
+    let actual =
+      eval(scope, "new f().proto_func() + f.prototype.proto_func()").unwrap();
     let expected = v8::Integer::new(scope, 84);
     assert!(expected.strict_equals(actual));
   }


### PR DESCRIPTION
- Getting instance template object and prototype template object from its function template object
- Getting holder object from FunctionCallbackArguments
- Making external works with std::rc::Rc (which enhance set_internal_field)

All new methods have tested in my machine.

And btw, you may find I did some same thing with what @bnoordhuis has done in the same week 🤣 (about internal fields), so I've remove my implement after merging master.