### PR TITLE
Rename Handle::get to Handle::inner

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -146,8 +146,8 @@ impl<T> Global<T> {
     }
   }
 
-  pub fn get<'a>(&'a self, scope: &mut Isolate) -> &'a T {
-    Handle::get(self, scope)
+  pub fn inner<'a>(&'a self, scope: &mut Isolate) -> &'a T {
+    Handle::inner(self, scope)
   }
 }
 
@@ -186,7 +186,7 @@ pub trait Handle: Sized {
   /// This function panics in the following situations:
   /// - The handle is not hosted by the specified Isolate.
   /// - The Isolate that hosts this handle has been disposed.
-  fn get<'a>(&'a self, isolate: &mut Isolate) -> &'a Self::Data {
+  fn inner<'a>(&'a self, isolate: &mut Isolate) -> &'a Self::Data {
     let HandleInfo { data, host } = self.get_handle_info();
     host.assert_match_isolate(isolate);
     unsafe { &*data.as_ptr() }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -170,7 +170,7 @@ impl<'s> HandleScope<'s> {
     param: &'s mut P,
     context: H,
   ) -> Self {
-    let context_ref = context.get(param.get_isolate_mut());
+    let context_ref = context.inner(param.get_isolate_mut());
     param
       .get_scope_data_mut()
       .new_handle_scope_data_with_context(context_ref)

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -116,17 +116,34 @@ fn global_handles() {
   }
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    assert_eq!(g1.get(scope).to_rust_string_lossy(scope), "bla");
-    assert_eq!(g2.as_ref().unwrap().get(scope).value(), 123);
-    assert_eq!(g3.get(scope).value(), 123);
-    assert_eq!(g4.get(scope).value(), 123);
+    assert_eq!(g1.inner(scope).to_rust_string_lossy(scope), "bla");
+    assert_eq!(g2.as_ref().unwrap().inner(scope).value(), 123);
+    assert_eq!(g3.inner(scope).value(), 123);
+    assert_eq!(g4.inner(scope).value(), 123);
     {
-      let num = g5.as_ref().unwrap().get(scope);
+      let num = g5.as_ref().unwrap().inner(scope);
       assert_eq!(num.value(), 100);
     }
     g5.take();
     assert!(g6 == g1);
-    assert_eq!(g6.get(scope).to_rust_string_lossy(scope), "bla");
+    assert_eq!(g6.inner(scope).to_rust_string_lossy(scope), "bla");
+  }
+}
+
+#[test]
+fn local_handle_deref() {
+  let _setup_guard = setup();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  let scope = &mut v8::HandleScope::new(isolate);
+  let context = v8::Context::new(scope);
+  let scope = &mut v8::ContextScope::new(scope, context);
+  let key = v8::String::new(scope, "key").unwrap();
+  let obj: v8::Local<v8::Object> = v8::Object::new(scope);
+  obj.get(scope, key.into());
+  {
+    use v8::Handle;
+    obj.get(scope, key.into());
+    obj.inner(scope).get(scope, key.into());
   }
 }
 


### PR DESCRIPTION
Since local implements Deref, having a get in Handle conflicted with
the get in Object when using a Local<Object>.

For example, given a obj: Local<Object>,

    obj.get(scope).get(scope, key.into());

would compile only with a "use v8::Handle", but adding that would break

obj.get(scope, key.into());

which was working without the use.