### PR TITLE
chore: upgrade Rust to 1.54.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         uses: hecrj/setup-rust-action@v1
         with:
           components: clippy, rustfmt
-          rust-version: 1.53.0
+          rust-version: 1.54.0
 
       - name: Install python
         uses: actions/setup-python@v1

--- a/build.rs
+++ b/build.rs
@@ -105,11 +105,11 @@ fn build_v8() {
   }
 
   if let Some(p) = env::var_os("SCCACHE") {
-    cc_wrapper(&mut gn_args, &Path::new(&p));
+    cc_wrapper(&mut gn_args, Path::new(&p));
   } else if let Ok(p) = which("sccache") {
     cc_wrapper(&mut gn_args, &p);
   } else if let Some(p) = env::var_os("CCACHE") {
-    cc_wrapper(&mut gn_args, &Path::new(&p));
+    cc_wrapper(&mut gn_args, Path::new(&p));
   } else if let Ok(p) = which("ccache") {
     cc_wrapper(&mut gn_args, &p);
   } else {


### PR DESCRIPTION
Upgrades Rust to 1.54.0 and applys clippy's fixes.