### PR TITLE
Add code cache API.

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -345,6 +345,11 @@ v8::ScriptCompiler::CachedData* v8__ScriptCompiler__CachedData__NEW(
       data, length, v8::ScriptCompiler::CachedData::BufferNotOwned);
 }
 
+void v8__ScriptCompiler__CachedData__DELETE(
+    v8::ScriptCompiler::CachedData* self) {
+  delete self;
+}
+
 const v8::ScriptCompiler::CachedData* v8__ScriptCompiler__Source__GetCachedData(
     const v8::ScriptCompiler::Source* source) {
   return source->GetCachedData();
@@ -1583,6 +1588,17 @@ const v8::UnboundScript* v8__Script__GetUnboundScript(
 const v8::Script* v8__UnboundScript__BindToCurrentContext(
     const v8::UnboundScript& unbound_script) {
   return local_to_ptr(ptr_to_local(&unbound_script)->BindToCurrentContext());
+}
+
+v8::ScriptCompiler::CachedData* v8__UnboundScript__CreateCodeCache(
+    const v8::UnboundScript& unbound_script) {
+  return v8::ScriptCompiler::CreateCodeCache(ptr_to_local(&unbound_script));
+}
+
+v8::ScriptCompiler::CachedData* v8__UnboundModuleScript__CreateCodeCache(
+    const v8::UnboundModuleScript& unbound_module_script) {
+  return v8::ScriptCompiler::CreateCodeCache(
+      ptr_to_local(&unbound_module_script));
 }
 
 const v8::Value* v8__Script__Run(const v8::Script& script,

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -64,6 +64,17 @@ static_assert(sizeof(v8::CFunction) == sizeof(size_t) * 2,
 static_assert(sizeof(three_pointers_t) == sizeof(v8_inspector::StringView),
               "StringView size mismatch");
 
+static_assert(sizeof(v8::ScriptCompiler::CachedData) == 24,
+              "CachedData size mismatch");
+static_assert(offsetof(v8::ScriptCompiler::CachedData, data) == 0,
+              "CachedData.data offset mismatch");
+static_assert(offsetof(v8::ScriptCompiler::CachedData, length) == 8,
+              "CachedData.length offset mismatch");
+static_assert(offsetof(v8::ScriptCompiler::CachedData, rejected) == 12,
+              "CachedData.rejected offset mismatch");
+static_assert(offsetof(v8::ScriptCompiler::CachedData, buffer_policy) == 16,
+              "CachedData.buffer_policy offset mismatch");
+
 enum InternalSlots {
   kSlotDynamicImport = 0,
   kNumInternalSlots,

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -64,7 +64,7 @@ static_assert(sizeof(v8::CFunction) == sizeof(size_t) * 2,
 static_assert(sizeof(three_pointers_t) == sizeof(v8_inspector::StringView),
               "StringView size mismatch");
 
-#if INTPTR_MAX == INT64_MAX
+#if INTPTR_MAX == INT64_MAX  // 64-bit platforms
 static_assert(sizeof(v8::ScriptCompiler::CachedData) == 24,
               "CachedData size mismatch");
 static_assert(offsetof(v8::ScriptCompiler::CachedData, data) == 0,

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -64,6 +64,7 @@ static_assert(sizeof(v8::CFunction) == sizeof(size_t) * 2,
 static_assert(sizeof(three_pointers_t) == sizeof(v8_inspector::StringView),
               "StringView size mismatch");
 
+#if INTPTR_MAX == INT64_MAX
 static_assert(sizeof(v8::ScriptCompiler::CachedData) == 24,
               "CachedData size mismatch");
 static_assert(offsetof(v8::ScriptCompiler::CachedData, data) == 0,
@@ -74,6 +75,18 @@ static_assert(offsetof(v8::ScriptCompiler::CachedData, rejected) == 12,
               "CachedData.rejected offset mismatch");
 static_assert(offsetof(v8::ScriptCompiler::CachedData, buffer_policy) == 16,
               "CachedData.buffer_policy offset mismatch");
+#else
+static_assert(sizeof(v8::ScriptCompiler::CachedData) == 16,
+              "CachedData size mismatch");
+static_assert(offsetof(v8::ScriptCompiler::CachedData, data) == 0,
+              "CachedData.data offset mismatch");
+static_assert(offsetof(v8::ScriptCompiler::CachedData, length) == 4,
+              "CachedData.length offset mismatch");
+static_assert(offsetof(v8::ScriptCompiler::CachedData, rejected) == 8,
+              "CachedData.rejected offset mismatch");
+static_assert(offsetof(v8::ScriptCompiler::CachedData, buffer_policy) == 12,
+              "CachedData.buffer_policy offset mismatch");
+#endif
 
 enum InternalSlots {
   kSlotDynamicImport = 0,

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -329,13 +329,25 @@ void v8__Global__Reset(const v8::Data* data) {
 
 void v8__ScriptCompiler__Source__CONSTRUCT(
     uninit_t<v8::ScriptCompiler::Source>* buf, const v8::String& source_string,
-    const v8::ScriptOrigin& origin) {
+    const v8::ScriptOrigin& origin,
+    v8::ScriptCompiler::CachedData* cached_data) {
   construct_in_place<v8::ScriptCompiler::Source>(
-      buf, ptr_to_local(&source_string), origin);
+      buf, ptr_to_local(&source_string), origin, cached_data);
 }
 
 void v8__ScriptCompiler__Source__DESTRUCT(v8::ScriptCompiler::Source* self) {
   self->~Source();
+}
+
+v8::ScriptCompiler::CachedData* v8__ScriptCompiler__CachedData__NEW(
+    const uint8_t* data, int length) {
+  return new v8::ScriptCompiler::CachedData(
+      data, length, v8::ScriptCompiler::CachedData::BufferNotOwned);
+}
+
+const v8::ScriptCompiler::CachedData* v8__ScriptCompiler__Source__GetCachedData(
+    const v8::ScriptCompiler::Source* source) {
+  return source->GetCachedData();
 }
 
 const v8::Module* v8__ScriptCompiler__CompileModule(
@@ -2119,7 +2131,13 @@ MaybeBool v8__Module__SetSyntheticModuleExport(const v8::Module& self,
       isolate, ptr_to_local(export_name), ptr_to_local(export_value)));
 }
 
-const v8::String* v8__ModuleRequest__GetSpecifier(const v8::ModuleRequest& self) {
+const v8::UnboundModuleScript* v8__Module__GetUnboundModuleScript(
+    const v8::Module& self) {
+  return local_to_ptr(ptr_to_local(&self)->GetUnboundModuleScript());
+}
+
+const v8::String* v8__ModuleRequest__GetSpecifier(
+    const v8::ModuleRequest& self) {
   return local_to_ptr(self.GetSpecifier());
 }
 
@@ -2127,7 +2145,8 @@ int v8__ModuleRequest__GetSourceOffset(const v8::ModuleRequest& self) {
   return self.GetSourceOffset();
 }
 
-const v8::FixedArray* v8__ModuleRequest__GetImportAssertions(const v8::ModuleRequest& self) {
+const v8::FixedArray* v8__ModuleRequest__GetImportAssertions(
+    const v8::ModuleRequest& self) {
   return local_to_ptr(self.GetImportAssertions());
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ pub use scope::EscapableHandleScope;
 pub use scope::HandleScope;
 pub use scope::TryCatch;
 pub use script::ScriptOrigin;
+pub use script_compiler::CachedData;
 pub use snapshot::FunctionCodeHandling;
 pub use snapshot::SnapshotCreator;
 pub use snapshot::StartupData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ mod support;
 mod symbol;
 mod template;
 mod typed_array;
+mod unbound_module_script;
 mod unbound_script;
 mod value;
 mod value_deserializer;

--- a/src/module.rs
+++ b/src/module.rs
@@ -18,6 +18,7 @@ use crate::Local;
 use crate::Module;
 use crate::ModuleRequest;
 use crate::String;
+use crate::UnboundModuleScript;
 use crate::Value;
 
 /// Called during Module::instantiate_module. Provided with arguments:
@@ -177,6 +178,9 @@ extern "C" {
     export_name: *const String,
     export_value: *const Value,
   ) -> MaybeBool;
+  fn v8__Module__GetUnboundModuleScript(
+    this: *const Module,
+  ) -> *const UnboundModuleScript;
   fn v8__Location__GetLineNumber(this: *const Location) -> int;
   fn v8__Location__GetColumnNumber(this: *const Location) -> int;
   fn v8__ModuleRequest__GetSpecifier(
@@ -421,6 +425,17 @@ impl Module {
       )
     }
     .into()
+  }
+
+  pub fn get_unbound_module_script<'s>(
+    &self,
+    scope: &mut HandleScope<'s>,
+  ) -> Local<'s, UnboundModuleScript> {
+    unsafe {
+      scope
+        .cast_local(|_| v8__Module__GetUnboundModuleScript(self))
+        .unwrap()
+    }
   }
 }
 

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -1,21 +1,28 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
-use std::mem::MaybeUninit;
+use std::{marker::PhantomData, mem::MaybeUninit};
 
-use crate::HandleScope;
 use crate::Isolate;
 use crate::Local;
 use crate::Module;
 use crate::ScriptOrigin;
 use crate::String;
+use crate::{HandleScope, UniqueRef};
 
 extern "C" {
   fn v8__ScriptCompiler__Source__CONSTRUCT(
     buf: *mut MaybeUninit<Source>,
     source_string: *const String,
     origin: *const ScriptOrigin,
+    cached_data: *mut CachedData,
   );
   fn v8__ScriptCompiler__Source__DESTRUCT(this: *mut Source);
-
+  fn v8__ScriptCompiler__Source__GetCachedData<'a>(
+    this: *const Source,
+  ) -> *const CachedData<'a>;
+  fn v8__ScriptCompiler__CachedData__NEW<'a>(
+    data: *const u8,
+    length: i32,
+  ) -> *mut CachedData<'a>;
   fn v8__ScriptCompiler__CompileModule(
     isolate: *mut Isolate,
     source: *mut Source,
@@ -29,14 +36,78 @@ extern "C" {
 #[derive(Debug)]
 pub struct Source([usize; 8]);
 
+/// Compilation data that the embedder can cache and pass back to speed up future
+/// compilations. The data is produced if the CompilerOptions passed to the compilation
+/// functions in ScriptCompiler contains produce_data_to_cache = true. The data to cache
+/// can then can be retrieved from UnboundScript.
+#[repr(C)]
+#[derive(Debug)]
+pub struct CachedData<'a> {
+  data: *const u8,
+  length: i32,
+  rejected: bool,
+  buffer_policy: BufferPolicy,
+  _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> CachedData<'a> {
+  pub fn new(data: &'a [u8]) -> UniqueRef<Self> {
+    unsafe {
+      UniqueRef::from_raw(v8__ScriptCompiler__CachedData__NEW(
+        data.as_ptr(),
+        data.len() as i32,
+      ))
+    }
+  }
+}
+
+impl<'a> std::ops::Deref for CachedData<'a> {
+  type Target = [u8];
+  fn deref(&self) -> &Self::Target {
+    unsafe { std::slice::from_raw_parts(self.data, self.length as usize) }
+  }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+enum BufferPolicy {
+  BufferNotOwned = 0,
+  BufferOwned,
+}
+
 impl Source {
-  // TODO(ry) cached_data
   pub fn new(source_string: Local<String>, origin: &ScriptOrigin) -> Self {
     let mut buf = MaybeUninit::<Self>::uninit();
     unsafe {
-      v8__ScriptCompiler__Source__CONSTRUCT(&mut buf, &*source_string, origin);
+      v8__ScriptCompiler__Source__CONSTRUCT(
+        &mut buf,
+        &*source_string,
+        origin,
+        std::ptr::null_mut(),
+      );
       buf.assume_init()
     }
+  }
+
+  pub fn new_with_cached_data(
+    source_string: Local<String>,
+    origin: &ScriptOrigin,
+    cached_data: UniqueRef<CachedData>,
+  ) -> Self {
+    let mut buf = MaybeUninit::<Self>::uninit();
+    unsafe {
+      v8__ScriptCompiler__Source__CONSTRUCT(
+        &mut buf,
+        &*source_string,
+        origin,
+        cached_data.into_raw(),
+      );
+      buf.assume_init()
+    }
+  }
+
+  pub fn get_cached_data(&self) -> &CachedData {
+    unsafe { &*v8__ScriptCompiler__Source__GetCachedData(self) }
   }
 }
 

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -109,7 +109,7 @@ impl Source {
         &mut buf,
         &*source_string,
         origin,
-        cached_data.into_raw(),
+        cached_data.into_raw(), // Source constructor takes ownership.
       );
       buf.assume_init()
     }

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -23,6 +23,7 @@ extern "C" {
     data: *const u8,
     length: i32,
   ) -> *mut CachedData<'a>;
+  fn v8__ScriptCompiler__CachedData__DELETE<'a>(this: *mut CachedData<'a>);
   fn v8__ScriptCompiler__CompileModule(
     isolate: *mut Isolate,
     source: *mut Source,
@@ -48,6 +49,14 @@ pub struct CachedData<'a> {
   rejected: bool,
   buffer_policy: BufferPolicy,
   _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> Drop for CachedData<'a> {
+  fn drop(&mut self) {
+    unsafe {
+      v8__ScriptCompiler__CachedData__DELETE(self);
+    }
+  }
 }
 
 impl<'a> CachedData<'a> {

--- a/src/support.rs
+++ b/src/support.rs
@@ -106,12 +106,12 @@ impl<T> From<UniqueRef<T>> for UniquePtr<T> {
 pub struct UniqueRef<T: ?Sized>(NonNull<T>);
 
 impl<T> UniqueRef<T> {
-  pub unsafe fn try_from_raw(ptr: *mut T) -> Option<Self> {
+  pub(crate) unsafe fn try_from_raw(ptr: *mut T) -> Option<Self> {
     assert_unique_ptr_layout_compatible::<Self, T>();
     NonNull::new(ptr).map(Self)
   }
 
-  pub unsafe fn from_raw(ptr: *mut T) -> Self {
+  pub(crate) unsafe fn from_raw(ptr: *mut T) -> Self {
     assert_unique_ptr_layout_compatible::<Self, T>();
     Self::try_from_raw(ptr).unwrap()
   }

--- a/src/support.rs
+++ b/src/support.rs
@@ -106,7 +106,7 @@ impl<T> From<UniqueRef<T>> for UniquePtr<T> {
 pub struct UniqueRef<T: ?Sized>(NonNull<T>);
 
 impl<T> UniqueRef<T> {
-  unsafe fn try_from_raw(ptr: *mut T) -> Option<Self> {
+  pub unsafe fn try_from_raw(ptr: *mut T) -> Option<Self> {
     assert_unique_ptr_layout_compatible::<Self, T>();
     NonNull::new(ptr).map(Self)
   }

--- a/src/unbound_module_script.rs
+++ b/src/unbound_module_script.rs
@@ -1,0 +1,22 @@
+use crate::script_compiler::CachedData;
+use crate::UnboundModuleScript;
+use crate::UniqueRef;
+
+extern "C" {
+  fn v8__UnboundModuleScript__CreateCodeCache(
+    script: *const UnboundModuleScript,
+  ) -> *mut CachedData<'static>;
+}
+
+impl UnboundModuleScript {
+  /// Creates and returns code cache for the specified unbound_module_script.
+  /// This will return nullptr if the script cannot be serialized. The
+  /// CachedData returned by this function should be owned by the caller.
+  pub fn create_code_cache<'s>(
+    &self,
+  ) -> Option<UniqueRef<CachedData<'static>>> {
+    unsafe {
+      UniqueRef::try_from_raw(v8__UnboundModuleScript__CreateCodeCache(self))
+    }
+  }
+}

--- a/src/unbound_module_script.rs
+++ b/src/unbound_module_script.rs
@@ -12,9 +12,7 @@ impl UnboundModuleScript {
   /// Creates and returns code cache for the specified unbound_module_script.
   /// This will return nullptr if the script cannot be serialized. The
   /// CachedData returned by this function should be owned by the caller.
-  pub fn create_code_cache(
-    &self,
-  ) -> Option<UniqueRef<CachedData<'static>>> {
+  pub fn create_code_cache(&self) -> Option<UniqueRef<CachedData<'static>>> {
     unsafe {
       UniqueRef::try_from_raw(v8__UnboundModuleScript__CreateCodeCache(self))
     }

--- a/src/unbound_module_script.rs
+++ b/src/unbound_module_script.rs
@@ -12,7 +12,7 @@ impl UnboundModuleScript {
   /// Creates and returns code cache for the specified unbound_module_script.
   /// This will return nullptr if the script cannot be serialized. The
   /// CachedData returned by this function should be owned by the caller.
-  pub fn create_code_cache<'s>(
+  pub fn create_code_cache(
     &self,
   ) -> Option<UniqueRef<CachedData<'static>>> {
     unsafe {

--- a/src/unbound_module_script.rs
+++ b/src/unbound_module_script.rs
@@ -1,4 +1,4 @@
-use crate::script_compiler::CachedData;
+use crate::CachedData;
 use crate::UnboundModuleScript;
 use crate::UniqueRef;
 

--- a/src/unbound_script.rs
+++ b/src/unbound_script.rs
@@ -1,4 +1,4 @@
-use crate::script_compiler::CachedData;
+use crate::CachedData;
 use crate::Local;
 use crate::Script;
 use crate::UnboundScript;

--- a/src/unbound_script.rs
+++ b/src/unbound_script.rs
@@ -1,12 +1,16 @@
-use crate::HandleScope;
+use crate::script_compiler::CachedData;
 use crate::Local;
 use crate::Script;
 use crate::UnboundScript;
+use crate::{HandleScope, UniqueRef};
 
 extern "C" {
   fn v8__UnboundScript__BindToCurrentContext(
     script: *const UnboundScript,
   ) -> *const Script;
+  fn v8__UnboundScript__CreateCodeCache(
+    script: *const UnboundScript,
+  ) -> *mut CachedData<'static>;
 }
 
 impl UnboundScript {
@@ -19,5 +23,14 @@ impl UnboundScript {
       scope.cast_local(|_| v8__UnboundScript__BindToCurrentContext(self))
     }
     .unwrap()
+  }
+
+  /// Creates and returns code cache for the specified unbound_script.
+  /// This will return nullptr if the script cannot be serialized. The
+  /// CachedData returned by this function should be owned by the caller.
+  pub fn create_code_cache<'s>(
+    &self,
+  ) -> Option<UniqueRef<CachedData<'static>>> {
+    unsafe { UniqueRef::try_from_raw(v8__UnboundScript__CreateCodeCache(self)) }
   }
 }

--- a/src/unbound_script.rs
+++ b/src/unbound_script.rs
@@ -28,7 +28,7 @@ impl UnboundScript {
   /// Creates and returns code cache for the specified unbound_script.
   /// This will return nullptr if the script cannot be serialized. The
   /// CachedData returned by this function should be owned by the caller.
-  pub fn create_code_cache<'s>(
+  pub fn create_code_cache(
     &self,
   ) -> Option<UniqueRef<CachedData<'static>>> {
     unsafe { UniqueRef::try_from_raw(v8__UnboundScript__CreateCodeCache(self)) }

--- a/src/unbound_script.rs
+++ b/src/unbound_script.rs
@@ -28,9 +28,7 @@ impl UnboundScript {
   /// Creates and returns code cache for the specified unbound_script.
   /// This will return nullptr if the script cannot be serialized. The
   /// CachedData returned by this function should be owned by the caller.
-  pub fn create_code_cache(
-    &self,
-  ) -> Option<UniqueRef<CachedData<'static>>> {
+  pub fn create_code_cache(&self) -> Option<UniqueRef<CachedData<'static>>> {
     unsafe { UniqueRef::try_from_raw(v8__UnboundScript__CreateCodeCache(self)) }
   }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4858,26 +4858,23 @@ fn code_cache() {
     unbound_module_script.create_code_cache().unwrap().to_vec()
   };
 
-  {
-    let isolate = &mut v8::Isolate::new(Default::default());
-    let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
-    let mut scope = v8::ContextScope::new(scope, context);
-    let module =
-      create_module(&mut scope, CODE, Some(v8::CachedData::new(&code_cache)));
-    let mut scope = v8::HandleScope::new(&mut scope);
-    module
-      .instantiate_module(&mut scope, resolve_callback)
-      .unwrap();
-    module.evaluate(&mut scope).unwrap();
-    let top =
-      v8::Local::<v8::Object>::try_from(module.get_module_namespace()).unwrap();
-
-    let key = v8::String::new(&mut scope, "hello").unwrap();
-    let value = v8::Local::<v8::String>::try_from(
-      top.get(&mut scope, key.into()).unwrap(),
-    )
+  let isolate = &mut v8::Isolate::new(Default::default());
+  let scope = &mut v8::HandleScope::new(isolate);
+  let context = v8::Context::new(scope);
+  let mut scope = v8::ContextScope::new(scope, context);
+  let module =
+    create_module(&mut scope, CODE, Some(v8::CachedData::new(&code_cache)));
+  let mut scope = v8::HandleScope::new(&mut scope);
+  module
+    .instantiate_module(&mut scope, resolve_callback)
     .unwrap();
-    assert_eq!(&value.to_rust_string_lossy(&mut scope), "world");
-  }
+  module.evaluate(&mut scope).unwrap();
+  let top =
+    v8::Local::<v8::Object>::try_from(module.get_module_namespace()).unwrap();
+
+  let key = v8::String::new(&mut scope, "hello").unwrap();
+  let value =
+    v8::Local::<v8::String>::try_from(top.get(&mut scope, key.into()).unwrap())
+      .unwrap();
+  assert_eq!(&value.to_rust_string_lossy(&mut scope), "world");
 }


### PR DESCRIPTION
This pull request exposes the V8 `CachedData` interface and supports:

- Creating code cache from `UnboundScript` and `UnboundModuleScript`.
- Creating `Source` with cached code.
