### PR TITLE
Fix ValueDeserializer::read_value() lifetime

### DIFF
--- a/src/value_deserializer.rs
+++ b/src/value_deserializer.rs
@@ -261,7 +261,10 @@ pub trait ValueDeserializerHelper {
     .into()
   }
 
-  fn read_value(&mut self, context: Local<Context>) -> Option<Local<Value>> {
+  fn read_value<'s>(
+    &mut self,
+    context: Local<'s, Context>,
+  ) -> Option<Local<'s, Value>> {
     unsafe {
       Local::from_raw(v8__ValueDeserializer__ReadValue(
         self.get_cxx_value_deserializer(),
@@ -413,10 +416,10 @@ impl<'a, 's> ValueDeserializer<'a, 's> {
     }
   }
 
-  pub fn read_value(
+  pub fn read_value<'t>(
     &mut self,
-    context: Local<Context>,
-  ) -> Option<Local<Value>> {
+    context: Local<'t, Context>,
+  ) -> Option<Local<'t, Value>> {
     (*self.value_deserializer_heap).read_value(context)
   }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4240,6 +4240,7 @@ fn value_serializer_and_deserializer_js_objects() {
     let name = v8::String::new(scope, "objects").unwrap();
     let objects: v8::Local<v8::Value> =
       value_deserializer.read_value(context).unwrap();
+    drop(value_deserializer);
 
     context.global(scope).set(scope, name.into(), objects);
 
@@ -4343,6 +4344,7 @@ fn value_serializer_and_deserializer_array_buffers() {
     let name = v8::String::new(scope, "objects").unwrap();
     let objects: v8::Local<v8::Value> =
       value_deserializer.read_value(context).unwrap();
+    drop(value_deserializer);
 
     context.global(scope).set(scope, name.into(), objects);
 


### PR DESCRIPTION
The return value should have the lifetime of the context, not the
deserializer.

Fixes #607.