### PR TITLE
Exclude tools/clang from publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ exclude = [
  "buildtools/third_party/libc++/trunk/utils/",
  "buildtools/third_party/libc++/trunk/www/",
  "buildtools/third_party/libc++abi/trunk/test/",
+ "tools/clang",
  "v8/ChangeLog",
  "v8/benchmarks/",
  "v8/docs/",


### PR DESCRIPTION
The only file that is actually needed is tools/clang/scripts/update.py
and that's already explicitly excluded from the exclude list.

Shrinks the (unpacked) crate size by 2.4 MB.