### PR TITLE
perf: disable siphash, v8 now uses 64bit hash seed

### DIFF
--- a/.gn
+++ b/.gn
@@ -37,7 +37,6 @@ default_args = {
   v8_monolithic = false
   v8_use_external_startup_data = false
   v8_use_snapshot = true
-  v8_use_siphash = true
   is_component_build = false
   win_crt_flavor_agnostic = true
   symbol_level = 1


### PR DESCRIPTION
thanks for the tip @indutny 