### PR TITLE
Include ICU file in crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,12 +190,13 @@ jobs:
 
       # TODO: add clang-format and maybe cpplint.
 
-      # TODO(ry) It would be ideal to check that "cargo package" also runs and
-      # that the resulting package is less than 10 MB. However it seems to
-      # result in a complete V8 rebuild. For now just be careful not to manually
-      # check that "cargo package" is working when updating the build.
-      # - name: Package
-      #   run: cargo package -vv --locked
+      - name: Cargo Package
+        if: >-
+          github.repository == 'denoland/rusty_v8' &&
+          startsWith(matrix.config.target , 'x86_64') &&
+          matrix.config.variant == 'debug' &&
+          runner.os == 'Linux'
+        run: cargo package -vv --locked
 
       - name: Publish
         # Only publish on x64 linux when there's a git tag:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,6 @@ exclude = [
  "v8/samples/",
  "v8/test/",
  "v8/tools/",
- # ICU data files
- "*.dat",
  # These files are required for the build.
  "!.gn",
  "!BUILD.gn",


### PR DESCRIPTION
Fixes #721

```
# ls -lh target/package/rusty_v8-0.24.0.crate
-rw-r--r--  1 ry  staff    14M Jul  1 17:06 target/package/rusty_v8-0.24.0.crate
```

This was the only workaround I could find. Should still fit under the 20M limit for crates.io

We should also add a CI job that tests "cargo package".