### PR TITLE
Revert "upgrade sccache (#592)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           SCCACHE_CACHE_SIZE: 128M
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
-          $version = "v0.2.15"
+          $version = "0.2.12"
           $platform =
             @{ "macOS"   = "x86_64-apple-darwin"
                "Linux"   = "x86_64-unknown-linux-musl"
@@ -158,7 +158,6 @@ jobs:
           cd ~
           curl -LO $url
           tar -xzvf "$basename.tar.gz"
-          chmod u+x $basename/sccache
           . $basename/sccache --start-server
           echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 


### PR DESCRIPTION
Doesn't work correctly on windows.

This reverts commit c623c451b1d04f262be030754a164ac949933544.