### PR TITLE
Make Symbol work with context-less HandleScope

### DIFF
--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -19,7 +19,7 @@ extern "C" {
 
 macro_rules! well_known {
   ($name:ident, $binding:ident) => {
-    pub fn $name<'s>(scope: &mut HandleScope<'s>) -> Local<'s, Symbol> {
+    pub fn $name<'s>(scope: &mut HandleScope<'s, ()>) -> Local<'s, Symbol> {
       extern "C" {
         fn $binding(isolate: *mut Isolate) -> *const Symbol;
       }
@@ -32,7 +32,7 @@ impl Symbol {
   /// Create a symbol. If description is not empty, it will be used as the
   /// description.
   pub fn new<'s>(
-    scope: &mut HandleScope<'s>,
+    scope: &mut HandleScope<'s, ()>,
     description: Option<Local<String>>,
   ) -> Local<'s, Symbol> {
     unsafe {
@@ -54,7 +54,7 @@ impl Symbol {
   /// To minimize the potential for clashes, use qualified descriptions as keys.
   /// Corresponds to v8::Symbol::For() in C++.
   pub fn for_global<'s>(
-    scope: &mut HandleScope<'s>,
+    scope: &mut HandleScope<'s, ()>,
     description: Local<String>,
   ) -> Local<'s, Symbol> {
     unsafe {
@@ -68,7 +68,7 @@ impl Symbol {
   /// Returns the description string of the symbol, or undefined if none.
   pub fn description<'s>(
     &self,
-    scope: &mut HandleScope<'s>,
+    scope: &mut HandleScope<'s, ()>,
   ) -> Local<'s, Value> {
     unsafe { scope.cast_local(|_| v8__Symbol__Description(&*self)) }.unwrap()
   }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3832,8 +3832,6 @@ fn symbol() {
   let _setup_guard = setup();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
-  let scope = &mut v8::ContextScope::new(scope, context);
 
   let desc = v8::String::new(scope, "a description").unwrap();
 
@@ -3850,6 +3848,9 @@ fn symbol() {
   let s_pub2 = v8::Symbol::for_global(scope, desc);
   assert!(s_pub2 != s);
   assert!(s_pub == s_pub2);
+
+  let context = v8::Context::new(scope);
+  let scope = &mut v8::ContextScope::new(scope, context);
 
   let s = eval(scope, "Symbol.asyncIterator").unwrap();
   assert!(s == v8::Symbol::get_async_iterator(scope));


### PR DESCRIPTION
v8::Symbol is like v8::String and other primitives, it doesn't need an
active v8::Context.

See also #549.