### PR TITLE
Revert "Fix rustdoc warnings (#526)"

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -57,9 +57,7 @@ impl BigInt {
   /// specified list of digits/words.
   /// The resulting number is calculated as:
   ///
-  /// ```
   /// (-1)^sign_bit * (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...)
-  /// ```
   pub fn new_from_words<'s>(
     scope: &mut HandleScope<'s>,
     sign_bit: bool,

--- a/src/data.rs
+++ b/src/data.rs
@@ -503,7 +503,7 @@ impl_partial_eq! { ObjectTemplate for Template use identity }
 /// and "instance" for the instance object created above. The function
 /// and the instance will have the following properties:
 ///
-/// ```javascript,ignore
+/// ```ignore
 ///   func_property in function == true;
 ///   function.func_property == 1;
 ///
@@ -547,7 +547,7 @@ impl_partial_eq! { ObjectTemplate for Template use identity }
 /// The Child function and Child instance will have the following
 /// properties:
 ///
-/// ```javascript,ignore
+/// ```ignore
 ///   child_func.prototype.__proto__ == function.prototype;
 ///   child_instance.instance_accessor calls 'InstanceAccessorCallback'
 ///   child_instance.instance_property == 3;

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -77,7 +77,7 @@ impl Promise {
     unsafe { v8__Promise__HasHandler(&*self) }
   }
 
-  /// Returns the content of the Promise Result. The Promise must not
+  /// Returns the content of the [[PromiseResult]] field. The Promise must not
   /// be pending.
   pub fn result<'s>(&self, scope: &mut HandleScope<'s>) -> Local<'s, Value> {
     unsafe { scope.cast_local(|_| v8__Promise__Result(&*self)) }.unwrap()


### PR DESCRIPTION
This reverts commit 58ca728c5f6ef3987f003a261b33deb716cd3173.

<hr>

cc @danbev - your PR passed CI but it's causing `cargo test` to fail locally for me. This is with rustc 1.47.0.

<details>

```
---- src/bigint.rs - bigint::BigInt::new_from_words (line 60) stdout ----
error: unexpected token: `...`
 --> src/bigint.rs:61:62
  |
3 | (-1)^sign_bit * (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...)
  |                                                              ^^^
  |
help: use `..` for an exclusive range
  |
3 | (-1)^sign_bit * (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ..)
  |                                                              ^^
help: or `..=` for an inclusive range
  |
3 | (-1)^sign_bit * (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ..=)
  |                                                              ^^^

error[E0586]: inclusive range with no end
 --> src/bigint.rs:61:62
  |
3 | (-1)^sign_bit * (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...)
  |                                                              ^^^ help: use `..` instead
  |
  = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)

error[E0425]: cannot find value `sign_bit` in this scope
 --> src/bigint.rs:61:6
  |
3 | (-1)^sign_bit * (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...)
  |      ^^^^^^^^ not found in this scope

error[E0425]: cannot find value `words` in this scope
 --> src/bigint.rs:61:18
  |
3 | (-1)^sign_bit * (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...)
  |                  ^^^^^ not found in this scope

error[E0425]: cannot find value `words` in this scope
 --> src/bigint.rs:61:40
  |
3 | (-1)^sign_bit * (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...)
  |                                        ^^^^^ not found in this scope

error[E0308]: mismatched types
 --> src/bigint.rs:61:1
  |
2 | fn main() {
  |           - expected `()` because of default return type
3 | (-1)^sign_bit * (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found integer
```

</details>