### PR TITLE
Add new_single_threaded_default_platform()

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1934,8 +1934,13 @@ v8::StartupData v8__SnapshotCreator__CreateBlob(
 }
 
 v8::Platform* v8__platform__NewDefaultPlatform() {
-  // TODO: support optional arguments.
+  // TODO(bnoordhuis) Support optional arguments.
   return v8::platform::NewDefaultPlatform().release();
+}
+
+v8::Platform* v8__platform__NewSingleThreadedDefaultPlatform() {
+  // TODO(bnoordhuis) Support optional arguments.
+  return v8::platform::NewSingleThreadedDefaultPlatform().release();
 }
 
 void v8__Platform__DELETE(v8::Platform* self) { delete self; }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ pub use isolate_create_params::CreateParams;
 pub use module::*;
 pub use object::*;
 pub use platform::new_default_platform;
+pub use platform::new_single_threaded_default_platform;
 pub use platform::Platform;
 pub use primitives::*;
 pub use private::*;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -3,11 +3,21 @@ use crate::support::UniquePtr;
 
 extern "C" {
   fn v8__platform__NewDefaultPlatform() -> *mut Platform;
+  fn v8__platform__NewSingleThreadedDefaultPlatform() -> *mut Platform;
   fn v8__Platform__DELETE(this: *mut Platform);
 }
 
+/// Returns a new instance of the default v8::Platform implementation.
 pub fn new_default_platform() -> UniquePtr<Platform> {
   unsafe { UniquePtr::from_raw(v8__platform__NewDefaultPlatform()) }
+}
+
+/// The same as new_default_platform() but disables the worker thread pool.
+/// It must be used with the --single-threaded V8 flag.
+pub fn new_single_threaded_default_platform() -> UniquePtr<Platform> {
+  unsafe {
+    UniquePtr::from_raw(v8__platform__NewSingleThreadedDefaultPlatform())
+  }
 }
 
 #[repr(C)]

--- a/tests/test_single_threaded_default_platform.rs
+++ b/tests/test_single_threaded_default_platform.rs
@@ -1,0 +1,24 @@
+use rusty_v8 as v8;
+
+#[test]
+fn single_threaded_default_platform() {
+  v8::V8::set_flags_from_string("--single_threaded");
+  v8::V8::initialize_platform(
+    v8::new_single_threaded_default_platform().unwrap(),
+  );
+  v8::V8::initialize();
+
+  {
+    let isolate = &mut v8::Isolate::new(Default::default());
+    let scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(scope);
+    let scope = &mut v8::ContextScope::new(scope, context);
+    let source = v8::String::new(scope, "Math.random()").unwrap();
+    let script = v8::Script::compile(scope, source, None).unwrap();
+    let result = script.run(scope).unwrap();
+    let _ = result.to_string(scope).unwrap();
+  }
+
+  unsafe { v8::V8::dispose() };
+  v8::V8::shutdown_platform();
+}


### PR DESCRIPTION
This is a v8::Platform implementation that doesn't spawn additional
threads. Useful in combination with the --single_threaded flag.