### PR TITLE
Simplify Function::new_with_data()

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1264,16 +1264,11 @@ const v8::StackTrace* v8__Exception__GetStackTrace(const v8::Value& exception) {
 }
 
 const v8::Function* v8__Function__New(const v8::Context& context,
-                                      v8::FunctionCallback callback) {
+                                      v8::FunctionCallback callback,
+                                      const v8::Value* maybe_data) {
   return maybe_local_to_ptr(
-      v8::Function::New(ptr_to_local(&context), callback));
-}
-
-const v8::Function* v8__Function__NewWithData(const v8::Context& context,
-                                              v8::FunctionCallback callback,
-                                              const v8::Value& data) {
-  return maybe_local_to_ptr(
-      v8::Function::New(ptr_to_local(&context), callback, ptr_to_local(&data)));
+      v8::Function::New(ptr_to_local(&context), callback,
+                        ptr_to_local(maybe_data)));
 }
 
 const v8::Value* v8__Function__Call(const v8::Function& self,

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,5 +1,6 @@
 use std::convert::TryFrom;
 use std::marker::PhantomData;
+use std::ptr::null;
 
 use crate::scope::CallbackScope;
 use crate::support::MapFnFrom;
@@ -17,10 +18,6 @@ use crate::Value;
 
 extern "C" {
   fn v8__Function__New(
-    context: *const Context,
-    callback: FunctionCallback,
-  ) -> *const Function;
-  fn v8__Function__NewWithData(
     context: *const Context,
     callback: FunctionCallback,
     data: *const Value,
@@ -294,7 +291,11 @@ impl Function {
   ) -> Option<Local<'s, Function>> {
     unsafe {
       scope.cast_local(|sd| {
-        v8__Function__New(sd.get_current_context(), callback.map_fn_to())
+        v8__Function__New(
+          sd.get_current_context(),
+          callback.map_fn_to(),
+          null(),
+        )
       })
     }
   }
@@ -308,7 +309,7 @@ impl Function {
   ) -> Option<Local<'s, Function>> {
     unsafe {
       scope.cast_local(|sd| {
-        v8__Function__NewWithData(
+        v8__Function__New(
           sd.get_current_context(),
           callback.map_fn_to(),
           &*data,


### PR DESCRIPTION
It's not necessary to have a separate C++ glue function, it can be
shared with Function::new().