### PR TITLE
WIP: Support loading snapshots before snapshotting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rusty_v8"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bitflags",
  "cargo_gn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_v8"
-version = "0.14.0"
+version = "0.15.0"
 description = "Rust bindings to V8"
 readme = "README.md"
 authors = ["the Deno authors"]

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1661,8 +1661,9 @@ bool v8__Proxy__IsRevoked(const v8::Proxy& self) {
 void v8__Proxy__Revoke(const v8::Proxy& self) { ptr_to_local(&self)->Revoke(); }
 
 void v8__SnapshotCreator__CONSTRUCT(uninit_t<v8::SnapshotCreator>* buf,
-                                    const intptr_t* external_references) {
-  construct_in_place<v8::SnapshotCreator>(buf, external_references);
+                                    const intptr_t* external_references,
+                                    v8::StartupData* existing_blob) {
+  construct_in_place<v8::SnapshotCreator>(buf, external_references, existing_blob);
 }
 
 void v8__SnapshotCreator__DESTRUCT(v8::SnapshotCreator* self) {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -18,6 +18,7 @@ extern "C" {
   fn v8__SnapshotCreator__CONSTRUCT(
     buf: *mut MaybeUninit<SnapshotCreator>,
     external_references: *const intptr_t,
+    existing_blob: *mut StartupData,
   );
   fn v8__SnapshotCreator__DESTRUCT(this: *mut SnapshotCreator);
   fn v8__SnapshotCreator__GetIsolate(
@@ -94,17 +95,24 @@ pub struct SnapshotCreator([usize; 1]);
 impl SnapshotCreator {
   /// Create and enter an isolate, and set it up for serialization.
   /// The isolate is created from scratch.
-  pub fn new(external_references: Option<&'static ExternalReferences>) -> Self {
+  pub fn new(external_references: Option<&'static ExternalReferences>, existing_blob: Option<StartupData>) -> Self {
     let mut snapshot_creator: MaybeUninit<Self> = MaybeUninit::uninit();
     let external_references_ptr = if let Some(er) = external_references {
       er.as_ptr()
     } else {
       std::ptr::null()
     };
+    let existing_blob_ptr = if let Some(mut eb) = existing_blob {
+      &mut eb as *mut StartupData
+    } else {
+      std::ptr::null_mut()
+    };
+
     unsafe {
       v8__SnapshotCreator__CONSTRUCT(
         &mut snapshot_creator,
         external_references_ptr,
+        existing_blob_ptr,
       );
       snapshot_creator.assume_init()
     }


### PR DESCRIPTION
This is my current attempt at allowing snapshots to be loaded before another snapshot is taken on an isolate.

It currently doesn't work with the error message (see: #551)
```
# Fatal error in ../../../../v8/src/api/api.cc, line 636
# Debug check failed: data->created_.
```