### PR TITLE
Revert "Throw DataCloneError if SAB cannot be cloned (#781)"

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2551,11 +2551,8 @@ struct v8__ValueSerializer__Delegate : public v8::ValueSerializer::Delegate {
       v8::Local<v8::SharedArrayBuffer> shared_array_buffer) override {
     uint32_t result = 0;
     if (!v8__ValueSerializer__Delegate__GetSharedArrayBufferId(
-            this, isolate, shared_array_buffer, &result)) {
-      // Forward to the original method. It'll throw DataCloneError.
-      return v8::ValueSerializer::Delegate::GetSharedArrayBufferId(
-          isolate, shared_array_buffer);
-    }
+            this, isolate, shared_array_buffer, &result))
+      return v8::Nothing<uint32_t>();
     return v8::Just(result);
   }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4723,12 +4723,8 @@ fn value_serializer_not_implemented() {
   assert!(scope.stack_trace().is_some());
   assert!(scope.message().is_some());
   assert_eq!(
-    scope
-      .message()
-      .unwrap()
-      .get(scope)
-      .to_rust_string_lossy(scope),
-    "Uncaught Error: #<SharedArrayBuffer> could not be cloned."
+    scope.message().unwrap().get(scope).to_rust_string_lossy(scope),
+    "Uncaught Error: Deno serializer: get_shared_array_buffer_id not implemented"
   );
 }
 


### PR DESCRIPTION
This seems to have caused the CI to go red with a segfault on Windows? https://github.com/denoland/rusty_v8/runs/3640447313

This reverts commit 09347d32c8bffee8010a32fa98ab0d533326aadc.