### PR TITLE
Use "include" to specify kept files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,17 +36,20 @@ exclude = [
  "v8/docs/",
  "v8/samples/",
  "v8/test/",
- "v8/tools/",
+ "v8/tools/"
+]
+
+include = [
  # These files are required for the build.
- "!.gn",
- "!BUILD.gn",
- "!tools/clang/scripts/update.py",
- "!v8/test/torque/test-torque.tq",
- "!v8/tools/gen-postmortem-metadata.py",
- "!v8/tools/js2c.py",
- "!v8/tools/run.py",
- "!v8/tools/snapshot/asm_to_inline_asm.py",
- "!v8/tools/testrunner/utils/dump_build_config.py",
+ ".gn",
+ "BUILD.gn",
+ "tools/clang/scripts/update.py",
+ "v8/test/torque/test-torque.tq",
+ "v8/tools/gen-postmortem-metadata.py",
+ "v8/tools/js2c.py",
+ "v8/tools/run.py",
+ "v8/tools/snapshot/asm_to_inline_asm.py",
+ "v8/tools/testrunner/utils/dump_build_config.py",
 ]
 
 [dependencies]


### PR DESCRIPTION
Ref: [include/exclude in Cargo manual](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields).

This should fix the problem of `.gn` and other files being missing from the crate, though I'm not sure how I can test that (haven't worked much with crates).

`BUILD.gn` _is_ there however, so I wonder if this points to a bug in Cargo? I'm hoping that the explicit `include` setting will help the case here.

```bash
shm/vendor/rusty_v8 is 📦 v0.14.0 via 🦀 v1.47.0
❯ ls -lrath
total 436K
-rw-r--r--   1 avindra users 2.0K Dec 19 04:07 Cargo.toml
-rw-r--r--   1 avindra users 5.5K Dec 19 04:07 Cargo.lock
-rw-r--r--   1 avindra users 1.2K Dec 19 04:07 BUILD.gn
drwxr-xr-x   3 avindra users   60 Dec 19 04:07 base/
-rw-r--r--   1 avindra users  10K Dec 19 04:07 build.rs
drwxr-xr-x  15 avindra users 1.6K Dec 19 04:07 build/
drwxr-xr-x   6 avindra users  120 Dec 19 04:07 third_party/
drwxr-xr-x   3 avindra users  160 Dec 19 04:07 tests/
drwxr-xr-x   3 avindra users  920 Dec 19 04:07 src/
drwxr-xr-x   2 avindra users  120 Dec 19 04:07 examples/
drwxr-xr-x   7 avindra users  200 Dec 19 04:07 buildtools/
drwxr-xr-x   3 avindra users  120 Dec 19 04:07 tools/
drwxr-xr-x   9 avindra users  280 Dec 19 04:07 v8/
-rw-r--r--   1 avindra users 406K Dec 19 04:07 .cargo-checksum.json
drwxr-xr-x  11 avindra users  320 Dec 19 04:07 ./
drwxr-xr-x 335 avindra users 6.6K Dec 19 04:07 ../

#### note: where is .gn? It's not in the crate...
```