### PR TITLE
Make RUSTY_V8_MIRROR understand file:// URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,41 @@ Binaries builds are turned on by default: `cargo build` will initiate a download
 from github to get the static lib. To disable this build using the
 `V8_FROM_SOURCE` environmental variable.
 
-If you prefer another location for downloading binaries,
-use the`RUSTY_V8_MIRROR` environmental variable.
-
 When making changes to rusty_v8 itself, it should be tested by build from
 source. The CI always builds from source.
+
+## The `RUSTY_V8_MIRROR` environment variable
+
+Tells the build script where to get binary builds from. Understands
+`http://` and `https://` URLs, and file paths. The default is
+https://github.com/denoland/rusty_v8/releases/download.
+
+File-based mirrors are good for using cached downloads. First, point
+the environment variable to a suitable location:
+
+    # you might want to add this to your .bashrc
+    $ export RUSTY_V8_MIRROR=$HOME/.cache/rusty_v8
+
+Then populate the cache:
+
+```bash
+#!/bin/bash
+
+# see https://github.com/denoland/rusty_v8/releases
+
+for REL in v0.9.0 v0.10.0; do
+  mkdir -p $RUSTY_V8_MIRROR/$REL
+  for FILE in \
+    librusty_v8_debug_x86_64-unknown-linux-gnu.a \
+    librusty_v8_release_x86_64-unknown-linux-gnu.a \
+  ; do
+    if [ ! -f $RUSTY_V8_MIRROR/$REL/$FILE ]; then
+      wget -O $CACHE_DIR/$REL/$FILE \
+        https://github.com/denoland/rusty_v8/releases/download/$REL/$FILE
+    fi
+  done
+done
+```
 
 ## Build V8 from Source
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 use std::env;
+use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::exit;
@@ -199,6 +200,11 @@ fn static_lib_url() -> (String, String) {
 }
 
 fn download_file(url: String, filename: PathBuf) {
+  if !url.starts_with("http:") && !url.starts_with("https:") {
+    fs::copy(&url, filename).unwrap();
+    return;
+  }
+
   // Try downloading with python first. Python is a V8 build dependency,
   // so this saves us from adding a Rust HTTP client dependency.
   println!("Downloading {}", url);


### PR DESCRIPTION
Having rusty_v8 redownload libv8.a every time you blow away target/ is
a good way to blow through your monthly bandwith allotment quickly, to
say nothing about the slowdown of the build.

Fixes #470