### PR TITLE
Throw DataCloneError if SAB cannot be cloned

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2551,8 +2551,11 @@ struct v8__ValueSerializer__Delegate : public v8::ValueSerializer::Delegate {
       v8::Local<v8::SharedArrayBuffer> shared_array_buffer) override {
     uint32_t result = 0;
     if (!v8__ValueSerializer__Delegate__GetSharedArrayBufferId(
-            this, isolate, shared_array_buffer, &result))
-      return v8::Nothing<uint32_t>();
+            this, isolate, shared_array_buffer, &result)) {
+      // Forward to the original method. It'll throw DataCloneError.
+      return v8::ValueSerializer::Delegate::GetSharedArrayBufferId(
+          isolate, shared_array_buffer);
+    }
     return v8::Just(result);
   }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4723,8 +4723,12 @@ fn value_serializer_not_implemented() {
   assert!(scope.stack_trace().is_some());
   assert!(scope.message().is_some());
   assert_eq!(
-    scope.message().unwrap().get(scope).to_rust_string_lossy(scope),
-    "Uncaught Error: Deno serializer: get_shared_array_buffer_id not implemented"
+    scope
+      .message()
+      .unwrap()
+      .get(scope)
+      .to_rust_string_lossy(scope),
+    "Uncaught Error: #<SharedArrayBuffer> could not be cloned."
   );
 }
 


### PR DESCRIPTION
Best case, it produces serialized output that cannot be deserialized.

Worst case, it hits this assert in V8:

    # Fatal error in v8::FromJust
    # Maybe value is Nothing.