### PR TITLE
Fix expected output for compile_fail tests

### DIFF
--- a/tests/compile_fail/handle_scope_escape_to_nowhere.stderr
+++ b/tests/compile_fail/handle_scope_escape_to_nowhere.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `rusty_v8::OwnedIsolate: rusty_v8::scope::param::NewEscapableHandleScope<'_, '_>` is not satisfied
+error[E0277]: the trait bound `OwnedIsolate: rusty_v8::scope::param::NewEscapableHandleScope<'_, '_>` is not satisfied
  --> $DIR/handle_scope_escape_to_nowhere.rs:6:50
   |
 6 |   let mut _scope = v8::EscapableHandleScope::new(&mut isolate);
-  |                                                  ^^^^^^^^^^^^ the trait `rusty_v8::scope::param::NewEscapableHandleScope<'_, '_>` is not implemented for `rusty_v8::OwnedIsolate`
+  |                                                  ^^^^^^^^^^^^ the trait `rusty_v8::scope::param::NewEscapableHandleScope<'_, '_>` is not implemented for `OwnedIsolate`
   |
-  = note: required by `rusty_v8::EscapableHandleScope::<'s, 'e>::new`
+  = note: required by `EscapableHandleScope::<'s, 'e>::new`
 
-error[E0277]: the trait bound `rusty_v8::OwnedIsolate: rusty_v8::scope::param::NewEscapableHandleScope<'_, '_>` is not satisfied
+error[E0277]: the trait bound `OwnedIsolate: rusty_v8::scope::param::NewEscapableHandleScope<'_, '_>` is not satisfied
  --> $DIR/handle_scope_escape_to_nowhere.rs:6:20
   |
 6 |   let mut _scope = v8::EscapableHandleScope::new(&mut isolate);
-  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `rusty_v8::scope::param::NewEscapableHandleScope<'_, '_>` is not implemented for `rusty_v8::OwnedIsolate`
+  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `rusty_v8::scope::param::NewEscapableHandleScope<'_, '_>` is not implemented for `OwnedIsolate`

--- a/tests/compile_fail/handle_scope_lifetime_1.stderr
+++ b/tests/compile_fail/handle_scope_lifetime_1.stderr
@@ -6,4 +6,4 @@ error[E0499]: cannot borrow `scope1` as mutable more than once at a time
 8 |   let _local = v8::Integer::new(&mut scope1, 123);
   |                                 ^^^^^^^^^^^ second mutable borrow occurs here
 9 | }
-  | - first borrow might be used here, when `_scope2` is dropped and runs the `Drop` code for type `rusty_v8::EscapableHandleScope`
+  | - first borrow might be used here, when `_scope2` is dropped and runs the `Drop` code for type `EscapableHandleScope`

--- a/tests/compile_fail/handle_scope_lifetime_3.stderr
+++ b/tests/compile_fail/handle_scope_lifetime_3.stderr
@@ -6,4 +6,4 @@ error[E0499]: cannot borrow `scope1` as mutable more than once at a time
 10 |     v8::Integer::new(&mut scope1, 123)
    |                      ^^^^^^^^^^^ second mutable borrow occurs here
 11 |   };
-   |   - first borrow might be used here, when `_scope2` is dropped and runs the `Drop` code for type `rusty_v8::EscapableHandleScope`
+   |   - first borrow might be used here, when `_scope2` is dropped and runs the `Drop` code for type `EscapableHandleScope`

--- a/tests/compile_fail/object_without_context_scope.stderr
+++ b/tests/compile_fail/object_without_context_scope.stderr
@@ -4,5 +4,5 @@ error[E0308]: mismatched types
 7 |   let _object = v8::Object::new(&mut scope);
   |                                 ^^^^^^^^^^ expected struct `rusty_v8::Context`, found `()`
   |
-  = note: expected mutable reference `&mut rusty_v8::HandleScope<'_>`
-             found mutable reference `&mut rusty_v8::HandleScope<'_, ()>`
+  = note: expected mutable reference `&mut HandleScope<'_>`
+             found mutable reference `&mut HandleScope<'_, ()>`


### PR DESCRIPTION
Currently, I'm seeing a few failures for the tests in
tests/compile_fail, simliar to the following:
```console
test tests/compile_fail/handle_scope_lifetime_1.rs ... mismatch

EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0499]: cannot borrow `scope1` as mutable more than once at a time
 --> $DIR/handle_scope_lifetime_1.rs:8:33
  |
7 |   let mut _scope2 = v8::EscapableHandleScope::new(&mut scope1);
  |                                                   ----------- first
 mutable borrow occurs here
8 |   let _local = v8::Integer::new(&mut scope1, 123);
  |                                 ^^^^^^^^^^^ second mutable borrow
occurs here
9 | }
  | - first borrow might be used here, when `_scope2` is dropped and
runs the `Drop` code for type `rusty_v8::EscapableHandleScope`
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0499]: cannot borrow `scope1` as mutable more than once at a time
 --> $DIR/handle_scope_lifetime_1.rs:8:33
  |
7 |   let mut _scope2 = v8::EscapableHandleScope::new(&mut scope1);
  |                                                   ----------- first
mutable borrow occurs here
8 |   let _local = v8::Integer::new(&mut scope1, 123);
  |                                 ^^^^^^^^^^^ second mutable borrow
occurs here
9 | }
  | - first borrow might be used here, when `_scope2` is dropped and
runs the `Drop` code for type `EscapableHandleScope`
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
```
This commit updates the .stderr files that are affected by these
failures (by running `env TRYBUILD=overwrite cargo test`).