### PR TITLE
Remove mut from Example in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! let code = v8::String::new(scope, "'Hello' + ' World!'").unwrap();
 //! println!("javascript code: {}", code.to_rust_string_lossy(scope));
 //!
-//! let mut script = v8::Script::compile(scope, code, None).unwrap();
+//! let script = v8::Script::compile(scope, code, None).unwrap();
 //! let result = script.run(scope).unwrap();
 //! let result = result.to_string(scope).unwrap();
 //! println!("result: {}", result.to_rust_string_lossy(scope));


### PR DESCRIPTION
This commit removes `mut` from the `script` variable to avoid the following
warning if used:
```console
25 |   let mut script = v8::Script::compile(scope, code, None).unwrap();
   |       ----^^^^^^
   |       |
   |       help: remove this `mut`
   |
   = note: `#[warn(unused_mut)]` on by default

warning: 1 warning emitted
```