### PR TITLE
build: upgrade ci script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,8 @@ jobs:
           cd ~
           curl -LO $url
           tar -xzvf "$basename.tar.gz"
-          echo "$(pwd)/$basename"
-          echo "$(pwd)/$basename" >> $GITHUB_PATH
+          echo "$(pwd)/$basename/"
+          echo "$(pwd)/$basename/" >> $GITHUB_PATH
           . $basename/sccache --start-server
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
           tar -xzvf "$basename.tar.gz"
           . $basename/sccache --start-server
 
-          echo "$(pwd)/$basename" >> $GITHUB_PATH
+          echo "$(pwd)/$(basename)" >> $GITHUB_PATH
 
       - name: Test
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,13 +140,13 @@ jobs:
           SCCACHE_CACHE_SIZE: 128M
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
-          version = "0.2.12"
+          version="0.2.12"
           case "${{ runner.os }}" in
             macOS) platform="x86_64-apple-darwin" ;;
             Linux) platform="x86_64-unknown-linux-musl" ;;
             Windows) platform="x86_64-pc-windows-msvc" ;;
           esac
-          basename = "sccache-$version-$platform"
+          basename="sccache-$version-$platform"
           url = "https://github.com/mozilla/sccache/releases/download/$version/$basename.tar.gz"
           cd ~
           curl -LO $url

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,9 @@ jobs:
           cd ~
           curl -LO $url
           tar -xzvf "$basename.tar.gz"
+          . $basename/sccache --start-server
+
           echo "$(pwd)/$basename/" >> $GITHUB_PATH
-          sccache --start-server
 
       - name: Test
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           cd ~
           curl -LO $url
           tar -xzvf "$basename.tar.gz"
-          . $basename/sccache --start-server
+          $basename/sccache --start-server
 
           echo "$(pwd)/$basename/" >> $GITHUB_PATH
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
           tar -xzvf "$basename.tar.gz"
           . $basename/sccache --start-server
 
-          echo "$(pwd)/$(basename)" >> $GITHUB_PATH
+          echo "$(pwd)/$basename" >> ${GITHUB_PATH}
 
       - name: Test
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
         run: cargo clean -p serde_derive
 
       - name: Install and start sccache
+        shell: bash
         env:
           SCCACHE_DIR: ${{ github.workspace }}/target/sccache
           SCCACHE_CACHE_SIZE: 128M

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,13 +147,12 @@ jobs:
             Windows) platform="x86_64-pc-windows-msvc" ;;
           esac
           basename="sccache-$version-$platform"
-          url = "https://github.com/mozilla/sccache/releases/download/$version/$basename.tar.gz"
+          url="https://github.com/mozilla/sccache/releases/download/$version/$basename.tar.gz"
           cd ~
           curl -LO $url
           tar -xzvf "$basename.tar.gz"
-          echo "$(pwd)/$basename/"
           echo "$(pwd)/$basename/" >> $GITHUB_PATH
-          . $basename/sccache --start-server
+          sccache --start-server
 
       - name: Test
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
           sudo ln -s /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 \
                      /lib/ld-linux-aarch64.so.1
 
-          echo "::set-env name=CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER::/usr/bin/aarch64-linux-gnu-gcc-5"
-          echo "::set-env name=QEMU_LD_PREFIX::/usr/aarch64-linux-gnu"
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc-5" >> ${GITHUB_ENV}
+          echo "QEMU_LD_PREFIX=/usr/aarch64-linux-gnu" >> ${GITHUB_ENV}
 
       - name: Cache
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,15 +141,11 @@ jobs:
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
           version = "0.2.12"
-          if [[ "macOS" = "${{ runner.os }}" ]]; then
-            platform = "x86_64-apple-darwin"
-          fi 
-          if [[ "Linux" = "${{ runner.os }}" ]]; then
-            platform = "x86_64-unknown-linux-musl"
-          fi 
-          if [[ "Windows" = "${{ runner.os }}" ]]; then
-            platform = "x86_64-pc-windows-msvc"
-          fi 
+          case "${{ runner.os }}" in
+            macOS) platform="x86_64-apple-darwin" ;;
+            Linux) platform="x86_64-unknown-linux-musl" ;;
+            Windows) platform="x86_64-pc-windows-msvc" ;;
+          esac
           basename = "sccache-$version-$platform"
           url = "https://github.com/mozilla/sccache/releases/download/$version/$basename.tar.gz"
           cd ~

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
           tar -xzvf "$basename.tar.gz"
           $basename/sccache --start-server
 
+          echo "$(pwd)/$basename/"
           echo "$(pwd)/$basename/" >> $GITHUB_PATH
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,22 +135,23 @@ jobs:
         run: cargo clean -p serde_derive
 
       - name: Install and start sccache
-        shell: pwsh
         env:
           SCCACHE_DIR: ${{ github.workspace }}/target/sccache
           SCCACHE_CACHE_SIZE: 128M
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
-          $version = "0.2.12"
-          $platform =
-            @{ "macOS"   = "x86_64-apple-darwin"
-               "Linux"   = "x86_64-unknown-linux-musl"
-               "Windows" = "x86_64-pc-windows-msvc"
-             }.${{ runner.os }}
-          $basename = "sccache-$version-$platform"
-          $url = "https://github.com/mozilla/sccache/releases/download/" +
-                 "$version/$basename.tar.gz"
-
+          version = "0.2.12"
+          if [[ "macOS" = "${{ runner.os }}" ]]; then
+            platform = "x86_64-apple-darwin"
+          fi 
+          if [[ "Linux" = "${{ runner.os }}" ]]; then
+            platform = "x86_64-unknown-linux-musl"
+          fi 
+          if [[ "Windows" = "${{ runner.os }}" ]]; then
+            platform = "x86_64-pc-windows-msvc"
+          fi 
+          basename = "sccache-$version-$platform"
+          url = "https://github.com/mozilla/sccache/releases/download/$version/$basename.tar.gz"
           cd ~
           curl -LO $url
           tar -xzvf "$basename.tar.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           cd ~
           curl -LO $url
           tar -xzvf "$basename.tar.gz"
-          echo "$HOME/$basename" >> $GITHUB_PATH
+          echo "$HOME/${basename}" >> $GITHUB_PATH
           . $basename/sccache --start-server
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,27 +135,27 @@ jobs:
         run: cargo clean -p serde_derive
 
       - name: Install and start sccache
-        shell: bash
+        shell: pwsh
         env:
           SCCACHE_DIR: ${{ github.workspace }}/target/sccache
           SCCACHE_CACHE_SIZE: 128M
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
-          version="0.2.12"
-          case "${{ runner.os }}" in
-            macOS) platform="x86_64-apple-darwin" ;;
-            Linux) platform="x86_64-unknown-linux-musl" ;;
-            Windows) platform="x86_64-pc-windows-msvc" ;;
-          esac
-          basename="sccache-$version-$platform"
-          url="https://github.com/mozilla/sccache/releases/download/$version/$basename.tar.gz"
+          $version = "0.2.12"
+          $platform =
+            @{ "macOS"   = "x86_64-apple-darwin"
+               "Linux"   = "x86_64-unknown-linux-musl"
+               "Windows" = "x86_64-pc-windows-msvc"
+             }.${{ runner.os }}
+          $basename = "sccache-$version-$platform"
+          $url = "https://github.com/mozilla/sccache/releases/download/" +
+                 "$version/$basename.tar.gz"
           cd ~
           curl -LO $url
           tar -xzvf "$basename.tar.gz"
-          $basename/sccache --start-server
+          . $basename/sccache --start-server
+          echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-          echo "$(pwd)/$basename/"
-          echo "$(pwd)/$basename/" >> $GITHUB_PATH
 
       - name: Test
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
           cd ~
           curl -LO $url
           tar -xzvf "$basename.tar.gz"
+          echo "$(pwd)/$basename"
           echo "$(pwd)/$basename" >> $GITHUB_PATH
           . $basename/sccache --start-server
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           cd ~
           curl -LO $url
           tar -xzvf "$basename.tar.gz"
-          echo "$HOME/${basename}" >> $GITHUB_PATH
+          echo "$(pwd)/$basename" >> $GITHUB_PATH
           . $basename/sccache --start-server
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,9 +154,8 @@ jobs:
           cd ~
           curl -LO $url
           tar -xzvf "$basename.tar.gz"
+          echo "$HOME/$basename" >> $GITHUB_PATH
           . $basename/sccache --start-server
-
-          echo "$(pwd)/$basename" >> ${GITHUB_PATH}
 
       - name: Test
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
           tar -xzvf "$basename.tar.gz"
           . $basename/sccache --start-server
 
-          echo "::add-path::$(pwd)/$basename"
+          echo "$(pwd)/$basename" >> $GITHUB_PATH
 
       - name: Test
         run:


### PR DESCRIPTION
Replace deprecated `add-path` and `set-env` with echoing to `$GITHUB_PATH` and `$GITHUB_ENV` respectively.