### PR TITLE
Ignore environment variables set by cargo

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,9 +18,6 @@ fn main() {
   // variable can lead to broken links when switching rusty_v8
   // versions.
   let envs = vec![
-    "CARGO",
-    "CARGO_MANIFEST_DIR",
-    "CARGO_PKG_VERSION",
     "CCACHE",
     "CLANG_BASE_PATH",
     "DENO_TRYBUILD",
@@ -30,11 +27,9 @@ fn main() {
     "HOST",
     "NINJA",
     "OUT_DIR",
-    "PROFILE",
     "RUSTY_V8_ARCHIVE",
     "RUSTY_V8_MIRROR",
     "SCCACHE",
-    "TARGET",
     "V8_FORCE_DEBUG",
     "V8_FROM_SOURCE",
   ];


### PR DESCRIPTION
This avoids constant rebuilds when alternating between running

$ cargo build
$ cargo run <something that runs cargo build>

Since the second command will see these environment variables set
during the logic deciding if build.rs should be rerun or not.

Since these are cargo specific variables, hopefully cargo already does
the right thing without our help.