### PR TITLE
Revert "Use "include" to specify kept files (#559)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,20 +36,17 @@ exclude = [
  "v8/docs/",
  "v8/samples/",
  "v8/test/",
- "v8/tools/"
-]
-
-include = [
+ "v8/tools/",
  # These files are required for the build.
- ".gn",
- "BUILD.gn",
- "tools/clang/scripts/update.py",
- "v8/test/torque/test-torque.tq",
- "v8/tools/gen-postmortem-metadata.py",
- "v8/tools/js2c.py",
- "v8/tools/run.py",
- "v8/tools/snapshot/asm_to_inline_asm.py",
- "v8/tools/testrunner/utils/dump_build_config.py",
+ "!.gn",
+ "!BUILD.gn",
+ "!tools/clang/scripts/update.py",
+ "!v8/test/torque/test-torque.tq",
+ "!v8/tools/gen-postmortem-metadata.py",
+ "!v8/tools/js2c.py",
+ "!v8/tools/run.py",
+ "!v8/tools/snapshot/asm_to_inline_asm.py",
+ "!v8/tools/testrunner/utils/dump_build_config.py",
 ]
 
 [dependencies]


### PR DESCRIPTION
This reverts commit e057d096fd67bd273bb261d0ef2fdeb65ab9b815.

That commit caused failure of `cargo publish`:
```
Run cargo publish -vv
    Updating crates.io index
warning: both package.include and package.exclude are specified; the exclude list will be ignored
```