### PR TITLE
build: patch GN's host_cpu detection on Apple Silicon

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -84,7 +84,7 @@ fn build_v8() {
   if !is_debug() {
     gn_args.push("v8_enable_handle_zapping=false".to_string());
   }
-  
+
   // Fix GN's host_cpu detection when using x86_64 bins on Apple Silicon
   if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
     gn_args.push("host_cpu=\"arm64\"".to_string())

--- a/build.rs
+++ b/build.rs
@@ -84,6 +84,11 @@ fn build_v8() {
   if !is_debug() {
     gn_args.push("v8_enable_handle_zapping=false".to_string());
   }
+  
+  // Fix GN's host_cpu detection when using x86_64 bins on Apple Silicon
+  if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+    gn_args.push("host_cpu=\"arm64\"".to_string())
+  }
 
   if let Some(clang_base_path) = find_compatible_system_clang() {
     println!("clang_base_path {}", clang_base_path.display());


### PR DESCRIPTION
Since we download `x86_64` `ninja` and `gn` on M1 macs `gn` incorrectly targets `x86_64` by default.

This codifies [ry's workaround](https://github.com/denoland/rusty_v8/issues/520#issuecomment-740190036) so that `V8_FROM_SOURCE=1 cargo build --release` does the right thing out of the box, no surprises.

I hadn't checked the comments and all the threads, so I ended up "wasting" a decent amount of time building versions I couldn't link against, when wanting to test local changes with other crates. So hopefully this saves other contributors time.