### PR TITLE
Adding explicit return statement in build.rs line:157

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -155,18 +155,20 @@ fn maybe_install_sysroot(arch: &str) {
 }
 
 fn platform() -> &'static str {
+  let target_os;
   #[cfg(target_os = "windows")]
   {
-    "win"
+    target_os = "win"
   }
   #[cfg(target_os = "linux")]
   {
-    "linux64"
+    target_os = "linux64"
   }
   #[cfg(target_os = "macos")]
   {
-    "mac"
+    target_os = "mac"
   }
+  return target_os;
 }
 
 fn download_ninja_gn_binaries() {


### PR DESCRIPTION
It caused my deno installation build to fail.
![Screenshot_2021-05-31-13-36-56-12_84d3000e3f4017145260f7618db1d683](https://user-images.githubusercontent.com/52950675/120162143-b9120600-c215-11eb-95fe-54475bacac6e.jpg)
