### PR TITLE
Add dispose/shutdown_platform to hello_world

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -6,60 +6,67 @@ fn main() {
   v8::V8::initialize_platform(platform);
   v8::V8::initialize();
 
-  // Create a new Isolate and make it the current one.
-  let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
+  {
+    // Create a new Isolate and make it the current one.
+    let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
 
-  // Create a stack-allocated handle scope.
-  let handle_scope = &mut v8::HandleScope::new(isolate);
+    // Create a stack-allocated handle scope.
+    let handle_scope = &mut v8::HandleScope::new(isolate);
 
-  // Create a new context.
-  let context = v8::Context::new(handle_scope);
+    // Create a new context.
+    let context = v8::Context::new(handle_scope);
 
-  // Enter the context for compiling and running the hello world script.
-  let scope = &mut v8::ContextScope::new(handle_scope, context);
+    // Enter the context for compiling and running the hello world script.
+    let scope = &mut v8::ContextScope::new(handle_scope, context);
 
-  // Create a string containing the JavaScript source code.
-  let code = v8::String::new(scope, "'Hello' + ' World!'").unwrap();
+    // Create a string containing the JavaScript source code.
+    let code = v8::String::new(scope, "'Hello' + ' World!'").unwrap();
 
-  // Compile the source code.
-  let script = v8::Script::compile(scope, code, None).unwrap();
-  // Run the script to get the result.
-  let result = script.run(scope).unwrap();
+    // Compile the source code.
+    let script = v8::Script::compile(scope, code, None).unwrap();
+    // Run the script to get the result.
+    let result = script.run(scope).unwrap();
 
-  // Convert the result to a string and print it.
-  let result = result.to_string(scope).unwrap();
-  println!("{}", result.to_rust_string_lossy(scope));
+    // Convert the result to a string and print it.
+    let result = result.to_string(scope).unwrap();
+    println!("{}", result.to_rust_string_lossy(scope));
 
-  // Use the JavaScript API to generate a WebAssembly module.
-  //
-  // |bytes| contains the binary format for the following module:
-  //
-  //     (func (export "add") (param i32 i32) (result i32)
-  //       get_local 0
-  //       get_local 1
-  //       i32.add)
-  //
-  let c_source = r#"
-        let bytes = new Uint8Array([
-          0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01,
-          0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07,
-          0x07, 0x01, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00, 0x0a, 0x09, 0x01,
-          0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b
-        ]);
-        let module = new WebAssembly.Module(bytes);
-        let instance = new WebAssembly.Instance(module);
-        instance.exports.add(3, 4);
-      "#;
-  // Create a string containing the JavaScript source code.
-  let source = v8::String::new(scope, c_source).unwrap();
+    // Use the JavaScript API to generate a WebAssembly module.
+    //
+    // |bytes| contains the binary format for the following module:
+    //
+    //     (func (export "add") (param i32 i32) (result i32)
+    //       get_local 0
+    //       get_local 1
+    //       i32.add)
+    //
+    let c_source = r#"
+          let bytes = new Uint8Array([
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01,
+            0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07,
+            0x07, 0x01, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00, 0x0a, 0x09, 0x01,
+            0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b
+          ]);
+          let module = new WebAssembly.Module(bytes);
+          let instance = new WebAssembly.Instance(module);
+          instance.exports.add(3, 4);
+        "#;
+    // Create a string containing the JavaScript source code.
+    let source = v8::String::new(scope, c_source).unwrap();
 
-  // Compile the source code.
-  let script = v8::Script::compile(scope, source, None).unwrap();
+    // Compile the source code.
+    let script = v8::Script::compile(scope, source, None).unwrap();
 
-  // Run the script to get the result.
-  let result = script.run(scope).unwrap();
+    // Run the script to get the result.
+    let result = script.run(scope).unwrap();
 
-  // Print the result.
-  let result = result.to_uint32(scope).unwrap();
-  println!("3 + 4 = {}", result.value());
+    // Print the result.
+    let result = result.to_uint32(scope).unwrap();
+    println!("3 + 4 = {}", result.value());
+  }
+
+  unsafe {
+    v8::V8::dispose();
+  }
+  v8::V8::shutdown_platform();
 }


### PR DESCRIPTION
This commit adds calls to `v8::V8::dispose` and `v8::V8::shutdown_platform`
to the `hello_world.rs` example.

The motivation for adding this is that it was not obvious to me that I
needed to have the Isolate in a separate scope. If there is not, the
platform will have been shutdown before the Isolate's `Drop` function
is called at the end of the function where the scope ends. `Drop` will in
turn call `Dispose` on the V8 Isolate, which calls `Isolate::Deinit`, and
`Deinit` calls `tracing_cpu_profilers.reset()` which will call
`~TracingCpuProfilerImpl` which has a call to `V8::GetCurrentPlatform()`
which will produce the following error:

```console
#
# Fatal error in ../../../v8/src/init/v8.cc, line 144
# Debug check failed: platform.
#
#
#
#FailureMessage Object: 0x7fff45b03700Illegal instruction (core dumped)
```

Having an example might safe others some time if they run into the same
issue.