### PR TITLE
feat: v8::StackTrace::CurrentStackTrace() bindings

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1658,6 +1658,11 @@ const v8::Value* v8__ReturnValue__Get(const v8::ReturnValue<v8::Value>& self) {
   return local_to_ptr(self.Get());
 }
 
+// Note: StackTraceOptions is deprecated, kDetailed is always used
+const v8::StackTrace* v8__StackTrace__CurrentStackTrace(v8::Isolate* isolate, int frame_limit) {
+  return local_to_ptr(v8::StackTrace::CurrentStackTrace(isolate, frame_limit));
+}
+
 int v8__StackTrace__GetFrameCount(const v8::StackTrace& self) {
   return self.GetFrameCount();
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1659,7 +1659,8 @@ const v8::Value* v8__ReturnValue__Get(const v8::ReturnValue<v8::Value>& self) {
 }
 
 // Note: StackTraceOptions is deprecated, kDetailed is always used
-const v8::StackTrace* v8__StackTrace__CurrentStackTrace(v8::Isolate* isolate, int frame_limit) {
+const v8::StackTrace* v8__StackTrace__CurrentStackTrace(v8::Isolate* isolate,
+                                                        int frame_limit) {
   return local_to_ptr(v8::StackTrace::CurrentStackTrace(isolate, frame_limit));
 }
 

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use std::convert::TryInto;
+
 use crate::isolate::Isolate;
 use crate::support::int;
 use crate::Context;
@@ -74,8 +76,9 @@ impl StackTrace {
   /// Grab a snapshot of the current JavaScript execution stack.
   pub fn current_stack_trace<'s>(
     scope: &mut HandleScope<'s>,
-    frame_limit: i32,
+    frame_limit: usize,
   ) -> Option<Local<'s, StackTrace>> {
+    let frame_limit = frame_limit.try_into().ok()?;
     unsafe {
       scope.cast_local(|sd| {
         v8__StackTrace__CurrentStackTrace(sd.get_isolate_ptr(), frame_limit)

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -32,6 +32,10 @@ extern "C" {
   fn v8__Message__IsOpaque(this: *const Message) -> bool;
   fn v8__Message__GetStackTrace(this: *const Message) -> *const StackTrace;
 
+  fn v8__StackTrace__CurrentStackTrace(
+    isolate: *mut Isolate,
+    frame_limit: int,
+  ) -> *const StackTrace;
   fn v8__StackTrace__GetFrameCount(this: *const StackTrace) -> int;
   fn v8__StackTrace__GetFrame(
     this: *const StackTrace,
@@ -67,6 +71,18 @@ extern "C" {
 }
 
 impl StackTrace {
+  /// Grab a snapshot of the current JavaScript execution stack.
+  pub fn current_stack_trace<'s>(
+    scope: &mut HandleScope<'s>,
+    frame_limit: i32,
+  ) -> Option<Local<'s, StackTrace>> {
+    unsafe {
+      scope.cast_local(|sd| {
+        v8__StackTrace__CurrentStackTrace(sd.get_isolate_ptr(), frame_limit)
+      })
+    }
+  }
+
   /// Returns the number of StackFrames.
   pub fn get_frame_count(&self) -> usize {
     unsafe { v8__StackTrace__GetFrameCount(self) as usize }


### PR DESCRIPTION
I originally added this binding to experiment with stacktrace stitching in `deno`, but as I suspected it's way too slow ...

Might be good to add for completeness sake or other use-cases ...