### PR TITLE
Add set_flags_from_command_line_with_usage fn

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -10,6 +10,7 @@
 #include "v8/include/v8.h"
 #include "v8/src/execution/isolate-utils-inl.h"
 #include "v8/src/execution/isolate-utils.h"
+#include "v8/src/flags/flags.h"
 #include "v8/src/objects/objects-inl.h"
 #include "v8/src/objects/objects.h"
 #include "v8/src/objects/smi.h"
@@ -89,8 +90,12 @@ v8::MaybeLocal<v8::Promise> HostImportModuleDynamicallyCallback(
 }
 
 extern "C" {
-void v8__V8__SetFlagsFromCommandLine(int* argc, char** argv) {
-  v8::V8::SetFlagsFromCommandLine(argc, argv, true);
+void v8__V8__SetFlagsFromCommandLine(int* argc, char** argv,
+                                     const char* usage) {
+  namespace i = v8::internal;
+  using HelpOptions = i::FlagList::HelpOptions;
+  HelpOptions help_options = HelpOptions(HelpOptions::kExit, usage);
+  i::FlagList::SetFlagsFromCommandLine(argc, argv, true, help_options);
 }
 
 void v8__V8__SetFlagsFromString(const char* flags, size_t length) {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1000,6 +1000,15 @@ fn set_flags_from_command_line() {
 }
 
 #[test]
+fn set_flags_from_command_line_with_usage() {
+  let r = v8::V8::set_flags_from_command_line_with_usage(
+    vec!["binaryname".to_string(), "--help".to_string()],
+    Some("Usage: binaryname --startup-src=file\n\n"),
+  );
+  assert_eq!(r, vec!["binaryname".to_string()]);
+}
+
+#[test]
 fn inspector_string_view() {
   let chars = b"Hello world!";
   let view = v8::inspector::StringView::from(&chars[..]);


### PR DESCRIPTION
This commit suggests adding a usage string which can be passed to V8
when setting the command line flags. If the `--help` flag is specified
then the usage string will be printed before the V8 options.

The motivation for this would be to enable embedders of rusty_v8 to
pass their own usage string and have their usage printed before V8's
options.

For example:
```console
Usage: binaryname --startup-src=file

SSE3=1 SSSE3=1 SSE4_1=1 SSE4_2=1 SAHF=1 AVX=1 FMA3=1 BMI1=1 BMI2=1
The following syntax for options is accepted (both '-' and '--' are ok):
  --flag        (bool flags only)
  --no-flag     (bool flags only)
  --flag=value  (non-bool flags only, no spaces around '=')
  --flag value  (non-bool flags only)
  --            (captures all remaining args in JavaScript)

Options:
...
```