### PR TITLE
fix: pass serializer helpers as mut refs

### DIFF
--- a/src/value_deserializer.rs
+++ b/src/value_deserializer.rs
@@ -35,9 +35,10 @@ pub unsafe extern "C" fn v8__ValueDeserializer__Delegate__ReadHostObject(
     &mut crate::scope::CallbackScope::new(value_deserializer_heap.context);
   let value_deserializer_impl =
     value_deserializer_heap.value_deserializer_impl.as_mut();
-  match value_deserializer_impl
-    .read_host_object(scope, &value_deserializer_heap.cxx_value_deserializer)
-  {
+  match value_deserializer_impl.read_host_object(
+    scope,
+    &mut value_deserializer_heap.cxx_value_deserializer,
+  ) {
     None => std::ptr::null(),
     Some(x) => x.as_non_null().as_ptr(),
   }
@@ -153,7 +154,7 @@ pub trait ValueDeserializerImpl {
   fn read_host_object<'s>(
     &mut self,
     scope: &mut HandleScope<'s>,
-    value_deserializer: &dyn ValueDeserializerHelper,
+    value_deserializer: &mut dyn ValueDeserializerHelper,
   ) -> Option<Local<'s, Object>> {
     let msg =
       String::new(scope, "Deno deserializer: read_host_object not implemented")

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn v8__ValueSerializer__Delegate__WriteHostObject(
   MaybeBool::from(value_serializer_impl.write_host_object(
     scope,
     object,
-    &value_serializer_heap.cxx_value_serializer,
+    &mut value_serializer_heap.cxx_value_serializer,
   ))
 }
 
@@ -215,7 +215,7 @@ pub trait ValueSerializerImpl {
     &mut self,
     scope: &mut HandleScope<'s>,
     object: Local<'s, Object>,
-    value_serializer: &dyn ValueSerializerHelper,
+    value_serializer: &mut dyn ValueSerializerHelper,
   ) -> Option<bool> {
     let msg =
       String::new(scope, "Deno serializer: write_host_object not implemented")

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4289,6 +4289,16 @@ impl<'a> v8::ValueSerializerImpl for Custom1Value<'a> {
       ));
     Some((self.array_buffers.len() as u32) - 1)
   }
+
+  fn write_host_object<'s>(
+    &mut self,
+    _scope: &mut v8::HandleScope<'s>,
+    _object: v8::Local<'s, v8::Object>,
+    value_serializer: &mut dyn v8::ValueSerializerHelper,
+  ) -> Option<bool> {
+    value_serializer.write_uint64(1);
+    None
+  }
 }
 
 impl<'a> v8::ValueDeserializerImpl for Custom1Value<'a> {
@@ -4303,6 +4313,16 @@ impl<'a> v8::ValueDeserializerImpl for Custom1Value<'a> {
       scope,
       backing_store,
     ))
+  }
+
+  fn read_host_object<'s>(
+    &mut self,
+    _scope: &mut v8::HandleScope<'s>,
+    value_deserializer: &mut dyn v8::ValueDeserializerHelper,
+  ) -> Option<v8::Local<'s, v8::Object>> {
+    let mut value = 0;
+    value_deserializer.read_uint64(&mut value);
+    None
   }
 }
 


### PR DESCRIPTION
They are only useful in read_host_object and write_host_object if
the helpers are available as a mut ref.
