### PR TITLE
Add ObjectTemplate::set_accessor[_with_setter]

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -971,6 +971,19 @@ void v8__ObjectTemplate__SetInternalFieldCount(const v8::ObjectTemplate& self,
   ptr_to_local(&self)->SetInternalFieldCount(value);
 }
 
+void v8__ObjectTemplate__SetAccessor(const v8::ObjectTemplate& self,
+                                  const v8::Name& key,
+                                  v8::AccessorNameGetterCallback getter) {
+  ptr_to_local(&self)->SetAccessor(ptr_to_local(&key), getter);
+}
+
+void v8__ObjectTemplate__SetAccessorWithSetter(
+    const v8::ObjectTemplate& self, const v8::Name& key,
+    v8::AccessorNameGetterCallback getter,
+    v8::AccessorNameSetterCallback setter) {
+  ptr_to_local(&self)->SetAccessor(ptr_to_local(&key), getter, setter);
+}
+
 const v8::Object* v8__Object__New(v8::Isolate* isolate) {
   return local_to_ptr(v8::Object::New(isolate));
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -213,7 +213,9 @@ pub struct PropertyCallbackArguments<'s> {
 }
 
 impl<'s> PropertyCallbackArguments<'s> {
-  fn from_property_callback_info(info: *const PropertyCallbackInfo) -> Self {
+  pub(crate) fn from_property_callback_info(
+    info: *const PropertyCallbackInfo,
+  ) -> Self {
     Self {
       info,
       phantom: PhantomData,

--- a/src/template.rs
+++ b/src/template.rs
@@ -6,6 +6,8 @@ use crate::data::Template;
 use crate::isolate::Isolate;
 use crate::support::int;
 use crate::support::MapFnTo;
+use crate::AccessorNameGetterCallback;
+use crate::AccessorNameSetterCallback;
 use crate::CFunction;
 use crate::ConstructorBehavior;
 use crate::Context;
@@ -67,6 +69,17 @@ extern "C" {
   fn v8__ObjectTemplate__SetInternalFieldCount(
     this: *const ObjectTemplate,
     value: int,
+  );
+  fn v8__ObjectTemplate__SetAccessor(
+    this: *const ObjectTemplate,
+    key: *const Name,
+    getter: AccessorNameGetterCallback,
+  );
+  fn v8__ObjectTemplate__SetAccessorWithSetter(
+    this: *const ObjectTemplate,
+    key: *const Name,
+    getter: AccessorNameGetterCallback,
+    setter: AccessorNameSetterCallback,
   );
 }
 
@@ -226,6 +239,30 @@ impl ObjectTemplate {
         unsafe { v8__ObjectTemplate__SetInternalFieldCount(self, value) };
         true
       }
+    }
+  }
+
+  pub fn set_accessor(
+    &self,
+    key: Local<Name>,
+    getter: impl for<'s> MapFnTo<AccessorNameGetterCallback<'s>>,
+  ) {
+    unsafe { v8__ObjectTemplate__SetAccessor(self, &*key, getter.map_fn_to()) }
+  }
+
+  pub fn set_accessor_with_setter(
+    &self,
+    key: Local<Name>,
+    getter: impl for<'s> MapFnTo<AccessorNameGetterCallback<'s>>,
+    setter: impl for<'s> MapFnTo<AccessorNameSetterCallback<'s>>,
+  ) {
+    unsafe {
+      v8__ObjectTemplate__SetAccessorWithSetter(
+        self,
+        &*key,
+        getter.map_fn_to(),
+        setter.map_fn_to(),
+      )
     }
   }
 }


### PR DESCRIPTION
These two methods were modeled on the existing `Object::set_accessor` and `Object::set_accessor_with_setter` methods for consistency.