### PR TITLE
Fix bad assumption in static_assert

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -52,7 +52,7 @@ static_assert(sizeof(v8::ReturnValue<v8::Value>) == sizeof(size_t) * 1,
 static_assert(sizeof(v8::TryCatch) == sizeof(size_t) * 6,
               "TryCatch size mismatch");
 
-static_assert(sizeof(v8::Location) == sizeof(size_t) * 1,
+static_assert(sizeof(v8::Location) == sizeof(int) * 2,
               "Location size mismatch");
 
 static_assert(sizeof(v8::SnapshotCreator) == sizeof(size_t) * 1,

--- a/src/module.rs
+++ b/src/module.rs
@@ -195,7 +195,7 @@ extern "C" {
 /// A location in JavaScript source.
 #[repr(C)]
 #[derive(Debug)]
-pub struct Location([usize; 1]);
+pub struct Location([i32; 2]);
 
 impl Location {
   pub fn get_line_number(&self) -> int {


### PR DESCRIPTION
v8::Location is the size of two ints, not the size of one size_t.

`2 * sizeof(int) == sizeof(size_t)` on 64 bits architectures but not on
32 bits architectures.

Fixes #667.