### PR TITLE
Add more ScriptCompiler APIs.

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -353,10 +353,15 @@ void v8__Global__Reset(const v8::Data* data) {
 
 void v8__ScriptCompiler__Source__CONSTRUCT(
     uninit_t<v8::ScriptCompiler::Source>* buf, const v8::String& source_string,
-    const v8::ScriptOrigin& origin,
+    const v8::ScriptOrigin* origin,
     v8::ScriptCompiler::CachedData* cached_data) {
-  construct_in_place<v8::ScriptCompiler::Source>(
-      buf, ptr_to_local(&source_string), origin, cached_data);
+  if (origin) {
+    construct_in_place<v8::ScriptCompiler::Source>(
+        buf, ptr_to_local(&source_string), *origin, cached_data);
+  } else {
+    construct_in_place<v8::ScriptCompiler::Source>(
+        buf, ptr_to_local(&source_string), cached_data);
+  }
 }
 
 void v8__ScriptCompiler__Source__DESTRUCT(v8::ScriptCompiler::Source* self) {
@@ -385,6 +390,25 @@ const v8::Module* v8__ScriptCompiler__CompileModule(
     v8::ScriptCompiler::NoCacheReason no_cache_reason) {
   v8::MaybeLocal<v8::Module> maybe_local = v8::ScriptCompiler::CompileModule(
       isolate, source, options, no_cache_reason);
+  return maybe_local_to_ptr(maybe_local);
+}
+
+const v8::Script* v8__ScriptCompiler__Compile(
+    const v8::Context* context, v8::ScriptCompiler::Source* source,
+    v8::ScriptCompiler::CompileOptions options,
+    v8::ScriptCompiler::NoCacheReason no_cache_reason) {
+  v8::MaybeLocal<v8::Script> maybe_local = v8::ScriptCompiler::Compile(
+      ptr_to_local(context), source, options, no_cache_reason);
+  return maybe_local_to_ptr(maybe_local);
+}
+
+const v8::UnboundScript* v8__ScriptCompiler__CompileUnboundScript(
+    v8::Isolate* isolate, v8::ScriptCompiler::Source* source,
+    v8::ScriptCompiler::CompileOptions options,
+    v8::ScriptCompiler::NoCacheReason no_cache_reason) {
+  v8::MaybeLocal<v8::UnboundScript> maybe_local =
+      v8::ScriptCompiler::CompileUnboundScript(isolate, source, options,
+                                               no_cache_reason);
   return maybe_local_to_ptr(maybe_local);
 }
 

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -97,44 +97,33 @@ enum BufferPolicy {
 }
 
 impl Source {
-  pub fn new<'a, 'b, T>(source_string: Local<String>, origin: T) -> Self
-  where
-    'a: 'b,
-    T: Into<Option<&'b ScriptOrigin<'a>>>,
-  {
+  pub fn new(
+    source_string: Local<String>,
+    origin: Option<&ScriptOrigin>,
+  ) -> Self {
     let mut buf = MaybeUninit::<Self>::uninit();
     unsafe {
       v8__ScriptCompiler__Source__CONSTRUCT(
         &mut buf,
         &*source_string,
-        origin
-          .into()
-          .map(|x| x as *const _)
-          .unwrap_or(std::ptr::null()),
+        origin.map(|x| x as *const _).unwrap_or(std::ptr::null()),
         std::ptr::null_mut(),
       );
       buf.assume_init()
     }
   }
 
-  pub fn new_with_cached_data<'a, 'b, T>(
+  pub fn new_with_cached_data(
     source_string: Local<String>,
-    origin: T,
+    origin: Option<&ScriptOrigin>,
     cached_data: UniqueRef<CachedData>,
-  ) -> Self
-  where
-    'a: 'b,
-    T: Into<Option<&'b ScriptOrigin<'a>>>,
-  {
+  ) -> Self {
     let mut buf = MaybeUninit::<Self>::uninit();
     unsafe {
       v8__ScriptCompiler__Source__CONSTRUCT(
         &mut buf,
         &*source_string,
-        origin
-          .into()
-          .map(|x| x as *const _)
-          .unwrap_or(std::ptr::null()),
+        origin.map(|x| x as *const _).unwrap_or(std::ptr::null()),
         cached_data.into_raw(), // Source constructor takes ownership.
       );
       buf.assume_init()

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -1,11 +1,11 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
 use std::{marker::PhantomData, mem::MaybeUninit};
 
-use crate::Isolate;
 use crate::Local;
 use crate::Module;
 use crate::ScriptOrigin;
 use crate::String;
+use crate::{Context, Isolate, Script, UnboundScript};
 use crate::{HandleScope, UniqueRef};
 
 extern "C" {
@@ -30,6 +30,18 @@ extern "C" {
     options: CompileOptions,
     no_cache_reason: NoCacheReason,
   ) -> *const Module;
+  fn v8__ScriptCompiler__Compile(
+    context: *const Context,
+    source: *mut Source,
+    options: CompileOptions,
+    no_cache_reason: NoCacheReason,
+  ) -> *const Script;
+  fn v8__ScriptCompiler__CompileUnboundScript(
+    isolate: *mut Isolate,
+    source: *mut Source,
+    options: CompileOptions,
+    no_cache_reason: NoCacheReason,
+  ) -> *const UnboundScript;
 }
 
 /// Source code which can then be compiled to a UnboundScript or Script.
@@ -85,30 +97,44 @@ enum BufferPolicy {
 }
 
 impl Source {
-  pub fn new(source_string: Local<String>, origin: &ScriptOrigin) -> Self {
+  pub fn new<'a, 'b, T>(source_string: Local<String>, origin: T) -> Self
+  where
+    'a: 'b,
+    T: Into<Option<&'b ScriptOrigin<'a>>>,
+  {
     let mut buf = MaybeUninit::<Self>::uninit();
     unsafe {
       v8__ScriptCompiler__Source__CONSTRUCT(
         &mut buf,
         &*source_string,
-        origin,
+        origin
+          .into()
+          .map(|x| x as *const _)
+          .unwrap_or(std::ptr::null()),
         std::ptr::null_mut(),
       );
       buf.assume_init()
     }
   }
 
-  pub fn new_with_cached_data(
+  pub fn new_with_cached_data<'a, 'b, T>(
     source_string: Local<String>,
-    origin: &ScriptOrigin,
+    origin: T,
     cached_data: UniqueRef<CachedData>,
-  ) -> Self {
+  ) -> Self
+  where
+    'a: 'b,
+    T: Into<Option<&'b ScriptOrigin<'a>>>,
+  {
     let mut buf = MaybeUninit::<Self>::uninit();
     unsafe {
       v8__ScriptCompiler__Source__CONSTRUCT(
         &mut buf,
         &*source_string,
-        origin,
+        origin
+          .into()
+          .map(|x| x as *const _)
+          .unwrap_or(std::ptr::null()),
         cached_data.into_raw(), // Source constructor takes ownership.
       );
       buf.assume_init()
@@ -182,6 +208,42 @@ pub fn compile_module2<'s>(
   unsafe {
     scope.cast_local(|sd| {
       v8__ScriptCompiler__CompileModule(
+        sd.get_isolate_ptr(),
+        &mut source,
+        options,
+        no_cache_reason,
+      )
+    })
+  }
+}
+
+pub fn compile<'s>(
+  scope: &mut HandleScope<'s>,
+  mut source: Source,
+  options: CompileOptions,
+  no_cache_reason: NoCacheReason,
+) -> Option<Local<'s, Script>> {
+  unsafe {
+    scope.cast_local(|sd| {
+      v8__ScriptCompiler__Compile(
+        &*sd.get_current_context(),
+        &mut source,
+        options,
+        no_cache_reason,
+      )
+    })
+  }
+}
+
+pub fn compile_unbound_script<'s>(
+  scope: &mut HandleScope<'s>,
+  mut source: Source,
+  options: CompileOptions,
+  no_cache_reason: NoCacheReason,
+) -> Option<Local<'s, UnboundScript>> {
+  unsafe {
+    scope.cast_local(|sd| {
+      v8__ScriptCompiler__CompileUnboundScript(
         sd.get_isolate_ptr(),
         &mut source,
         options,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1911,7 +1911,7 @@ fn mock_source<'s>(
 ) -> v8::script_compiler::Source {
   let source_str = v8::String::new(scope, source).unwrap();
   let script_origin = mock_script_origin(scope, resource_name);
-  v8::script_compiler::Source::new(source_str, &script_origin)
+  v8::script_compiler::Source::new(source_str, Some(&script_origin))
 }
 
 #[test]
@@ -1928,7 +1928,7 @@ fn script_compiler_source() {
     let script_origin = mock_script_origin(scope, "foo.js");
     let source = v8::script_compiler::Source::new(
       v8::String::new(scope, source).unwrap(),
-      &script_origin,
+      Some(&script_origin),
     );
 
     let result = v8::script_compiler::compile_module(scope, source);
@@ -1952,7 +1952,7 @@ fn module_instantiation_failures1() {
     )
     .unwrap();
     let origin = mock_script_origin(scope, "foo.js");
-    let source = v8::script_compiler::Source::new(source_text, &origin);
+    let source = v8::script_compiler::Source::new(source_text, Some(&origin));
 
     let module = v8::script_compiler::compile_module(scope, source).unwrap();
     assert_eq!(v8::ModuleStatus::Uninstantiated, module.get_status());
@@ -2015,7 +2015,7 @@ fn compile_specifier_as_module_resolve_callback<'a>(
 ) -> Option<v8::Local<'a, v8::Module>> {
   let scope = &mut unsafe { v8::CallbackScope::new(context) };
   let origin = mock_script_origin(scope, "module.js");
-  let source = v8::script_compiler::Source::new(specifier, &origin);
+  let source = v8::script_compiler::Source::new(specifier, Some(&origin));
   let module = v8::script_compiler::compile_module(scope, source).unwrap();
   Some(module)
 }
@@ -2036,7 +2036,7 @@ fn module_evaluation() {
     )
     .unwrap();
     let origin = mock_script_origin(scope, "foo.js");
-    let source = v8::script_compiler::Source::new(source_text, &origin);
+    let source = v8::script_compiler::Source::new(source_text, Some(&origin));
 
     let module = v8::script_compiler::compile_module(scope, source).unwrap();
     assert!(module.script_id().is_some());
@@ -2088,7 +2088,7 @@ fn import_assertions() {
 
     let origin = mock_script_origin(scope, "module.js");
     let src = v8::String::new(scope, "export const a = 'a';").unwrap();
-    let source = v8::script_compiler::Source::new(src, &origin);
+    let source = v8::script_compiler::Source::new(src, Some(&origin));
     let module = v8::script_compiler::compile_module(scope, source).unwrap();
     Some(module)
   }
@@ -2125,7 +2125,7 @@ fn import_assertions() {
     )
     .unwrap();
     let origin = mock_script_origin(scope, "foo.js");
-    let source = v8::script_compiler::Source::new(source_text, &origin);
+    let source = v8::script_compiler::Source::new(source_text, Some(&origin));
 
     let module = v8::script_compiler::compile_module(scope, source).unwrap();
     assert!(module.script_id().is_some());
@@ -3723,7 +3723,7 @@ fn module_snapshot() {
       )
       .unwrap();
       let origin = mock_script_origin(scope, "foo.js");
-      let source = v8::script_compiler::Source::new(source_text, &origin);
+      let source = v8::script_compiler::Source::new(source_text, Some(&origin));
 
       let module = v8::script_compiler::compile_module(scope, source).unwrap();
       assert_eq!(v8::ModuleStatus::Uninstantiated, module.get_status());
@@ -4807,10 +4807,10 @@ fn create_module<'s>(
   let source = match code_cache {
     Some(x) => v8::script_compiler::Source::new_with_cached_data(
       source,
-      &script_origin,
+      Some(&script_origin),
       x,
     ),
-    None => v8::script_compiler::Source::new(source, &script_origin),
+    None => v8::script_compiler::Source::new(source, Some(&script_origin)),
   };
   let module = v8::script_compiler::compile_module2(
     scope,


### PR DESCRIPTION
- Expose `ScriptCompiler::Compile` and `ScriptCompiler::CompileUnboundScript`.
- Make the `origin` parameter on `Source` constructor optional.