### PR TITLE
v8: fix segfault during concurrent isolate creation/disposal on Windows

### DIFF
--- a/tests/test_concurrent_isolate_creation_and_disposal.rs
+++ b/tests/test_concurrent_isolate_creation_and_disposal.rs
@@ -1,0 +1,28 @@
+use std::iter::repeat_with;
+use std::thread;
+
+#[test]
+fn concurrent_isolate_creation_and_disposal() {
+  let platform = v8::new_single_threaded_default_platform(false).make_shared();
+  v8::V8::initialize_platform(platform);
+  v8::V8::initialize();
+
+  for round in 0..1000 {
+    eprintln!("round {}", round);
+
+    let threads = repeat_with(|| {
+      thread::spawn(|| {
+        v8::Isolate::new(Default::default());
+      })
+    })
+    .take(16)
+    .collect::<Vec<_>>();
+
+    for join_handle in threads {
+      join_handle.join().unwrap();
+    }
+  }
+
+  unsafe { v8::V8::dispose() };
+  v8::V8::shutdown_platform();
+}


### PR DESCRIPTION
This patch includes a test for this issue.

The V8 patch is intentionally left simple to avoid merge conflicts in
the future. To be landed upstream, the `unwindinfo_use_count_` would
probably have to be made non-atomic and we'd have to add a cctest.

Upstream bug: https://bugs.chromium.org/p/v8/issues/detail?id=12393

Fixes: #714