### PR TITLE
Add Global::map()

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -147,6 +147,14 @@ impl<T> Global<T> {
   pub fn get<'a>(&'a self, scope: &mut Isolate) -> &'a T {
     Handle::get(self, scope)
   }
+
+  // Note: only works for strong persistent globals. Needs to change
+  // if and when rusty_v8 grows support for weak persistent globals.
+  pub fn map<U, F: FnOnce(&Local<T>) -> U>(&self, f: F) -> U {
+    let p = self.data.cast().as_ptr();
+    let v = unsafe { Local::from_raw(p) }.unwrap();
+    f(&v)
+  }
 }
 
 impl<T> Clone for Global<T> {

--- a/tests/compile_fail/global_map_lifetime_1.rs
+++ b/tests/compile_fail/global_map_lifetime_1.rs
@@ -1,0 +1,14 @@
+// Copyright 2019-2020 the Deno authors. All rights reserved. MIT license.
+use rusty_v8 as v8;
+
+pub fn main() {
+  let mut isolate = v8::Isolate::new(mock());
+  let scope = &mut v8::HandleScope::new(&mut isolate);
+  let local = v8::Integer::new(scope, 42);
+  let global = v8::Global::new(scope, local);
+  let _ = global.map(|that| that);
+}
+
+fn mock<T>() -> T {
+  unimplemented!()
+}

--- a/tests/compile_fail/global_map_lifetime_1.stderr
+++ b/tests/compile_fail/global_map_lifetime_1.stderr
@@ -1,0 +1,17 @@
+error: lifetime may not live long enough
+ --> $DIR/global_map_lifetime_1.rs:9:29
+  |
+9 |   let _ = global.map(|that| that);
+  |                       ----- ^^^^ returning this value requires that `'1` must outlive `'2`
+  |                       |   |
+  |                       |   return type of closure is &'2 rusty_v8::Local<'_, rusty_v8::Integer>
+  |                       has type `&'1 rusty_v8::Local<'_, rusty_v8::Integer>`
+
+error: lifetime may not live long enough
+ --> $DIR/global_map_lifetime_1.rs:9:29
+  |
+9 |   let _ = global.map(|that| that);
+  |                       ----- ^^^^ returning this value requires that `'3` must outlive `'4`
+  |                       |   |
+  |                       |   return type of closure is &rusty_v8::Local<'4, rusty_v8::Integer>
+  |                       has type `&rusty_v8::Local<'3, rusty_v8::Integer>`

--- a/tests/compile_fail/global_map_lifetime_2.rs
+++ b/tests/compile_fail/global_map_lifetime_2.rs
@@ -1,0 +1,14 @@
+// Copyright 2019-2020 the Deno authors. All rights reserved. MIT license.
+use rusty_v8 as v8;
+
+pub fn main() {
+  let mut isolate = v8::Isolate::new(mock());
+  let scope = &mut v8::HandleScope::new(&mut isolate);
+  let local = v8::Integer::new(scope, 42);
+  let global = v8::Global::new(scope, local);
+  let () = global.map(|_| drop(global));
+}
+
+fn mock<T>() -> T {
+  unimplemented!()
+}

--- a/tests/compile_fail/global_map_lifetime_2.stderr
+++ b/tests/compile_fail/global_map_lifetime_2.stderr
@@ -1,0 +1,9 @@
+error[E0505]: cannot move out of `global` because it is borrowed
+ --> $DIR/global_map_lifetime_2.rs:9:23
+  |
+9 |   let () = global.map(|_| drop(global));
+  |            ------ --- ^^^      ------ move occurs due to use in closure
+  |            |      |   |
+  |            |      |   move out of `global` occurs here
+  |            |      borrow later used by call
+  |            borrow of `global` occurs here

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -121,6 +121,12 @@ fn global_handles() {
     assert!(g6 == g1);
     assert_eq!(g6.get(scope).to_rust_string_lossy(scope), "bla");
   }
+  {
+    let scope = &mut v8::HandleScope::new(isolate);
+    let this: v8::Local<v8::Value> = v8::Integer::new(scope, 42).into();
+    let g = v8::Global::new(scope, this);
+    assert!(g.map(|that| this.strict_equals(*that)));
+  }
 }
 
 #[test]


### PR DESCRIPTION
Add a convenience method for unwrapping the `v8::Global` without a scope
object. This is the same trick that Node.js applies to speed up unboxing
strong persistent handles.

Refs: https://github.com/denoland/deno/issues/7969

<hr>

It's an idea I had while thinking about denoland/deno#7969. I'm not saying it's a good idea but it seems convenient to have.