### PR TITLE
chore: downgrade to ubuntu-18.04 ci image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
             target: x86_64-apple-darwin
             variant: release
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: x86_64-unknown-linux-gnu
             variant: debug
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: x86_64-unknown-linux-gnu
             variant: release
 
@@ -41,11 +41,11 @@ jobs:
             target: x86_64-pc-windows-msvc
             variant: release # Note: we do not support windows debug builds.
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: aarch64-unknown-linux-gnu
             variant: debug
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: aarch64-unknown-linux-gnu
             variant: release
 


### PR DESCRIPTION
denoland/rusty_v8 uses ubuntu-latest-xl, which is still at 18.04. Use a
compatible image for third-party forks.

Third-party builds failed trying to install the gcc-5 cross-compiler
toolchain, which indeed is no longer available in 20.04.

Fixes #733.