### PR TITLE
add explicit 'dyn's in a few spots

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -415,14 +415,14 @@ impl Isolate {
   /// Get a reference to embedder data added with `set_slot()`.
   pub fn get_slot<T: 'static>(&self) -> Option<&T> {
     let b = self.get_annex().slots.get(&TypeId::of::<T>())?;
-    let r = Any::downcast_ref::<T>(&**b).unwrap();
+    let r = <dyn Any>::downcast_ref::<T>(&**b).unwrap();
     Some(r)
   }
 
   /// Get a mutable reference to embedder data added with `set_slot()`.
   pub fn get_slot_mut<T: 'static>(&mut self) -> Option<&mut T> {
     let b = self.get_annex_mut().slots.get_mut(&TypeId::of::<T>())?;
-    let r = Any::downcast_mut::<T>(&mut **b).unwrap();
+    let r = <dyn Any>::downcast_mut::<T>(&mut **b).unwrap();
     Some(r)
   }
 

--- a/src/support.rs
+++ b/src/support.rs
@@ -408,7 +408,7 @@ impl<T: ?Sized + 'static> Allocation<T> {
     value: Abstract,
     wrap: fn(Concrete) -> Self,
   ) -> Result<Self, Abstract> {
-    if Any::is::<Concrete>(&value) {
+    if <dyn Any>::is::<Concrete>(&value) {
       Ok(unsafe { Self::transmute_wrap(value, wrap) })
     } else {
       Err(value)


### PR DESCRIPTION
makes a few warnings go away.

```
warning: trait objects without an explicit `dyn` are deprecated
   --> src/isolate.rs:418:13
    |
418 |     let r = Any::downcast_ref::<T>(&**b).unwrap();
    |             ^^^ help: use `dyn`: `<dyn Any>`
    |
    = note: `#[warn(bare_trait_objects)]` on by default

warning: trait objects without an explicit `dyn` are deprecated
   --> src/isolate.rs:425:13
    |
425 |     let r = Any::downcast_mut::<T>(&mut **b).unwrap();
    |             ^^^ help: use `dyn`: `<dyn Any>`

warning: trait objects without an explicit `dyn` are deprecated
   --> src/support.rs:411:8
    |
411 |     if Any::is::<Concrete>(&value) {
    |        ^^^ help: use `dyn`: `<dyn Any>`

warning: 3 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 2.29s
```

Signed-off-by: Nicky Sielicki <sielicki@yandex.com>