### PR TITLE
Hack ICU build scripts so we don't have to depend on icudata file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,4 @@
 	url = https://chromium.googlesource.com/chromium/src/third_party/zlib.git
 [submodule "third_party/icu"]
 	path = third_party/icu
-	url = https://chromium.googlesource.com/chromium/deps/icu.git
+	url = https://github.com/denoland/icu.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "rusty_v8"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "bitflags",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_v8"
-version = "0.18.0"
+version = "0.18.1"
 description = "Rust bindings to V8"
 readme = "README.md"
 authors = ["the Deno authors"]


### PR DESCRIPTION
Here is the hack: https://github.com/denoland/icu/commit/28b0e9ea59878fdd1682593be2ac489a6a6bbb21

Note the size of [0.18.0](https://crates.io/crates/rusty_v8/0.18.0)  on crates.io  is 19.5 MB. This change will bring that back down to a reasonable level.