### PR TITLE
Make v8::ScriptOrigin support optional arguments

### DIFF
--- a/examples/shell.rs
+++ b/examples/shell.rs
@@ -111,14 +111,14 @@ fn execute_string(
   let script = v8::String::new(&mut scope, script).unwrap();
   let origin = v8::ScriptOrigin::new(
     v8::String::new(&mut scope, filename).unwrap().into(),
-    v8::Integer::new(&mut scope, 0),
-    v8::Integer::new(&mut scope, 0),
-    v8::Boolean::new(&mut scope, false),
-    v8::Integer::new(&mut scope, 0),
-    v8::undefined(&mut scope).into(),
-    v8::Boolean::new(&mut scope, false),
-    v8::Boolean::new(&mut scope, false),
-    v8::Boolean::new(&mut scope, false),
+    Some(v8::Integer::new(&mut scope, 0)),
+    Some(v8::Integer::new(&mut scope, 0)),
+    Some(v8::Boolean::new(&mut scope, false)),
+    Some(v8::Integer::new(&mut scope, 0)),
+    Some(v8::undefined(&mut scope).into()),
+    Some(v8::Boolean::new(&mut scope, false)),
+    Some(v8::Boolean::new(&mut scope, false)),
+    Some(v8::Boolean::new(&mut scope, false)),
   );
 
   let script = if let Some(script) =

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -94,6 +94,10 @@ impl<'s, T> Local<'s, T> {
   pub(crate) fn slice_into_raw(slice: &[Self]) -> &[*const T] {
     unsafe { &*(slice as *const [Self] as *const [*const T]) }
   }
+
+  pub(crate) fn raw_or_null(v: Option<Self>) -> *const T {
+    v.map(|v| &*v as *const _).unwrap_or_else(std::ptr::null)
+  }
 }
 
 impl<'s, T> Copy for Local<'s, T> {}

--- a/src/script.rs
+++ b/src/script.rs
@@ -77,28 +77,28 @@ impl<'s> ScriptOrigin<'s> {
   #[allow(clippy::too_many_arguments)]
   pub fn new(
     resource_name: Local<'s, Value>,
-    resource_line_offset: Local<'s, Integer>,
-    resource_column_offset: Local<'s, Integer>,
-    resource_is_shared_cross_origin: Local<'s, Boolean>,
-    script_id: Local<'s, Integer>,
-    source_map_url: Local<'s, Value>,
-    resource_is_opaque: Local<'s, Boolean>,
-    is_wasm: Local<'s, Boolean>,
-    is_module: Local<'s, Boolean>,
+    resource_line_offset: Option<Local<'s, Integer>>,
+    resource_column_offset: Option<Local<'s, Integer>>,
+    resource_is_shared_cross_origin: Option<Local<'s, Boolean>>,
+    script_id: Option<Local<'s, Integer>>,
+    source_map_url: Option<Local<'s, Value>>,
+    resource_is_opaque: Option<Local<'s, Boolean>>,
+    is_wasm: Option<Local<'s, Boolean>>,
+    is_module: Option<Local<'s, Boolean>>,
   ) -> Self {
     unsafe {
       let mut buf = std::mem::MaybeUninit::<ScriptOrigin>::uninit();
       v8__ScriptOrigin__CONSTRUCT(
         &mut buf,
         &*resource_name,
-        &*resource_line_offset,
-        &*resource_column_offset,
-        &*resource_is_shared_cross_origin,
-        &*script_id,
-        &*source_map_url,
-        &*resource_is_opaque,
-        &*is_wasm,
-        &*is_module,
+        Local::raw_or_null(resource_line_offset),
+        Local::raw_or_null(resource_column_offset),
+        Local::raw_or_null(resource_is_shared_cross_origin),
+        Local::raw_or_null(script_id),
+        Local::raw_or_null(source_map_url),
+        Local::raw_or_null(resource_is_opaque),
+        Local::raw_or_null(is_wasm),
+        Local::raw_or_null(is_module),
       );
       buf.assume_init()
     }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -963,14 +963,14 @@ fn script_origin() {
 
     let script_origin = v8::ScriptOrigin::new(
       resource_name.into(),
-      resource_line_offset,
-      resource_column_offset,
-      resource_is_shared_cross_origin,
-      script_id,
-      source_map_url.into(),
-      resource_is_opaque,
-      is_wasm,
-      is_module,
+      Some(resource_line_offset),
+      Some(resource_column_offset),
+      Some(resource_is_shared_cross_origin),
+      Some(script_id),
+      Some(source_map_url.into()),
+      Some(resource_is_opaque),
+      Some(is_wasm),
+      Some(is_module),
     );
 
     let source = v8::String::new(scope, "1+2").unwrap();
@@ -1829,22 +1829,17 @@ fn mock_script_origin<'s>(
   let resource_name = v8::String::new(scope, resource_name_).unwrap();
   let resource_line_offset = v8::Integer::new(scope, 0);
   let resource_column_offset = v8::Integer::new(scope, 0);
-  let resource_is_shared_cross_origin = v8::Boolean::new(scope, true);
-  let script_id = v8::Integer::new(scope, 123);
-  let source_map_url = v8::String::new(scope, "source_map_url").unwrap();
-  let resource_is_opaque = v8::Boolean::new(scope, true);
-  let is_wasm = v8::Boolean::new(scope, false);
   let is_module = v8::Boolean::new(scope, true);
   v8::ScriptOrigin::new(
     resource_name.into(),
-    resource_line_offset,
-    resource_column_offset,
-    resource_is_shared_cross_origin,
-    script_id,
-    source_map_url.into(),
-    resource_is_opaque,
-    is_wasm,
-    is_module,
+    Some(resource_line_offset),
+    Some(resource_column_offset),
+    None, // resource_is_shared_cross_origin
+    None, // script_id
+    None, // source_map_url
+    None, // resource_is_opaque
+    None, // is_wasm
+    Some(is_module),
   )
 }
 


### PR DESCRIPTION
The C++ API requires the resource name argument but the other eight (!)
arguments are optional. Mimic that by allowing `None`.

This commit adds a small helper to turn `Option<Local<T>>` into a raw
`T*` pointer. I'll move over more of the code base in a follow-up pull
request.