### PR TITLE
Expose v8::WriteOptions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ pub use snapshot::FunctionCodeHandling;
 pub use snapshot::SnapshotCreator;
 pub use snapshot::StartupData;
 pub use string::NewStringType;
+pub use string::WriteOptions;
 pub use support::SharedPtr;
 pub use support::SharedRef;
 pub use support::UniquePtr;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -156,6 +156,15 @@ fn test_string() {
     assert_eq!(15, local.length());
     assert_eq!(17, local.utf8_length(scope));
     assert_eq!(reference, local.to_rust_string_lossy(scope));
+    let mut vec = Vec::new();
+    vec.resize(17, 0);
+    let options = v8::WriteOptions::NO_NULL_TERMINATION;
+    let mut nchars = 0;
+    assert_eq!(
+      17,
+      local.write_utf8(scope, &mut vec, Some(&mut nchars), options)
+    );
+    assert_eq!(15, nchars);
   }
   {
     let scope = &mut v8::HandleScope::new(isolate);


### PR DESCRIPTION
Without it, v8::String::write_utf8() is pretty much unusable.