### PR TITLE
build: enable v8's siphash for hash seed creation

### DIFF
--- a/.gn
+++ b/.gn
@@ -37,6 +37,7 @@ default_args = {
   v8_monolithic = false
   v8_use_external_startup_data = false
   v8_use_snapshot = true
+  v8_use_siphash = true
   is_component_build = false
   win_crt_flavor_agnostic = true
   symbol_level = 1


### PR DESCRIPTION
Enable the v8_use_siphash flag. This flag is enabled since Node.js
v11.12.0 (2019-03-15), see linked PR, release notes, and the blog post
detailing the attack.

Ref: https://github.com/nodejs/node/pull/26367
Ref: https://nodejs.org/gl/blog/release/v11.12.0/
Ref: https://darksi.de/12.hashwick-v8-vulnerability/