### PR TITLE
Rename Handle::get() to Handle::open() instead

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -146,8 +146,13 @@ impl<T> Global<T> {
     }
   }
 
-  pub fn inner<'a>(&'a self, scope: &mut Isolate) -> &'a T {
-    Handle::inner(self, scope)
+  pub fn open<'a>(&'a self, scope: &mut Isolate) -> &'a T {
+    Handle::open(self, scope)
+  }
+
+  #[deprecated = "use Global::open() instead"]
+  pub fn get<'a>(&'a self, scope: &mut Isolate) -> &'a T {
+    Handle::open(self, scope)
   }
 }
 
@@ -186,7 +191,7 @@ pub trait Handle: Sized {
   /// This function panics in the following situations:
   /// - The handle is not hosted by the specified Isolate.
   /// - The Isolate that hosts this handle has been disposed.
-  fn inner<'a>(&'a self, isolate: &mut Isolate) -> &'a Self::Data {
+  fn open<'a>(&'a self, isolate: &mut Isolate) -> &'a Self::Data {
     let HandleInfo { data, host } = self.get_handle_info();
     host.assert_match_isolate(isolate);
     unsafe { &*data.as_ptr() }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -170,7 +170,7 @@ impl<'s> HandleScope<'s> {
     param: &'s mut P,
     context: H,
   ) -> Self {
-    let context_ref = context.inner(param.get_isolate_mut());
+    let context_ref = context.open(param.get_isolate_mut());
     param
       .get_scope_data_mut()
       .new_handle_scope_data_with_context(context_ref)

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -116,17 +116,17 @@ fn global_handles() {
   }
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    assert_eq!(g1.inner(scope).to_rust_string_lossy(scope), "bla");
-    assert_eq!(g2.as_ref().unwrap().inner(scope).value(), 123);
-    assert_eq!(g3.inner(scope).value(), 123);
-    assert_eq!(g4.inner(scope).value(), 123);
+    assert_eq!(g1.open(scope).to_rust_string_lossy(scope), "bla");
+    assert_eq!(g2.as_ref().unwrap().open(scope).value(), 123);
+    assert_eq!(g3.open(scope).value(), 123);
+    assert_eq!(g4.open(scope).value(), 123);
     {
-      let num = g5.as_ref().unwrap().inner(scope);
+      let num = g5.as_ref().unwrap().open(scope);
       assert_eq!(num.value(), 100);
     }
     g5.take();
     assert!(g6 == g1);
-    assert_eq!(g6.inner(scope).to_rust_string_lossy(scope), "bla");
+    assert_eq!(g6.open(scope).to_rust_string_lossy(scope), "bla");
   }
 }
 
@@ -143,7 +143,7 @@ fn local_handle_deref() {
   {
     use v8::Handle;
     obj.get(scope, key.into());
-    obj.inner(scope).get(scope, key.into());
+    obj.open(scope).get(scope, key.into());
   }
 }
 


### PR DESCRIPTION
This also adds a deprecated `Global::get()` method to avoid unnecessarily breaking a lot of users code.

cc @espindola 