### PR TITLE
Initial support for external v8 strings

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -808,6 +808,27 @@ int v8__String__WriteUtf8(const v8::String& self, v8::Isolate* isolate,
   return self.WriteUtf8(isolate, buffer, length, nchars_ref, options);
 }
 
+class ExternalStaticOneByteStringResource: public v8::String::ExternalOneByteStringResource {
+  public:
+    ExternalStaticOneByteStringResource(const char *data, int length):
+                                        _data(data), _length(length) {}
+    const char* data() const override { return _data; }
+    size_t length() const override { return _length; }
+
+  private:
+    const char* _data;
+    const int _length;
+};
+
+const v8::String* v8__String__NewExternalOneByteStatic(v8::Isolate *isolate,
+                                                      const char *data, int length) {
+  return maybe_local_to_ptr(
+    v8::String::NewExternalOneByte(
+      isolate, new ExternalStaticOneByteStringResource(data, length)
+    )
+  );
+}
+
 const v8::Symbol* v8__Symbol__New(v8::Isolate* isolate,
                                   const v8::String& description) {
   return local_to_ptr(v8::Symbol::New(isolate, ptr_to_local(&description)));

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -829,6 +829,11 @@ const v8::String* v8__String__NewExternalOneByteStatic(v8::Isolate *isolate,
   );
 }
 
+bool v8__String__IsExternal(const v8::String& self) { return self.IsExternal(); }
+bool v8__String__IsExternalOneByte(const v8::String& self) { return self.IsExternalOneByte(); }
+bool v8__String__IsExternalTwoByte(const v8::String& self) { return self.IsExternalTwoByte(); }
+bool v8__String__IsOneByte(const v8::String& self) { return self.IsOneByte(); }
+
 const v8::Symbol* v8__Symbol__New(v8::Isolate* isolate,
                                   const v8::String& description) {
   return local_to_ptr(v8::Symbol::New(isolate, ptr_to_local(&description)));

--- a/src/string.rs
+++ b/src/string.rs
@@ -38,6 +38,11 @@ extern "C" {
     buffer: *const char,
     length: int,
   ) -> *const String;
+  
+  fn v8__String__IsExternal(this: *const String) -> bool;
+  fn v8__String__IsExternalOneByte(this: *const String) -> bool;
+  fn v8__String__IsExternalTwoByte(this: *const String) -> bool;
+  fn v8__String__IsOneByte(this: *const String) -> bool;
 }
 
 #[repr(C)]
@@ -160,6 +165,35 @@ impl String {
         )
       })
     }
+  }
+  
+  /// True if string is external
+  pub fn is_external(&self) -> bool {
+    // TODO: re-enable on next v8-release
+    // Right now it fallbacks to Value::IsExternal, which is incorrect
+    // See: https://source.chromium.org/chromium/_/chromium/v8/v8.git/+/1dd8624b524d14076160c1743f7da0b20fbe68e0
+    // unsafe { v8__String__IsExternal(self) }
+    
+    // Fallback for now (though functionally identical)
+    return self.is_external_onebyte() || self.is_external_twobyte()
+  }
+  
+  /// True if string is external & one-byte
+  /// (e.g: created with new_external_onebyte_static)
+  pub fn is_external_onebyte(&self) -> bool {
+    unsafe { v8__String__IsExternalOneByte(self) }
+  }
+  
+  /// True if string is external & two-byte
+  /// NOTE: can't yet be created via rusty_v8
+  pub fn is_external_twobyte(&self) -> bool {
+    unsafe { v8__String__IsExternalTwoByte(self) }
+  }
+  
+  /// True if string is known to contain only one-byte data
+  /// doesn't read the string so can return false positives
+  pub fn is_onebyte(&self) -> bool {
+    unsafe { v8__String__IsExternalOneByte(self) }
   }
 
   /// Convenience function not present in the original V8 API.

--- a/src/string.rs
+++ b/src/string.rs
@@ -38,7 +38,7 @@ extern "C" {
     buffer: *const char,
     length: int,
   ) -> *const String;
-  
+
   fn v8__String__IsExternal(this: *const String) -> bool;
   fn v8__String__IsExternalOneByte(this: *const String) -> bool;
   fn v8__String__IsExternalTwoByte(this: *const String) -> bool;
@@ -166,30 +166,30 @@ impl String {
       })
     }
   }
-  
+
   /// True if string is external
   pub fn is_external(&self) -> bool {
     // TODO: re-enable on next v8-release
     // Right now it fallbacks to Value::IsExternal, which is incorrect
     // See: https://source.chromium.org/chromium/_/chromium/v8/v8.git/+/1dd8624b524d14076160c1743f7da0b20fbe68e0
     // unsafe { v8__String__IsExternal(self) }
-    
+
     // Fallback for now (though functionally identical)
-    return self.is_external_onebyte() || self.is_external_twobyte()
+    return self.is_external_onebyte() || self.is_external_twobyte();
   }
-  
+
   /// True if string is external & one-byte
   /// (e.g: created with new_external_onebyte_static)
   pub fn is_external_onebyte(&self) -> bool {
     unsafe { v8__String__IsExternalOneByte(self) }
   }
-  
+
   /// True if string is external & two-byte
   /// NOTE: can't yet be created via rusty_v8
   pub fn is_external_twobyte(&self) -> bool {
     unsafe { v8__String__IsExternalTwoByte(self) }
   }
-  
+
   /// True if string is known to contain only one-byte data
   /// doesn't read the string so can return false positives
   pub fn is_onebyte(&self) -> bool {

--- a/src/string.rs
+++ b/src/string.rs
@@ -175,7 +175,7 @@ impl String {
     // unsafe { v8__String__IsExternal(self) }
 
     // Fallback for now (though functionally identical)
-    return self.is_external_onebyte() || self.is_external_twobyte();
+    self.is_external_onebyte() || self.is_external_twobyte()
   }
 
   /// True if string is external & one-byte

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4912,11 +4912,25 @@ fn external_strings() {
     assert!(maybe_value.is_some());
     // Check length
     assert!(json_external.length() == 16);
+    // Externality checks
+    assert!(json_external.is_external());
+    assert!(json_external.is_external_onebyte());
+    assert!(json_external.is_onebyte());
 
     // In & out
     let hello =
       v8::String::new_external_onebyte_static(scope, "hello world").unwrap();
     let rust_str = hello.to_rust_string_lossy(scope);
     assert_eq!(rust_str, "hello world");
+    // Externality checks
+    assert!(hello.is_external());
+    assert!(hello.is_external_onebyte());
+    assert!(hello.is_onebyte());
+
+    // two-byte "internal" test
+    let gradients = v8::String::new(scope, "∇gradients").unwrap();
+    assert!(!gradients.is_external());
+    assert!(!gradients.is_external_onebyte());
+    assert!(!gradients.is_onebyte());
   }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4894,3 +4894,29 @@ fn code_cache() {
       .unwrap();
   assert_eq!(&value.to_rust_string_lossy(&mut scope), "world");
 }
+
+#[test]
+fn external_strings() {
+  let _setup_guard = setup();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  {
+    let scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(scope);
+    let scope = &mut v8::ContextScope::new(scope, context);
+
+    // Parse JSON from an external string
+    let json_static = "{\"a\": 1, \"b\": 2}";
+    let json_external =
+      v8::String::new_external_onebyte_static(scope, json_static).unwrap();
+    let maybe_value = v8::json::parse(scope, json_external);
+    assert!(maybe_value.is_some());
+    // Check length
+    assert!(json_external.length() == 16);
+
+    // In & out
+    let hello =
+      v8::String::new_external_onebyte_static(scope, "hello world").unwrap();
+    let rust_str = hello.to_rust_string_lossy(scope);
+    assert_eq!(rust_str, "hello world");
+  }
+}

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4964,38 +4964,36 @@ fn code_cache_script() {
 fn external_strings() {
   let _setup_guard = setup();
   let isolate = &mut v8::Isolate::new(Default::default());
-  {
-    let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
-    let scope = &mut v8::ContextScope::new(scope, context);
+  let scope = &mut v8::HandleScope::new(isolate);
+  let context = v8::Context::new(scope);
+  let scope = &mut v8::ContextScope::new(scope, context);
 
-    // Parse JSON from an external string
-    let json_static = "{\"a\": 1, \"b\": 2}";
-    let json_external =
-      v8::String::new_external_onebyte_static(scope, json_static).unwrap();
-    let maybe_value = v8::json::parse(scope, json_external);
-    assert!(maybe_value.is_some());
-    // Check length
-    assert!(json_external.length() == 16);
-    // Externality checks
-    assert!(json_external.is_external());
-    assert!(json_external.is_external_onebyte());
-    assert!(json_external.is_onebyte());
+  // Parse JSON from an external string
+  let json_static = "{\"a\": 1, \"b\": 2}";
+  let json_external =
+    v8::String::new_external_onebyte_static(scope, json_static).unwrap();
+  let maybe_value = v8::json::parse(scope, json_external);
+  assert!(maybe_value.is_some());
+  // Check length
+  assert!(json_external.length() == 16);
+  // Externality checks
+  assert!(json_external.is_external());
+  assert!(json_external.is_external_onebyte());
+  assert!(json_external.is_onebyte());
 
-    // In & out
-    let hello =
-      v8::String::new_external_onebyte_static(scope, "hello world").unwrap();
-    let rust_str = hello.to_rust_string_lossy(scope);
-    assert_eq!(rust_str, "hello world");
-    // Externality checks
-    assert!(hello.is_external());
-    assert!(hello.is_external_onebyte());
-    assert!(hello.is_onebyte());
+  // In & out
+  let hello =
+    v8::String::new_external_onebyte_static(scope, "hello world").unwrap();
+  let rust_str = hello.to_rust_string_lossy(scope);
+  assert_eq!(rust_str, "hello world");
+  // Externality checks
+  assert!(hello.is_external());
+  assert!(hello.is_external_onebyte());
+  assert!(hello.is_onebyte());
 
-    // two-byte "internal" test
-    let gradients = v8::String::new(scope, "∇gradients").unwrap();
-    assert!(!gradients.is_external());
-    assert!(!gradients.is_external_onebyte());
-    assert!(!gradients.is_onebyte());
-  }
+  // two-byte "internal" test
+  let gradients = v8::String::new(scope, "∇gradients").unwrap();
+  assert!(!gradients.is_external());
+  assert!(!gradients.is_external_onebyte());
+  assert!(!gradients.is_onebyte());
 }


### PR DESCRIPTION
This PR partially fixes #636, by adding support for external static rust strings.

Rust doesn't have utf16 (or two-byte string) literals, so we could shorten the name in this static case, i.e:
```rust
v8::String::new_external_static()
instead of
v8::String::new_external_onebyte_static()
```

We could support non-static external strings too, but I'm not sure we want to encourage that.