### PR TITLE
Re-enable aarch64 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
             target: x86_64-apple-darwin
             variant: release
 
-          - os: ubuntu-latest-xl
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
             target: x86_64-unknown-linux-gnu
             variant: debug
 
-          - os: ubuntu-latest-xl
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
             target: x86_64-unknown-linux-gnu
             variant: release
 
@@ -41,18 +41,13 @@ jobs:
             target: x86_64-pc-windows-msvc
             variant: release # Note: we do not support windows debug builds.
 
-          # Disabled because an apparent sscache bug causes it to crash with the
-          # following error:
-          #   [rusty_v8 0.15.0] sccache: error : Invalid checksum
-          #   [rusty_v8 0.15.0] sccache: error : corrupt deflate stream
-          #
-          # - os: ubuntu-latest-xl
-          #   target: aarch64-unknown-linux-gnu
-          #   variant: debug
-          #
-          # - os: ubuntu-latest-xl
-          #   target: aarch64-unknown-linux-gnu
-          #   variant: release
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+            target: aarch64-unknown-linux-gnu
+            variant: debug
+          
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+            target: aarch64-unknown-linux-gnu
+            variant: release
 
     env:
       V8_FROM_SOURCE: true


### PR DESCRIPTION
This PR:

-  re-enables `aarch64-unknown-linux-gnu` builds
- Updates the workflow to only use `ubuntu-latest-xl` on `denoland/rusty_v8`, since this runner is not available in regular repos (just to make forking a bit easier).

This PR doesn't do anything different to #589, and I suspect the issue lies with `denoland/rusty_v8`'s cache, since simply re-enabling the `aarch64-unknown-linux-gnu` builds "just worked" in my fork.

🤞