### PR TITLE
Make Private work with context-less HandleScope

### DIFF
--- a/src/private.rs
+++ b/src/private.rs
@@ -20,7 +20,7 @@ extern "C" {
 impl Private {
   /// Create a private symbol. If name is not empty, it will be the description.
   pub fn new<'s>(
-    scope: &mut HandleScope<'s>,
+    scope: &mut HandleScope<'s, ()>,
     name: Option<Local<String>>,
   ) -> Local<'s, Private> {
     unsafe {
@@ -42,7 +42,7 @@ impl Private {
   /// To minimize the potential for clashes, use qualified names as keys,
   /// e.g., "Class#property".
   pub fn for_api<'s>(
-    scope: &mut HandleScope<'s>,
+    scope: &mut HandleScope<'s, ()>,
     name: Option<Local<String>>,
   ) -> Local<'s, Private> {
     unsafe {
@@ -57,7 +57,7 @@ impl Private {
   }
 
   /// Returns the print name string of the private symbol, or undefined if none.
-  pub fn name<'s>(&self, scope: &mut HandleScope<'s>) -> Local<'s, Value> {
+  pub fn name<'s>(&self, scope: &mut HandleScope<'s, ()>) -> Local<'s, Value> {
     unsafe { scope.cast_local(|_| v8__Private__Name(&*self)) }.unwrap()
   }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3860,8 +3860,6 @@ fn private() {
   let _setup_guard = setup();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
-  let scope = &mut v8::ContextScope::new(scope, context);
 
   let p = v8::Private::new(scope, None);
   assert!(p.name(scope) == v8::undefined(scope));
@@ -3877,6 +3875,9 @@ fn private() {
   let p_api2 = v8::Private::for_api(scope, Some(name));
   assert!(p_api2 != p);
   assert!(p_api == p_api2);
+
+  let context = v8::Context::new(scope);
+  let scope = &mut v8::ContextScope::new(scope, context);
 
   let object = v8::Object::new(scope);
   let sentinel = v8::Object::new(scope).into();


### PR DESCRIPTION
v8::Private is like v8::String and other primitives, it doesn't need an
active v8::Context.