### PR TITLE
improve ninja/gn detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,15 @@ For Windows builds: the 64-bit toolchain needs to be used. 32-bit targets are
 not supported.
 
 The build depends on several binary tools: `gn`, `ninja` and a recent version
-of `clang` (V8 relies on bleeding edge features). Because these are not
-generally available they are automatically downloaded during the build by default.
-It should be possible to opt out of the gn and ninja download by specifying the
-`$GN` and `$NINJA` environmental variables. The clang download can be skipped by
-providing a `$CLANG_BASE_PATH` environmental variable pointing to a recent
-`llvm`/`clang` installation (currently LLVM v8.0+ or Apple clang v11.0+).
-You could also pass in additional arguments to `gn` by setting the `$GN_ARGS`
-environmental variable.
+of `clang` (V8 relies on bleeding edge features). The tools will automatically
+be downloaded, if they are not detected in the environment.
+
+Specifying the `$GN` and `$NINJA` environmental variables can be used to skip
+the download of gn and ninja. The clang download can be skipped by setting
+`$CLANG_BASE_PATH` to the directory containing recent `llvm`/`clang`
+binaries (currently LLVM v8.0+ or Apple clang v11.0+).
+
+Arguments can be passed to `gn` by setting the `$GN_ARGS` environmental variable.
 
 Env vars used in when building from source: `SCCACHE`, `CCACHE`, `GN`, `NINJA`,
 `CLANG_BASE_PATH`, `GN_ARGS`

--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ install them.
 For Windows builds: the 64-bit toolchain needs to be used. 32-bit targets are
 not supported.
 
-The build depends on several binary tools: `gn`, `ninja` and a recent version
-of `clang` (V8 relies on bleeding edge features). The tools will automatically
-be downloaded, if they are not detected in the environment.
+The build depends on several binary tools: `gn`, `ninja` and `clang`. The
+tools will automatically be downloaded, if they are not detected in the environment.
 
 Specifying the `$GN` and `$NINJA` environmental variables can be used to skip
 the download of gn and ninja. The clang download can be skipped by setting

--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ be downloaded, if they are not detected in the environment.
 
 Specifying the `$GN` and `$NINJA` environmental variables can be used to skip
 the download of gn and ninja. The clang download can be skipped by setting
-`$CLANG_BASE_PATH` to the directory containing recent `llvm`/`clang`
-binaries (currently LLVM v8.0+ or Apple clang v11.0+).
+`$CLANG_BASE_PATH` to the directory containing a `llvm`/`clang` installation.
+V8 is known to rely on bleeding edge features, so LLVM v8.0+ or Apple clang 11.0+
+is recommended.
 
 Arguments can be passed to `gn` by setting the `$GN_ARGS` environmental variable.
 

--- a/build.rs
+++ b/build.rs
@@ -287,8 +287,10 @@ fn print_link_flags() {
 }
 
 fn need_gn_ninja_download() -> bool {
-  !((which("ninja").is_ok() || env::var_os("NINJA").is_some())
-    && env::var_os("GN").is_some())
+  let has_ninja = which("ninja").is_ok() || env::var_os("NINJA").is_some();
+  let has_gn = which("gn").is_ok() || env::var_os("GN").is_some();
+
+  return !has_ninja || !has_gn;
 }
 
 // Chromiums gn arg clang_base_path is currently compatible with:


### PR DESCRIPTION
This should allow people to build without explicitly setting `GN` and `NINJA` env vars.

If the tool(s) are detected, the build will continue without trying to download the binaries.