### PR TITLE
feat(build): allow native compilation on non-amd64

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,4 +1,5 @@
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import("//build/config/host_byteorder.gni")
 
 static_library("rusty_v8") {
   complete_static_lib = true
@@ -18,7 +19,7 @@ static_library("rusty_v8") {
 }
 
 config("rusty_v8_config") {
-  configs = [ "//v8:external_config" ]
+  configs = [ "//v8:external_config", "//v8:toolchain", "//v8:features" ]
   cflags = []
 
   # We need these directories in the search path to be able to include some

--- a/build.rs
+++ b/build.rs
@@ -96,12 +96,17 @@ fn build_v8() {
     }
   }
 
-  if env::var("TARGET").unwrap() == "aarch64-unknown-linux-gnu" {
-    gn_args.push(r#"target_cpu="arm64""#.to_string());
-    gn_args.push("use_sysroot=true".to_string());
-    maybe_install_sysroot("arm64");
-    maybe_install_sysroot("amd64");
-  };
+  let target_triple = env::var("TARGET").unwrap();
+  // check if the target triple describes a non-native environment
+  if target_triple != env::var("HOST").unwrap() {
+    // cross-compilation setup
+    if target_triple == "aarch64-unknown-linux-gnu" {
+      gn_args.push(r#"target_cpu="arm64""#.to_string());
+      gn_args.push("use_sysroot=true".to_string());
+      maybe_install_sysroot("arm64");
+      maybe_install_sysroot("amd64");
+    };
+  }
 
   let gn_root = env::var("CARGO_MANIFEST_DIR").unwrap();
 


### PR DESCRIPTION
This pull request will allow `rusty_v8` to build natively on non-amd64 (`x86_64`) platforms.

The changes in `BUILD.gn` help `src/binding.cc` to pick up compiler flags from V8 configurations (like endianness settings).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/denoland/rusty_v8/514)
<!-- Reviewable:end -->
