### PR TITLE
feat: Add bindings for WasmStreaming::set_compiled_module_bytes and CompiledWasmModule::serialize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ pub use value_serializer::ValueSerializerHelper;
 pub use value_serializer::ValueSerializerImpl;
 pub use wasm::CompiledWasmModule;
 pub use wasm::WasmStreaming;
+pub use wasm::WasmStreamingClient;
 
 // TODO(piscisaureus): Ideally this trait would not be exported.
 pub use support::MapFnTo;


### PR DESCRIPTION
Add some bindings to serialize and load compiled WebAssembly module cache.

With these bindings, we can cache the compiling result of WebAssembly module: https://github.com/denoland/deno/issues/11918#issuecomment-955683827

Test is not working currently.