### PR TITLE
feat: Add `v8::CompiledWasmModule`

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2747,3 +2747,28 @@ bool v8__ValueDeserializer__ReadRawBytes(v8::ValueDeserializer* self,
   return self->ReadRawBytes(length, data);
 }
 }  // extern "C"
+
+// v8::CompiledWasmModule
+
+extern "C" {
+const v8::WasmModuleObject* v8__WasmModuleObject__FromCompiledModule(v8::Isolate* isolate,
+                                                                     const v8::CompiledWasmModule* compiled_module) {
+  return maybe_local_to_ptr(v8::WasmModuleObject::FromCompiledModule(isolate, *compiled_module));
+}
+
+v8::CompiledWasmModule* v8__WasmModuleObject__GetCompiledModule(const v8::WasmModuleObject* self) {
+  v8::CompiledWasmModule cwm = ptr_to_local(self)->GetCompiledModule();
+  return new v8::CompiledWasmModule(std::move(cwm));
+}
+
+const uint8_t* v8__CompiledWasmModule__GetWireBytesRef(v8::CompiledWasmModule* self,
+                                                       size_t* length) {
+  v8::MemorySpan<const uint8_t> span = self->GetWireBytesRef();
+  *length = span.size();
+  return span.data();
+}
+
+void v8__CompiledWasmModule__DELETE(v8::CompiledWasmModule* self) {
+  delete self;
+}
+}  // extern "C"

--- a/src/data.rs
+++ b/src/data.rs
@@ -1381,6 +1381,7 @@ impl_partial_eq! { Value for SymbolObject use identity }
 impl_partial_eq! { Object for SymbolObject use identity }
 impl_partial_eq! { SymbolObject for SymbolObject use identity }
 
+/// An instance of WebAssembly.Module.
 #[repr(C)]
 #[derive(Debug)]
 pub struct WasmModuleObject(Opaque);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,7 @@ pub use value_deserializer::ValueDeserializerImpl;
 pub use value_serializer::ValueSerializer;
 pub use value_serializer::ValueSerializerHelper;
 pub use value_serializer::ValueSerializerImpl;
+pub use wasm::CompiledWasmModule;
 pub use wasm::WasmStreaming;
 
 // TODO(piscisaureus): Ideally this trait would not be exported.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -120,6 +120,10 @@ impl CompiledWasmModule {
   }
 }
 
+// TODO(andreubotella): Safety???
+unsafe impl Send for CompiledWasmModule {}
+unsafe impl Sync for CompiledWasmModule {}
+
 impl Drop for CompiledWasmModule {
   fn drop(&mut self) {
     unsafe { v8__CompiledWasmModule__DELETE(self.0) }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -65,10 +65,8 @@ impl Drop for WasmStreaming {
 }
 
 impl WasmModuleObject {
-  /**
-   * Efficiently re-create a WasmModuleObject, without recompiling, from
-   * a CompiledWasmModule.
-   */
+  /// Efficiently re-create a WasmModuleObject, without recompiling, from
+  /// a CompiledWasmModule.
   pub fn from_compiled_module<'s>(
     scope: &mut HandleScope<'s>,
     compiled_module: &CompiledWasmModule,
@@ -83,10 +81,8 @@ impl WasmModuleObject {
     }
   }
 
-  /**
-   * Get the compiled module for this module object. The compiled module can be
-   * shared by several module objects.
-   */
+  /// Get the compiled module for this module object. The compiled module can be
+  /// shared by several module objects.
   pub fn get_compiled_module(&self) -> CompiledWasmModule {
     let ptr = unsafe { v8__WasmModuleObject__GetCompiledModule(self) };
     CompiledWasmModule(ptr)
@@ -107,9 +103,7 @@ struct InternalCompiledWasmModule(Opaque);
 pub struct CompiledWasmModule(*mut InternalCompiledWasmModule);
 
 impl CompiledWasmModule {
-  /**
-   * Get the (wasm-encoded) wire bytes that were used to compile this module.
-   */
+  /// Get the (wasm-encoded) wire bytes that were used to compile this module.
   pub fn get_wire_bytes_ref(&self) -> &[u8] {
     use std::convert::TryInto;
     let mut len = 0isize;


### PR DESCRIPTION
`v8::CompiledWasmModule` is a representation of a compiled WebAssembly module, which can be shared by multiple `v8::WasmModuleObject`s.

Closes #759.
