### PR TITLE
Fix docs.rs detection

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ fn main() {
   let is_trybuild = env::var_os("DENO_TRYBUILD").is_some();
 
   // Don't build V8 if "cargo doc" is being run. This is to support docs.rs.
-  let is_cargo_doc = env::var_os("RUSTDOCFLAGS").is_some();
+  let is_cargo_doc = env::var_os("DOCS_RS").is_some();
 
   // Don't build V8 if the rust language server (RLS) is running.
   let is_rls = env::var_os("CARGO")


### PR DESCRIPTION
Previously docs.rs supplied RUSTDOCFLAGS env var to builds, which we
used to skip building/downloading rusty_v8. docs.rs does not allow
network access.

Reference for DOCS_RS: https://docs.rs/about/builds
Failed build: https://docs.rs/crate/deno_core/0.61.0/builds/299870