### PR TITLE
Add Function::new_instance

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1285,6 +1285,14 @@ const v8::Value* v8__Function__Call(const v8::Function& self,
                                 argc, const_ptr_array_to_local_array(argv)));
 }
 
+const v8::Object* v8__Function__NewInstance(const v8::Function& self,
+                                    const v8::Context& context, int argc,
+                                    const v8::Value* const argv[]) {
+  return maybe_local_to_ptr(
+      ptr_to_local(&self)->NewInstance(ptr_to_local(&context),
+                                argc, const_ptr_array_to_local_array(argv)));
+}
+
 const v8::FunctionTemplate* v8__FunctionTemplate__New(
     v8::Isolate* isolate, v8::FunctionCallback callback = nullptr) {
   return local_to_ptr(v8::FunctionTemplate::New(isolate, callback));

--- a/src/function.rs
+++ b/src/function.rs
@@ -32,6 +32,12 @@ extern "C" {
     argc: int,
     argv: *const *const Value,
   ) -> *const Value;
+  fn v8__Function__NewInstance(
+    this: *const Function,
+    context: *const Context,
+    argc: int,
+    argv: *const *const Value,
+  ) -> *const Object;
 
   fn v8__FunctionCallbackInfo__GetReturnValue(
     info: *const FunctionCallbackInfo,
@@ -323,6 +329,21 @@ impl Function {
     unsafe {
       scope.cast_local(|sd| {
         v8__Function__Call(self, sd.get_current_context(), &*recv, argc, argv)
+      })
+    }
+  }
+
+  pub fn new_instance<'s>(
+    &self,
+    scope: &mut HandleScope<'s>,
+    args: &[Local<Value>],
+  ) -> Option<Local<'s, Object>> {
+    let args = Local::slice_into_raw(args);
+    let argc = int::try_from(args.len()).unwrap();
+    let argv = args.as_ptr();
+    unsafe {
+      scope.cast_local(|sd| {
+        v8__Function__NewInstance(self, sd.get_current_context(), argc, argv)
       })
     }
   }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1671,6 +1671,24 @@ fn function() {
   }
 }
 
+#[test]
+fn constructor() {
+  let _setup_guard = setup();
+  let isolate = &mut v8::Isolate::new(Default::default());
+
+  {
+    let scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(scope);
+    let scope = &mut v8::ContextScope::new(scope, context);
+    let global = context.global(scope);
+    let array_name = v8::String::new(scope, "Array").unwrap();
+    let array_constructor = global.get(scope, array_name.into()).unwrap();
+    let array_constructor = v8::Local::<v8::Function>::try_from(array_constructor).unwrap();
+    let array = array_constructor.new_instance(scope, &[]).unwrap();
+    v8::Local::<v8::Array>::try_from(array).unwrap();
+  }
+}
+
 extern "C" fn promise_reject_callback(msg: v8::PromiseRejectMessage) {
   let scope = &mut unsafe { v8::CallbackScope::new(&msg) };
   let event = msg.get_event();

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1683,7 +1683,8 @@ fn constructor() {
     let global = context.global(scope);
     let array_name = v8::String::new(scope, "Array").unwrap();
     let array_constructor = global.get(scope, array_name.into()).unwrap();
-    let array_constructor = v8::Local::<v8::Function>::try_from(array_constructor).unwrap();
+    let array_constructor =
+      v8::Local::<v8::Function>::try_from(array_constructor).unwrap();
     let array = array_constructor.new_instance(scope, &[]).unwrap();
     v8::Local::<v8::Array>::try_from(array).unwrap();
   }


### PR DESCRIPTION
This allows object instances to be created from constructor functions. This is useful for instantiating ECMAScript Classes from native code since they cannot be called as functions and must use this `new_instance` path.