### PR TITLE
refactor: Have `BackingStore::data` return `Option<NonNull<c_void>>`

### DIFF
--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -5509,7 +5509,10 @@ fn compiled_wasm_module() {
         .unwrap();
     let foo_bs = foo_ab.get_backing_store();
     let foo_section = unsafe {
-      std::slice::from_raw_parts(foo_bs.data() as *mut u8, foo_bs.byte_length())
+      std::slice::from_raw_parts(
+        foo_bs.data().unwrap().as_ptr() as *mut u8,
+        foo_bs.byte_length(),
+      )
     };
     assert_eq!(foo_section, b"bar");
   }


### PR DESCRIPTION
The pointer returned by `BackingStore::data` might be null if the backing store has zero length, but the return type `*mut c_void` does not force the user to consider this case. This change makes the return type `Option<NonNull<c_void>>`, which is semantically equivalent, but which forces users of the API to handle the `None` case.

This is a breaking API change.
