### PR TITLE
Add methods for termination to Isolate

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -271,6 +271,21 @@ impl Isolate {
     IsolateHandle::new(self)
   }
 
+  /// See [`IsolateHandle::terminate_execution`]
+  pub fn terminate_execution(&mut self) -> bool {
+    self.thread_safe_handle().terminate_execution()
+  }
+
+  /// See [`IsolateHandle::cancel_terminate_execution`]
+  pub fn cancel_terminate_execution(&mut self) -> bool {
+    self.thread_safe_handle().cancel_terminate_execution()
+  }
+
+  /// See [`IsolateHandle::is_execution_terminating`]
+  pub fn is_execution_terminating(&mut self) -> bool {
+    self.thread_safe_handle().is_execution_terminating()
+  }
+
   pub(crate) fn create_annex(
     &mut self,
     create_param_allocations: Box<dyn Any>,


### PR DESCRIPTION
This commit adds following methods to Isolate:
- terminate_execution
- cancel_terminate_execution
- is_execution_terminating

Addresses following TODOs from `deno_core`:
- https://github.com/denoland/deno/blob/b15539587e7cf6b67c2ae7d4dc39901634bf6bd5/core/runtime.rs#L607-L610
- https://github.com/denoland/deno/blob/b15539587e7cf6b67c2ae7d4dc39901634bf6bd5/core/runtime.rs#L616-L618
- https://github.com/denoland/deno/blob/b15539587e7cf6b67c2ae7d4dc39901634bf6bd5/core/runtime.rs#L641-L643

