### PR TITLE
Remove set_flags_from_command_line_with_usage test

### DIFF
--- a/src/V8.rs
+++ b/src/V8.rs
@@ -89,6 +89,21 @@ pub fn assert_initialized() {
 pub fn set_flags_from_command_line(args: Vec<String>) -> Vec<String> {
   set_flags_from_command_line_with_usage(args, None)
 }
+
+/// The example code below is here to avoid the V8 usage string and options
+/// that are printed to stdout by this function. Placing this here instead of
+/// in a test allows the output to be suppressed.
+///
+/// # Examples
+///
+/// ```
+///     use rusty_v8 as v8;
+///     let r = v8::V8::set_flags_from_command_line_with_usage(
+///       vec!["binaryname".to_string(), "--help".to_string()],
+///       Some("Usage: binaryname --startup-src=file\n\n"),
+///     );
+///     assert_eq!(r, vec!["binaryname".to_string()]);
+/// ```
 pub fn set_flags_from_command_line_with_usage(
   args: Vec<String>,
   usage: Option<&str>,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1010,15 +1010,6 @@ fn set_flags_from_command_line() {
 }
 
 #[test]
-fn set_flags_from_command_line_with_usage() {
-  let r = v8::V8::set_flags_from_command_line_with_usage(
-    vec!["binaryname".to_string(), "--help".to_string()],
-    Some("Usage: binaryname --startup-src=file\n\n"),
-  );
-  assert_eq!(r, vec!["binaryname".to_string()]);
-}
-
-#[test]
 fn inspector_string_view() {
   let chars = b"Hello world!";
   let view = v8::inspector::StringView::from(&chars[..]);


### PR DESCRIPTION
This commit removes the set_flags_from_command_line_with_usage and puts
it in an example code section instead.

The motivation for doing this is that the test output currently contains
the usage string and all the V8 options which creates a lot of output
when the tests is run regardless if --nocapture is used or not.