### PR TITLE
fix: `backing_store_deleter_callback` drops a `Box<c_void>`, not a `Box<[u8]>`

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -3,6 +3,7 @@
 use std::cell::Cell;
 use std::ffi::c_void;
 use std::ops::Deref;
+use std::ptr;
 use std::ptr::null_mut;
 use std::ptr::NonNull;
 use std::slice;
@@ -233,11 +234,12 @@ pub type BackingStoreDeleterCallback = unsafe extern "C" fn(
 
 pub unsafe extern "C" fn backing_store_deleter_callback(
   data: *mut c_void,
-  _byte_length: usize,
+  byte_length: usize,
   _deleter_data: *mut c_void,
 ) {
-  let b = Box::from_raw(data);
-  drop(b)
+  let slice_ptr = ptr::slice_from_raw_parts_mut(data as *mut u8, byte_length);
+  let b = Box::from_raw(slice_ptr);
+  drop(b);
 }
 
 /// A wrapper around the backing store (i.e. the raw memory) of an array buffer.

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -5660,3 +5660,18 @@ fn function_names() {
     assert_eq!(v8_name.to_rust_string_lossy(scope), "");
   }
 }
+
+// https://github.com/denoland/rusty_v8/issues/849
+#[test]
+fn backing_store_from_empty_boxed_slice() {
+  let _setup_guard = setup();
+
+  let mut isolate = v8::Isolate::new(Default::default());
+  let mut scope = v8::HandleScope::new(&mut isolate);
+  let context = v8::Context::new(&mut scope);
+  let mut scope = v8::ContextScope::new(&mut scope, context);
+
+  let store = v8::ArrayBuffer::new_backing_store_from_boxed_slice(Box::new([]))
+    .make_shared();
+  let _ = v8::ArrayBuffer::with_backing_store(&mut scope, &store);
+}


### PR DESCRIPTION
This results in a segmentation fault when dropping a `BackingStore` constructed through `ArrayBuffer::new_backing_store_from_boxed_slice` from an empty slice, since empty boxed slices can be invalid pointers, but `Box<c_void>` can't.

Fixes #849.
