### PR TITLE
fix: Linux i686 compilation and abi callback errors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -143,10 +143,9 @@ fn build_v8() {
       gn_args.push(r#"arm_float_abi="softfp""#.to_string());
     }
 
-    if use_sysroot {
-      gn_args.push("use_sysroot=true".to_string());
-      maybe_install_sysroot("arm");
-    }
+    // ignore use_sysroot to allow compilation on arm64
+    gn_args.push("use_sysroot=true".to_string());
+    maybe_install_sysroot("arm");
   } else if target_triple.starts_with("i686-") {
     gn_args.push(r#"target_cpu="x86""#.to_string());
   }

--- a/build.rs
+++ b/build.rs
@@ -143,6 +143,9 @@ fn build_v8() {
       gn_args.push(r#"arm_float_abi="softfp""#.to_string());
     }
 
+    // Build without debugging symbols because size is too large (like 600MB in release binary).
+    gn_args.push("symbol_level=0".to_string());
+
     // ignore use_sysroot to allow compilation on arm64
     gn_args.push("use_sysroot=true".to_string());
     maybe_install_sysroot("arm");

--- a/build.rs
+++ b/build.rs
@@ -132,6 +132,7 @@ fn build_v8() {
     if use_sysroot {
       gn_args.push("use_sysroot=true".to_string());
       maybe_install_sysroot("arm64");
+      maybe_install_sysroot("amd64");
     }
   } else if target_triple.starts_with("armv7-unknown-linux-gnueabi") {
     gn_args.push(r#"target_cpu="arm""#.to_string());

--- a/build.rs
+++ b/build.rs
@@ -124,17 +124,29 @@ fn build_v8() {
 
   let target_triple = env::var("TARGET").unwrap();
   // check if the target triple describes a non-native environment
-  if target_triple != env::var("HOST").unwrap() {
-    // cross-compilation setup
-    if target_triple == "aarch64-unknown-linux-gnu" {
-      gn_args.push(r#"target_cpu="arm64""#.to_string());
+  let use_sysroot = target_triple != env::var("HOST").unwrap();
+
+  if target_triple == "aarch64-unknown-linux-gnu" {
+    gn_args.push(r#"target_cpu="arm64""#.to_string());
+
+    if use_sysroot {
       gn_args.push("use_sysroot=true".to_string());
       maybe_install_sysroot("arm64");
-      maybe_install_sysroot("amd64");
-    };
-  }
+    }
+  } else if target_triple.starts_with("armv7-unknown-linux-gnueabi") {
+    gn_args.push(r#"target_cpu="arm""#.to_string());
 
-  if target_triple.starts_with("i686-") {
+    if target_triple.ends_with("hf") {
+      gn_args.push(r#"arm_float_abi="hard""#.to_string());
+    } else {
+      gn_args.push(r#"arm_float_abi="softfp""#.to_string());
+    }
+
+    if use_sysroot {
+      gn_args.push("use_sysroot=true".to_string());
+      maybe_install_sysroot("arm");
+    }
+  } else if target_triple.starts_with("i686-") {
     gn_args.push(r#"target_cpu="x86""#.to_string());
   }
 

--- a/build.rs
+++ b/build.rs
@@ -134,6 +134,10 @@ fn build_v8() {
     };
   }
 
+  if target_triple.starts_with("i686-") {
+    gn_args.push(r#"target_cpu="x86""#.to_string());
+  }
+
   let gn_root = env::var("CARGO_MANIFEST_DIR").unwrap();
 
   let gn_out = maybe_gen(&gn_root, gn_args);

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2463,7 +2463,7 @@ void v8__HeapProfiler__TakeHeapSnapshot(v8::Isolate* isolate,
 
 // This is necessary for v8__internal__GetIsolateFromHeapObject() to be
 // reliable enough for our purposes.
-#if !(defined V8_SHARED_RO_HEAP or defined V8_COMPRESS_POINTERS)
+#if UINTPTR_MAX == 0xffffffffffffffff && !(defined V8_SHARED_RO_HEAP or defined V8_COMPRESS_POINTERS)
 #error V8 must be built with either the 'v8_enable_pointer_compression' or \
 'v8_enable_shared_ro_heap' feature enabled.
 #endif

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -160,7 +160,7 @@ pub type PrepareStackTraceCallback<'s> = extern "C" fn(
   Local<'s, Array>,
 ) -> *const Value;
 
-// System V i386 ABI: Local<Module> returned in hidden pointer (struct).
+// System V i386 ABI: Local<Value> returned in hidden pointer (struct).
 #[cfg(all(not(target_os = "windows"), target_pointer_width = "32"))]
 #[repr(C)]
 pub struct PrepareStackTraceCallbackRet(*const Value);
@@ -1014,7 +1014,7 @@ where
     f.to_c_fn()
   }
 
-  // System V i386 ABI: Local<Module> returned in hidden pointer (struct).
+  // System V i386 ABI: Local<Value> returned in hidden pointer (struct).
   #[cfg(all(not(target_os = "windows"), target_pointer_width = "32"))]
   fn mapping() -> Self {
     let f = |context, error, sites| {

--- a/src/module.rs
+++ b/src/module.rs
@@ -122,7 +122,7 @@ where
 pub type SyntheticModuleEvaluationSteps<'a> =
   extern "C" fn(Local<'a, Context>, Local<'a, Module>) -> *const Value;
 
-// System V i386 ABI: Local<Module> returned in hidden pointer (struct).
+// System V i386 ABI: Local<Value> returned in hidden pointer (struct).
 #[cfg(all(not(target_os = "windows"), target_pointer_width = "32"))]
 #[repr(C)]
 pub struct SyntheticModuleEvaluationStepsRet(*const Value);

--- a/src/support.rs
+++ b/src/support.rs
@@ -556,7 +556,6 @@ impl Hasher for TypeIdHasher {
     // `TypeId` values are actually 64-bit values which themselves come out of
     // some hash function, so it's unnecessary to shuffle their bits further.
     assert_eq!(size_of::<TypeId>(), size_of::<u64>());
-    assert_eq!(align_of::<TypeId>(), size_of::<u64>());
     let prev_state = self.state.replace(value);
     assert_eq!(prev_state, None);
   }


### PR DESCRIPTION
This fixes compilation in i686 target in Linux, and several callbacks error caused by SystemV ABI differences between i686 and amd64.

Reference:
https://github.com/denoland/deno/pull/11653