### PR TITLE
Fix typo in send_notification print statement

### DIFF
--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3202,7 +3202,7 @@ impl v8::inspector::ChannelImpl for ChannelCounter {
     &mut self,
     message: v8::UniquePtr<v8::inspector::StringBuffer>,
   ) {
-    println!("send_notificatio message {}", message.unwrap().string());
+    println!("send_notification message {}", message.unwrap().string());
     self.count_send_notification += 1;
   }
   fn flush_protocol_notifications(&mut self) {


### PR DESCRIPTION
This commit fixes a typo in the `send_notification` function which can be
seen when running the following test:
```console
$ cargo test --test test_api -- --test \
inspector_schedule_pause_on_next_statement --nocapture
    Finished test [unoptimized + debuginfo] target(s) in 0.05s
     Running target/debug/deps/test_api-2dce272ff86e969e

running 1 test
send_response call_id 1 message
{"id":1,"result":
  {"debuggerId":"6374278651496261962.-7730398402173275062"}
}
send_notificatio message {...
```