### PR TITLE
add support for `aarch64-linux-android`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-linux-android]
+linker = "./third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang++"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       
       - name: Build cross docker image
         if: matrix.config.target == 'aarch64-linux-android'  
-        run: docker build --mount=type=cache,target=${{ github.workspace }}/target/sccache -t cross:aarch64-linux-android-0.2.1 .
+        run: docker build -t cross:aarch64-linux-android-0.2.1 .
 
       - name: Test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,7 @@ jobs:
 
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: aarch64-linux-android
-            variant: debug
-            cargo: cross
-
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
-            target: aarch64-linux-android
-            variant: release
+            variant: release # Note: v8 debug builds on QEMU is buggy.
             cargo: cross
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         run: cargo install cross
 
       - name: Test (android-arm64)
-        if: runner.os == "Linux"
+        if: runner.os == 'Linux'
         run: ./tools/clang/scripts/update.py && cross test --target aarch64-linux-android -vv
 
       - name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
             variant: release
 
     env:
-      V8_FROM_SOURCE: true
+      V8_FROM_SOURCE: false
       CARGO_VARIANT_FLAG: ${{ matrix.config.variant == 'release' && '--release' || '' }}
       LIB_NAME: ${{ contains(matrix.config.target, 'windows') && 'rusty_v8' || 'librusty_v8' }}
       LIB_EXT: ${{ contains(matrix.config.target, 'windows') && 'lib' || 'a' }}
@@ -162,6 +162,11 @@ jobs:
         run:
           cargo test -vv --all-targets --locked ${{ env.CARGO_VARIANT_FLAG }}
           --target ${{ matrix.config.target }}
+      - name: Install cross
+        run: cargo install cross
+
+      - name: Test (android-arm64)
+        run: cross test --target aarch64-linux-android -vv
 
       - name: Clippy
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,30 +24,37 @@ jobs:
           - os: macOS-latest
             target: x86_64-apple-darwin
             variant: debug
+            cargo: cargo
 
           - os: macOS-latest
             target: x86_64-apple-darwin
             variant: release
-
+            cargo: cargo
+          
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: x86_64-unknown-linux-gnu
             variant: debug
-
+            cargo: cargo
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: x86_64-unknown-linux-gnu
             variant: release
-
+            cargo: cargo
           - os: windows-2019
             target: x86_64-pc-windows-msvc
             variant: release # Note: we do not support windows debug builds.
-
+            cargo: cargo
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: aarch64-unknown-linux-gnu
             variant: debug
-
+            cargo: cargo
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: aarch64-unknown-linux-gnu
             variant: release
+            cargo: cargo
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
+            target: aarch64-linux-android
+            variant: debug
+            cargo: cross
 
     env:
       V8_FROM_SOURCE: true
@@ -159,25 +166,21 @@ jobs:
           echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install cross
-        if: runner.os == 'Linux'  
+        if: matrix.config.target = 'aarch64-linux-android'
         run: cargo install cross
       
       - name: Build cross docker image
-        if: runner.os == 'Linux'  
+        if: matrix.config.target = 'aarch64-linux-android'  
         run: docker build -t cross:aarch64-linux-android-0.2.1 .
-
-      - name: Test (android-arm64)
-        if: runner.os == 'Linux'
-        run: ./tools/clang/scripts/update.py && V8_FROM_SOURCE=true cross test --target aarch64-linux-android -vv
 
       - name: Test
         run:
-          cargo test -vv --all-targets --locked ${{ env.CARGO_VARIANT_FLAG }}
+          ${{ matrix.config.cargo }} test -vv --all-targets --locked ${{ env.CARGO_VARIANT_FLAG }}
           --target ${{ matrix.config.target }}
 
       - name: Clippy
         run:
-          cargo clippy --all-targets --locked ${{ env.CARGO_VARIANT_FLAG }}
+          ${{ matrix.config.cargo }} clippy --all-targets --locked ${{ env.CARGO_VARIANT_FLAG }}
           --target ${{ matrix.config.target }} -- -D clippy::all
 
       - name: Rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,7 @@ jobs:
 
     steps:
       - name: Configure git
-        run: | 
-          git config --global core.symlinks true
-          git config --global http.postBuffer 1048576000
+        run: git config --global core.symlinks true
 
       - name: Clone repository
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,9 +159,11 @@ jobs:
           echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install cross
+        if: runner.os == 'Linux'  
         run: cargo install cross
       
       - name: Build cross docker image
+        if: runner.os == 'Linux'  
         run: docker build -t cross:aarch64-linux-android-0.2.1 .
 
       - name: Test (android-arm64)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,9 @@ jobs:
 
       - name: Install cross
         run: cargo install cross
+      
+      - name: Build cross docker image
+        run: docker build -t cross:aarch64-linux-android-0.2.1 .
 
       - name: Test (android-arm64)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
             variant: release
 
     env:
-      V8_FROM_SOURCE: false
+      V8_FROM_SOURCE: true
       CARGO_VARIANT_FLAG: ${{ matrix.config.variant == 'release' && '--release' || '' }}
       LIB_NAME: ${{ contains(matrix.config.target, 'windows') && 'rusty_v8' || 'librusty_v8' }}
       LIB_EXT: ${{ contains(matrix.config.target, 'windows') && 'lib' || 'a' }}
@@ -158,16 +158,17 @@ jobs:
           . $basename/sccache --start-server
           echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Test
-        run:
-          cargo test -vv --all-targets --locked ${{ env.CARGO_VARIANT_FLAG }}
-          --target ${{ matrix.config.target }}
       - name: Install cross
         run: cargo install cross
 
       - name: Test (android-arm64)
         if: runner.os == 'Linux'
         run: ./tools/clang/scripts/update.py && V8_FROM_SOURCE=true cross test --target aarch64-linux-android -vv
+
+      - name: Test
+        run:
+          cargo test -vv --all-targets --locked ${{ env.CARGO_VARIANT_FLAG }}
+          --target ${{ matrix.config.target }}
 
       - name: Clippy
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       github.event_name == 'push' ||
       !startsWith(github.event.pull_request.head.label, 'denoland:')
     runs-on: ${{ matrix.config.os }}
-    timeout-minutes: 120
+    timeout-minutes: 240
     strategy:
       # Always run main branch builds to completion. This allows the cache to
       # stay mostly up-to-date in situations where a single job fails due to
@@ -171,7 +171,7 @@ jobs:
       
       - name: Build cross docker image
         if: matrix.config.target == 'aarch64-linux-android'  
-        run: docker build -t cross:aarch64-linux-android-0.2.1 .
+        run: docker build --mount=type=cache,target=${{ github.workspace }}/target/sccache -t cross:aarch64-linux-android-0.2.1 .
 
       - name: Test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,9 @@ jobs:
 
     steps:
       - name: Configure git
-        run: git config --global core.symlinks true
+        run: | 
+          git config --global core.symlinks true
+          git config --global http.postBuffer 1048576000
 
       - name: Clone repository
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Test (android-arm64)
         if: runner.os == 'Linux'
-        run: ./tools/clang/scripts/update.py && cross test --target aarch64-linux-android -vv
+        run: ./tools/clang/scripts/update.py && V8_FROM_SOURCE=true cross test --target aarch64-linux-android -vv
 
       - name: Clippy
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,11 +166,11 @@ jobs:
           echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install cross
-        if: matrix.config.target = 'aarch64-linux-android'
+        if: matrix.config.target == 'aarch64-linux-android'
         run: cargo install cross
       
       - name: Build cross docker image
-        if: matrix.config.target = 'aarch64-linux-android'  
+        if: matrix.config.target == 'aarch64-linux-android'  
         run: docker build -t cross:aarch64-linux-android-0.2.1 .
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,6 @@ jobs:
 
       - name: Test
         env:
-          SCCACHE_DIR: ${{ github.workspace }}/target/sccache
           SCCACHE_IDLE_TIMEOUT: 0
         run:
           ${{ matrix.config.cargo }} test -vv --all-targets --locked ${{ env.CARGO_VARIANT_FLAG }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       github.event_name == 'push' ||
       !startsWith(github.event.pull_request.head.label, 'denoland:')
     runs-on: ${{ matrix.config.os }}
-    timeout-minutes: 240
+    timeout-minutes: 120
     strategy:
       # Always run main branch builds to completion. This allows the cache to
       # stay mostly up-to-date in situations where a single job fails due to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,25 +35,35 @@ jobs:
             target: x86_64-unknown-linux-gnu
             variant: debug
             cargo: cargo
+
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: x86_64-unknown-linux-gnu
             variant: release
             cargo: cargo
+
           - os: windows-2019
             target: x86_64-pc-windows-msvc
             variant: release # Note: we do not support windows debug builds.
             cargo: cargo
+
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: aarch64-unknown-linux-gnu
             variant: debug
             cargo: cargo
+
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: aarch64-unknown-linux-gnu
             variant: release
             cargo: cargo
+
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
             target: aarch64-linux-android
             variant: debug
+            cargo: cross
+
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-latest-xl' || 'ubuntu-18.04' }}
+            target: aarch64-linux-android
+            variant: release
             cargo: cross
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,9 @@ jobs:
         run: docker build -t cross:aarch64-linux-android-0.2.1 .
 
       - name: Test
+        env:
+          SCCACHE_DIR: ${{ github.workspace }}/target/sccache
+          SCCACHE_IDLE_TIMEOUT: 0
         run:
           ${{ matrix.config.cargo }} test -vv --all-targets --locked ${{ env.CARGO_VARIANT_FLAG }}
           --target ${{ matrix.config.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,8 @@ jobs:
         run: cargo install cross
 
       - name: Test (android-arm64)
-        run: cross test --target aarch64-linux-android -vv
+        if: runner.os == "Linux"
+        run: ./tools/clang/scripts/update.py && cross test --target aarch64-linux-android -vv
 
       - name: Clippy
         run:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 /.cache
 /target/
 /compile_commands.json
+
+third_party/android_ndk
+third_party/android_platform
+third_party/catapult

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 third_party/android_ndk
 third_party/android_platform
 third_party/catapult
+third_party/llvm-build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,84 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "align-data"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1926655ba000b19e21f0402be09a1d52d318c8a8a68622870bfb7af2a71315cd"
+
+[[package]]
+name = "android_log-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
+
+[[package]]
+name = "android_logger"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9ed09b18365ed295d722d0b5ed59c01b79a826ff2d2a8f73d5ecca8e6fb2f66"
+dependencies = [
+ "android_log-sys",
+ "env_logger",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "ash"
+version = "0.33.3+1.2.191"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4f1d82f164f838ae413296d1131aa6fa79b917d25bebaa7033d25620c09219"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -15,21 +89,312 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "bumpalo"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+
+[[package]]
+name = "bytemuck"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439989e6b8c38d1b6570a384ef1e49c8848128f5a97f3914baef02920842712f"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "calloop"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42dcfbd723aa6eff9f024cfd5ad08b11144d79b2d8d37b4a31a006ceab255c77"
+dependencies = [
+ "log",
+ "nix",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cocoa"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832"
+dependencies = [
+ "bitflags",
+ "block",
+ "cocoa-foundation",
+ "core-foundation 0.9.2",
+ "core-graphics 0.22.3",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
+dependencies = [
+ "bitflags",
+ "block",
+ "core-foundation 0.9.2",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "copyless"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
+
+[[package]]
+name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys 0.8.3",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "core-graphics"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.7.0",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.2",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.2",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-video-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ecad23610ad9757664d644e369246edde1803fcb43ed72876565098a5d3828"
+dependencies = [
+ "cfg-if 0.1.10",
+ "core-foundation-sys 0.7.0",
+ "core-graphics 0.19.2",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "d3d12"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c"
+dependencies = [
+ "bitflags",
+ "libloading",
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dlib"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "flaky_test"
-version = "0.1.0"
+name = "env_logger"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cde5eb168cf5a056dd98f311cbfab7494c216394e4fb9eba0336827a8db93"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "log",
+ "regex",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fslock"
@@ -42,16 +407,161 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "glow"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c07210904884e8e2e6a2d7f36f39040a9cefe3b379b721969b5275e9f5b464a"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e64cbb8d36508d3e19da95e56e196a84f674fc190881f2cc010000798838aa6"
+dependencies = [
+ "bitflags",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a538f217be4d405ff4719a283ca68323cc2384003eca5baaa87501e821c81dda"
+dependencies = [
+ "bitflags",
+ "gpu-descriptor-types",
+ "hashbrown",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "inplace_it"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90953f308a79fe6d62a4643e51f848fbfddcd05975a38e69fdf4ab86a7baf7ca"
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "khronos-egl"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
+dependencies = [
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "lazy_static"
@@ -61,9 +571,345 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+
+[[package]]
+name = "libloading"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memmap2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084"
+dependencies = [
+ "bitflags",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "naga"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806f448a7ce662ca79ef5484ef8f451a9b7c51b8166c95f5a667228b3825a6ca"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "codespan-reporting",
+ "fxhash",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "num-traits",
+ "spirv",
+ "thiserror",
+]
+
+[[package]]
+name = "ndk"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8794322172319b972f528bf90c6b467be0079f1fa82780ffb431088e741a73ab"
+dependencies = [
+ "jni-sys",
+ "ndk-sys",
+ "num_enum",
+ "thiserror",
+]
+
+[[package]]
+name = "ndk"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d868f654c72e75f8687572699cdabe755f03effbb62542768e995d5b8d699d"
+dependencies = [
+ "bitflags",
+ "jni-sys",
+ "ndk-sys",
+ "num_enum",
+ "thiserror",
+]
+
+[[package]]
+name = "ndk-glue"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc291b8de2095cba8dab7cf381bf582ff4c17a09acf854c32e46545b08085d28"
+dependencies = [
+ "android_logger",
+ "lazy_static",
+ "libc",
+ "log",
+ "ndk 0.5.0",
+ "ndk-macro",
+ "ndk-sys",
+]
+
+[[package]]
+name = "ndk-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121"
+
+[[package]]
+name = "nix"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3bb9a13fa32bc5aeb64150cd3f32d6cf4c748f8f8a417cce5d2eb976a8370ba"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+ "version_check",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "085fe377a4b2805c0fbc09484415ec261174614b7f080b0e0d520456ac421a67"
+dependencies = [
+ "derivative",
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5249369707a1e07b39f78d98c8f34e00aca7dcb053812fdbb5ad7be82c1bba38"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+ "objc_exception",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pixels"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b64b547ca2cfd27fb550a98f9ede4a4058d947bc9ac3d708894c891cff6a429"
+dependencies = [
+ "bytemuck",
+ "pollster",
+ "raw-window-handle 0.3.4",
+ "thiserror",
+ "ultraviolet",
+ "wgpu",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+
+[[package]]
+name = "pollster"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb20dcc30536a1508e75d47dd0e399bb2fe7354dcf35cda9127f2bf1ed92e30e"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -75,6 +921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9926767b8b8244d7b6b64546585121d193c3d0b4856ccd656b7bfa9deb91ab6a"
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,10 +936,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28f55143d0548dad60bb4fbdc835a3d7ac6acc3324506450c5fdd6e42903a76"
+dependencies = [
+ "libc",
+ "raw-window-handle 0.4.2",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba75eee94a9d5273a68c9e1e105d9cffe1ef700532325788389e5a83e2522b7"
+dependencies = [
+ "cty",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "renderdoc-sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "safe_arch"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ff3d6d9696af502cc3110dacce942840fb06ff4514cad92236ecc455f2ce05"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -121,6 +1051,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "slotmap"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "210cf40de565aaaa085face1d860b17f6aee9f76f9d2816307ea2cc45eeb64f3"
+dependencies = [
+ "bitflags",
+ "calloop",
+ "dlib",
+ "lazy_static",
+ "log",
+ "memmap2",
+ "nix",
+ "pkg-config",
+ "wayland-client",
+ "wayland-cursor",
+ "wayland-protocols",
+]
+
+[[package]]
+name = "spirv"
+version = "0.2.0+1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
+dependencies = [
+ "bitflags",
+ "num-traits",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +1118,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -164,6 +1164,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ultraviolet"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b9e3507eba17043af05c8a72fce3ec2c24b58945f45732e71dbc6646d904a7"
+dependencies = [
+ "wide",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,12 +1190,265 @@ version = "0.37.0"
 dependencies = [
  "align-data",
  "bitflags",
- "flaky_test",
  "fslock",
  "lazy_static",
  "libc",
+ "ndk 0.3.0",
+ "ndk-glue",
+ "pixels",
  "trybuild",
  "which",
+ "winit",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "wayland-client"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9108ec1c37f4774d0c2937ba1a6c23d1786b2152c4a13bd9fdb20e42d16e8841"
+dependencies = [
+ "bitflags",
+ "downcast-rs",
+ "libc",
+ "nix",
+ "scoped-tls",
+ "wayland-commons",
+ "wayland-scanner",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-commons"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "265ef51b3b3e5c9ef098f10425c39624663f459c3821dcaacc4748be975f1beb"
+dependencies = [
+ "nix",
+ "once_cell",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c19bb6628daf4097e58b7911481e8371e13318d5a60894779901bd3267407a7"
+dependencies = [
+ "nix",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3b6f1dc0193072ef4eadcb144da30d58c1f2895516c063804d213310703c8e"
+dependencies = [
+ "bitflags",
+ "wayland-client",
+ "wayland-commons",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaaf2bc85e7b9143159af96bd23d954a5abe391c4376db712320643280fdc6f4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "xml-rs",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba9e06acb775b3007f8d3094438306979e572d1d3b844d7a71557a84b055d959"
+dependencies = [
+ "dlib",
+ "lazy_static",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wgpu"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7181fe6ba5f4b632a9079cc9e922a64555156c87def72c063f94b180c7d68"
+dependencies = [
+ "arrayvec",
+ "js-sys",
+ "log",
+ "parking_lot",
+ "raw-window-handle 0.3.4",
+ "smallvec",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35600627b6c718ad0e23ed75fb6140bfe32cdf21c8f539ce3c9ab8180e2cb38e"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg_aliases",
+ "copyless",
+ "fxhash",
+ "log",
+ "naga",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle 0.3.4",
+ "smallvec",
+ "thiserror",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af28b29ef0b44cd22dd9895d4349b9d5a687df42f58da234871198637eabe328"
+dependencies = [
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags",
+ "block",
+ "core-graphics-types",
+ "d3d12",
+ "foreign-types",
+ "fxhash",
+ "glow",
+ "gpu-alloc",
+ "gpu-descriptor",
+ "inplace_it",
+ "js-sys",
+ "khronos-egl",
+ "libloading",
+ "log",
+ "metal",
+ "naga",
+ "objc",
+ "parking_lot",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle 0.3.4",
+ "renderdoc-sys",
+ "thiserror",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "winapi",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e15e44ba88ec415466e18e91881319e7c9e96cb905dc623305168aea65b85ccc"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -191,6 +1459,16 @@ checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
 dependencies = [
  "either",
  "libc",
+]
+
+[[package]]
+name = "wide"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bbe7c604a27ca0b05c5503221e76da628225b568e6f1280b42dbad3b72d89b"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -223,3 +1501,63 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winit"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70466a5f4825cc88c92963591b06dbc255420bffe19d847bfcda475e82d079c0"
+dependencies = [
+ "bitflags",
+ "block",
+ "cocoa",
+ "core-foundation 0.9.2",
+ "core-graphics 0.22.3",
+ "core-video-sys",
+ "dispatch",
+ "instant",
+ "lazy_static",
+ "libc",
+ "log",
+ "mio",
+ "ndk 0.5.0",
+ "ndk-glue",
+ "ndk-sys",
+ "objc",
+ "parking_lot",
+ "percent-encoding",
+ "raw-window-handle 0.4.2",
+ "smithay-client-toolkit",
+ "wasm-bindgen",
+ "wayland-client",
+ "wayland-protocols",
+ "web-sys",
+ "winapi",
+ "x11-dl",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea26926b4ce81a6f5d9d0f3a0bc401e5a37c6ae14a1bfaa8ff6099ca80038c59"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "xcursor"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.42"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1768998d9a3b179411618e377dbb134c58a88cda284b0aa71c42c40660127d46"
+checksum = "9d664de8ea7e531ad4c0f5a834f20b8cb2b8e6dfe88d05796ee7887518ed67b9"
 dependencies = [
  "glob",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "flaky_test"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479cde5eb168cf5a056dd98f311cbfab7494c216394e4fb9eba0336827a8db93"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fslock"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +175,7 @@ version = "0.37.0"
 dependencies = [
  "align-data",
  "bitflags",
+ "flaky_test",
  "fslock",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ fslock = "0.1.6"
 [dev-dependencies]
 trybuild = "1.0.42"
 align-data = "0.1.0"
+flaky_test = "0.1.0"
 
 [[example]]
 name = "hello_world"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ which = "4.1.0"
 fslock = "0.1.6"
 
 [dev-dependencies]
-trybuild = "1.0.42"
+trybuild = "1.0.53"
 align-data = "0.1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "Rust bindings to V8"
 readme = "README.md"
 authors = ["the Deno authors"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/denoland/rusty_v8"
 
 exclude = [
@@ -86,7 +86,12 @@ fslock = "0.1.6"
 [dev-dependencies]
 trybuild = "1.0.42"
 align-data = "0.1.0"
-flaky_test = "0.1.0"
+
+[target.'cfg(target_os = "android")'.dependencies]
+winit = "0.26"
+pixels = "0.8.0"
+ndk = "0.3.0"
+ndk-glue = { version = "0.5.0", features = ["logger"] }
 
 [[example]]
 name = "hello_world"
@@ -96,3 +101,7 @@ name = "shell"
 
 [[example]]
 name = "process"
+
+[[example]]
+name = "android_fractal"
+crate-type = ["cdylib"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -6,5 +6,6 @@ passthrough = [
     "V8_FROM_SOURCE",
     "SCCACHE_ERROR_LOG",
     "SCCACHE_LOG",
-    "SCCACHE_DIR"
+    "SCCACHE_DIR",
+    "SCCACHE_IDLE_TIMEOUT"
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,4 @@
+[build.env]
+passthrough = [
+    "V8_FROM_SOURCE",
+]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,10 @@
+[target.aarch64-linux-android]
+image = "cross:aarch64-linux-android-0.2.1"
+
 [build.env]
 passthrough = [
     "V8_FROM_SOURCE",
+    "SCCACHE_ERROR_LOG",
+    "SCCACHE_LOG",
+    "SCCACHE_DIR"
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN \
 
 RUN chmod +x /sccache-v0.2.15-x86_64-unknown-linux-musl/sccache
 
-ENV RUSTC_WRAPPER=/sccache-v0.2.15-x86_64-unknown-linux-musl/sccache
+ENV SCCACHE=/sccache-v0.2.15-x86_64-unknown-linux-musl/sccache

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM rustembedded/cross:aarch64-linux-android-0.2.1
 
 RUN apt update && \
     apt install -y curl && \
-    curl -L https://github.com/mozilla/sccache/releases/download/0.2.15/sccache-0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+    curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xzf -
 
 ENV TZ=Etc/UTC
 COPY ./build/*.sh /chromium_build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ RUN \
 	&& rm -rf /chromium_build \
 	&& rm -rf /var/lib/apt/lists/*
 
+RUN chmod +x /sccache-v0.2.15-x86_64-unknown-linux-musl/sccache
+
 ENV RUSTC_WRAPPER=/sccache-v0.2.15-x86_64-unknown-linux-musl/sccache

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN \
 	&& rm -rf /chromium_build \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV RUSTC_WRAPPER=/sccache-0.2.15-x86_64-unknown-linux-musl/sccache
+ENV RUSTC_WRAPPER=/sccache-v0.2.15-x86_64-unknown-linux-musl/sccache

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,4 @@ RUN \
 RUN chmod +x /sccache-v0.2.15-x86_64-unknown-linux-musl/sccache
 
 ENV SCCACHE=/sccache-v0.2.15-x86_64-unknown-linux-musl/sccache
+ENV SCCACHE_DIR=./target/sccache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM rustembedded/cross:aarch64-linux-android-0.2.1
+
+RUN apt update && \
+    apt install -y curl && \
+    curl -L https://github.com/mozilla/sccache/releases/download/0.2.15/sccache-0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+
+ENV TZ=Etc/UTC
+COPY ./build/*.sh /chromium_build/
+RUN \
+	DEBIAN_FRONTEND=noninteractive \
+	ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+	&& apt-get update && apt-get install -y lsb-release sudo \
+	&& /chromium_build/install-build-deps-android.sh \
+	&& rm -rf /chromium_build \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV RUSTC_WRAPPER=/sccache-0.2.15-x86_64-unknown-linux-musl/sccache

--- a/build.rs
+++ b/build.rs
@@ -225,7 +225,7 @@ fn maybe_clone_repo(dest: &str, repo: &str) {
   if !Path::new(&dest).exists() {
     assert!(Command::new("git")
       .arg("clone")
-      .arg("--depth=1")
+      .arg("--depth=3")
       .arg(repo)
       .arg(dest)
       .status()

--- a/build.rs
+++ b/build.rs
@@ -120,16 +120,20 @@ fn build_v8() {
     gn_args.push("host_cpu=\"arm64\"".to_string())
   } 
 
-  if let Some(clang_base_path) = find_compatible_system_clang() {
+  if cfg!(target_os = "android") && cfg!(target_arch = "aarch64") { 
+    gn_args.push(format!("clang_base_path={:?}", "third_party/llvm-build/Release+Asserts"));
+    gn_args.push("clang_use_chrome_plugins=false".to_string());
+    gn_args.push("treat_warnings_as_errors=false".to_string());
+  } else if let Some(clang_base_path) = find_compatible_system_clang() {
     println!("clang_base_path {}", clang_base_path.display());
-    gn_args.push(format!("clang_base_path={:?}", "/home/divy/Desktop/gh/v8/v8/third_party/llvm-build/Release+Asserts"));
+    gn_args.push(format!("clang_base_path={:?}", clang_base_path));
     // TODO: Dedupe this with the one from cc_wrapper()
     gn_args.push("treat_warnings_as_errors=false".to_string());
     // we can't use chromiums clang plugins with a system clang
     gn_args.push("clang_use_chrome_plugins=false".to_string());
   } else {
-    let _clang_base_path = clang_download();
-    gn_args.push(format!("clang_base_path={:?}", "/home/divy/Desktop/gh/v8/v8/third_party/llvm-build/Release+Asserts/"));
+    let clang_base_path = clang_download();
+    gn_args.push(format!("clang_base_path={:?}", clang_base_path));
   }
 
   if let Some(p) = env::var_os("SCCACHE") {

--- a/build.rs
+++ b/build.rs
@@ -57,9 +57,6 @@ fn main() {
     if env::var_os("V8_FROM_SOURCE").is_some() {
       build_v8()
     } else {
-      // println!("cargo:rustc-link-search=.");
-      // println!("cargo:rustc-link-lib=static=rusty_v8");
-
       // utilize a lockfile to prevent linking of
       // only partially downloaded static library.
       let root = env::current_dir().unwrap();

--- a/build.rs
+++ b/build.rs
@@ -103,6 +103,7 @@ fn build_v8() {
 
   // On windows, rustc cannot link with a V8 debug build.
   let mut gn_args = if is_debug() && !cfg!(target_os = "windows") {
+    // Note: When building for Android aarch64-qemu, use release instead of debug.
     vec!["is_debug=true".to_string()]
   } else {
     vec!["is_debug=false".to_string()]

--- a/build.rs
+++ b/build.rs
@@ -59,7 +59,7 @@ fn main() {
     } else {
       // println!("cargo:rustc-link-search=.");
       // println!("cargo:rustc-link-lib=static=rusty_v8");
-      
+
       // utilize a lockfile to prevent linking of
       // only partially downloaded static library.
       let root = env::current_dir().unwrap();
@@ -118,10 +118,13 @@ fn build_v8() {
   // Fix GN's host_cpu detection when using x86_64 bins on Apple Silicon
   if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
     gn_args.push("host_cpu=\"arm64\"".to_string())
-  } 
+  }
 
-  if cfg!(target_os = "android") && cfg!(target_arch = "aarch64") { 
-    gn_args.push(format!("clang_base_path={:?}", "third_party/llvm-build/Release+Asserts"));
+  if cfg!(target_os = "android") && cfg!(target_arch = "aarch64") {
+    gn_args.push(format!(
+      "clang_base_path={:?}",
+      "third_party/llvm-build/Release+Asserts"
+    ));
     gn_args.push("clang_use_chrome_plugins=false".to_string());
     gn_args.push("treat_warnings_as_errors=false".to_string());
   } else if let Some(clang_base_path) = find_compatible_system_clang() {
@@ -158,7 +161,9 @@ fn build_v8() {
   // check if the target triple describes a non-native environment
   if target_triple != env::var("HOST").unwrap() {
     // cross-compilation setup
-    if target_triple == "aarch64-unknown-linux-gnu" || target_triple == "aarch64-linux-android" {
+    if target_triple == "aarch64-unknown-linux-gnu"
+      || target_triple == "aarch64-linux-android"
+    {
       gn_args.push(r#"target_cpu="arm64""#.to_string());
       gn_args.push("use_sysroot=true".to_string());
       maybe_install_sysroot("arm64");
@@ -168,7 +173,7 @@ fn build_v8() {
     if target_triple == "aarch64-linux-android" {
       gn_args.push("is_component_build=false".to_string());
       gn_args.push(r#"v8_target_cpu="arm64""#.to_string());
-      gn_args.push(r#"target_os="android""#.to_string());      
+      gn_args.push(r#"target_os="android""#.to_string());
     };
 
     gn_args.push("treat_warnings_as_errors=false".to_string());

--- a/build.rs
+++ b/build.rs
@@ -172,19 +172,15 @@ fn build_v8() {
       gn_args.push(r#"target_os="android""#.to_string());
 
       gn_args.push("treat_warnings_as_errors=false".to_string());
-      static CHROMIUM_URI: &str = "https://chromium.googlesource.com";
-
-      maybe_clone_repo(
-        "./third_party/android_ndk",
-        &format!("{}/android_ndk.git", CHROMIUM_URI),
-      );
 
       // NDK 23 and above removes libgcc entirely.
       // https://github.com/rust-lang/rust/pull/85806
-      checkout(
+      maybe_clone_repo(
         "./third_party/android_ndk",
-        "401019bf85744311b26c88ced255cd53401af8b7",
+        "https://github.com/denoland/android_ndk.git",
       );
+
+      static CHROMIUM_URI: &str = "https://chromium.googlesource.com";
 
       maybe_clone_repo(
         "./third_party/android_platform",
@@ -212,21 +208,11 @@ fn build_v8() {
   build("rusty_v8", None);
 }
 
-fn checkout(dest: &str, tag: &str) {
-  assert!(Command::new("git")
-    .arg("checkout")
-    .arg(tag)
-    .current_dir(dest)
-    .status()
-    .unwrap()
-    .success());
-}
-
 fn maybe_clone_repo(dest: &str, repo: &str) {
   if !Path::new(&dest).exists() {
     assert!(Command::new("git")
       .arg("clone")
-      .arg("--depth=3")
+      .arg("--depth=1")
       .arg(repo)
       .arg(dest)
       .status()

--- a/examples/android_fractal.js
+++ b/examples/android_fractal.js
@@ -1,0 +1,68 @@
+function DrawFrame(frameLen) {
+  const u8 = new Uint8Array(frameLen);
+  const width = 800;
+  const height = 800;
+
+  let x = y = 0;
+
+  for (let i = 0; i < u8.byteLength; i += 4) {
+    if (x == width) {
+      y++;
+      x = 0;
+    }
+
+    x += 1;
+    let r = Math.floor(0.3 * x);
+    let b = Math.floor(0.3 * y);
+
+    u8.set([r, 0x00, b, 0xff], i);
+  }
+
+  let scale_x = 3.0 / width;
+  let scale_y = 3.0 / height;
+
+  for (let x = 0; x < width; x++) {
+    for (let y = 0; y < height; y++) {
+      let cx = y * scale_x - 1.5;
+      let cy = x * scale_y - 1.5;
+
+      let c = new Complex(-0.4, 0.6);
+      let z = new Complex(cx, cy);
+
+      let i = 0;
+      while (i < 100 && z.abs() < 2) {
+        z = z.mul(z).add(c);
+        i++;
+      }
+
+      u8.set([0x00, i, 0x00, 0xff], (y * width + x) * 4);
+    }
+  }
+
+  return u8.buffer;
+}
+
+class Complex {
+  constructor(real, imag) {
+    this.real = real;
+    this.imag = imag;
+  }
+
+  mul(other) {
+    return new Complex(
+      this.real * other.real - this.imag * other.imag,
+      this.real * other.imag + this.imag * other.real,
+    );
+  }
+
+  add(other) {
+    return new Complex(
+      this.real + other.real,
+      this.imag + other.imag,
+    );
+  }
+
+  abs() {
+    return Math.sqrt(this.real * this.real + this.imag * this.imag);
+  }
+}

--- a/examples/android_fractal.js
+++ b/examples/android_fractal.js
@@ -1,3 +1,4 @@
+// Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
 function DrawFrame(frameLen) {
   const u8 = new Uint8Array(frameLen);
   const width = 800;

--- a/examples/android_fractal.rs
+++ b/examples/android_fractal.rs
@@ -51,6 +51,10 @@ fn main() {
           event: winit::event::WindowEvent::CloseRequested,
           ..
         } => *control_flow = winit::event_loop::ControlFlow::Exit,
+        // Drawing on android must only happen before Event::Suspended and
+        // after Event::Resumed.
+        //
+        // https://github.com/rust-windowing/winit/issues/1588
         winit::event::Event::Resumed => {
           allowed = true;
         }

--- a/examples/android_fractal.rs
+++ b/examples/android_fractal.rs
@@ -1,5 +1,9 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
+
+// Don't run on non-Android targets.
 #![cfg(target_os = "android")]
+// Don't run this as a test in `--all-targets` mode.
+#![cfg(not(test))]
 
 use pixels::Pixels;
 use pixels::SurfaceTexture;

--- a/examples/android_fractal.rs
+++ b/examples/android_fractal.rs
@@ -1,0 +1,148 @@
+use pixels::Pixels;
+use pixels::SurfaceTexture;
+use std::cell::Cell;
+use winit::platform::run_return::EventLoopExtRunReturn;
+
+#[cfg(target_os = "android")]
+#[ndk_glue::main(
+  backtrace = "on",
+  logger(level = "debug", tag = "android_fractal")
+)]
+fn main() {
+  let mut event_loop = winit::event_loop::EventLoop::new();
+  let window = winit::window::WindowBuilder::new()
+    .with_title("rusty_v8 android_fractal")
+    .build(&event_loop)
+    .unwrap();
+
+  // Initialize V8.
+  let platform = v8::new_default_platform(0, false).make_shared();
+  v8::V8::initialize_platform(platform);
+  v8::V8::initialize();
+
+  let mut isolate = v8::Isolate::new(v8::CreateParams::default());
+  let mut scope = v8::HandleScope::new(&mut isolate);
+  let source =
+    v8::String::new(&mut scope, include_str!("android_fractal.js")).unwrap();
+
+  let context = v8::Context::new(&mut scope);
+  let mut context_scope = v8::ContextScope::new(&mut scope, context);
+
+  execute_script(&mut context_scope, source);
+
+  let draw_str = v8::String::new(&mut context_scope, "DrawFrame").unwrap();
+  let draw_fn = context
+    .global(&mut context_scope)
+    .get(&mut context_scope, draw_str.into())
+    .expect("missing function DrawFrame");
+
+  let draw_fn =
+    v8::Local::<v8::Function>::try_from(draw_fn).expect("function expected");
+
+  let mut allowed = false;
+
+  loop {
+    event_loop.run_return(|event, _, control_flow| {
+      *control_flow = winit::event_loop::ControlFlow::Wait;
+      match event {
+        winit::event::Event::WindowEvent {
+          event: winit::event::WindowEvent::CloseRequested,
+          ..
+        } => *control_flow = winit::event_loop::ControlFlow::Exit,
+        winit::event::Event::Resumed => {
+          allowed = true;
+        }
+        winit::event::Event::Suspended => {
+          allowed = false;
+        }
+        winit::event::Event::RedrawRequested(_) => {
+          if !allowed {
+            return;
+          }
+          let surface_texture = SurfaceTexture::new(800, 800, &window);
+          let mut pixels = Pixels::new(800, 800, surface_texture).unwrap();
+
+          draw(&mut context_scope, draw_fn, pixels.get_frame());
+
+          if pixels.render().is_err() {
+            *control_flow = winit::event_loop::ControlFlow::Exit;
+            return;
+          }
+        }
+        _ => {}
+      }
+
+      window.request_redraw();
+    });
+  }
+}
+
+fn execute_script(
+  context_scope: &mut v8::ContextScope<v8::HandleScope>,
+  script: v8::Local<v8::String>,
+) {
+  let scope = &mut v8::HandleScope::new(context_scope);
+  let try_catch = &mut v8::TryCatch::new(scope);
+
+  let script = v8::Script::compile(try_catch, script, None)
+    .expect("failed to compile script");
+
+  if script.run(try_catch).is_none() {
+    let exception = try_catch.exception().unwrap();
+    let exception_string = exception
+      .to_string(try_catch)
+      .unwrap()
+      .to_rust_string_lossy(try_catch);
+
+    panic!("{}", exception_string);
+  }
+}
+
+fn draw(
+  context_scope: &mut v8::ContextScope<v8::HandleScope>,
+  draw_fn: v8::Local<v8::Function>,
+  frame: &mut [u8],
+) {
+  let scope = &mut v8::HandleScope::new(context_scope);
+  let recv = v8::undefined(scope);
+  let try_catch = &mut v8::TryCatch::new(scope);
+
+  let len = frame.len();
+  let frame_len = v8::Integer::new(try_catch, len as i32);
+
+  let ab = match draw_fn.call(try_catch, recv.into(), &[frame_len.into()]) {
+    Some(ab) => ab,
+    None => {
+      let exception = try_catch.exception().unwrap();
+      let exception_string = exception
+        .to_string(try_catch)
+        .unwrap()
+        .to_rust_string_lossy(try_catch);
+
+      panic!("{}", exception_string);
+    }
+  };
+
+  let ab =
+    v8::Local::<v8::ArrayBuffer>::try_from(ab).expect("array buffer expected");
+  let bs = ab.get_backing_store();
+
+  let js_frame = unsafe { get_backing_store_slice(&bs, 0, len) };
+  frame.copy_from_slice(js_frame.as_ref());
+}
+
+unsafe fn get_backing_store_slice(
+  backing_store: &v8::SharedRef<v8::BackingStore>,
+  byte_offset: usize,
+  byte_length: usize,
+) -> &[u8] {
+  let cells: *const [Cell<u8>] =
+    &backing_store[byte_offset..byte_offset + byte_length];
+  let bytes = cells as *const [u8];
+  &*bytes
+}
+
+#[cfg(not(target_os = "android"))]
+fn main() {
+  println!("This example is only available on Android. Compile with `--target=aarch64-linux-android`");
+}

--- a/examples/android_fractal.rs
+++ b/examples/android_fractal.rs
@@ -94,11 +94,11 @@ fn execute_script(
     .expect("failed to compile script");
 
   if script.run(try_catch).is_none() {
-    let exception = try_catch.exception().unwrap();
-    let exception_string = exception
-      .to_string(try_catch)
-      .unwrap()
-      .to_rust_string_lossy(try_catch);
+    let exception_string = try_catch
+      .stack_trace()
+      .or_else(|| try_catch.exception())
+      .map(|value| value.to_rust_string_lossy(try_catch))
+      .unwrap_or_else(|| "no stack trace".into());
 
     panic!("{}", exception_string);
   }
@@ -119,11 +119,11 @@ fn draw(
   let ab = match draw_fn.call(try_catch, recv.into(), &[frame_len.into()]) {
     Some(ab) => ab,
     None => {
-      let exception = try_catch.exception().unwrap();
-      let exception_string = exception
-        .to_string(try_catch)
-        .unwrap()
-        .to_rust_string_lossy(try_catch);
+      let exception_string = try_catch
+        .stack_trace()
+        .or_else(|| try_catch.exception())
+        .map(|value| value.to_rust_string_lossy(try_catch))
+        .unwrap_or_else(|| "no stack trace".into());
 
       panic!("{}", exception_string);
     }

--- a/examples/android_fractal.rs
+++ b/examples/android_fractal.rs
@@ -1,9 +1,10 @@
+#![cfg(target_os = "android")]
+
 use pixels::Pixels;
 use pixels::SurfaceTexture;
 use std::cell::Cell;
 use winit::platform::run_return::EventLoopExtRunReturn;
 
-#[cfg(target_os = "android")]
 #[ndk_glue::main(
   backtrace = "on",
   logger(level = "debug", tag = "android_fractal")
@@ -140,9 +141,4 @@ unsafe fn get_backing_store_slice(
     &backing_store[byte_offset..byte_offset + byte_length];
   let bytes = cells as *const [u8];
   &*bytes
-}
-
-#[cfg(not(target_os = "android"))]
-fn main() {
-  println!("This example is only available on Android. Compile with `--target=aarch64-linux-android`");
 }

--- a/examples/android_fractal.rs
+++ b/examples/android_fractal.rs
@@ -1,3 +1,4 @@
+// Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
 #![cfg(target_os = "android")]
 
 use pixels::Pixels;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -121,7 +121,6 @@ pub struct CompiledWasmModule(*mut InternalCompiledWasmModule);
 impl CompiledWasmModule {
   /// Get the (wasm-encoded) wire bytes that were used to compile this module.
   pub fn get_wire_bytes_ref(&self) -> &[u8] {
-    use std::convert::TryInto;
     let mut len = 0isize;
     unsafe {
       let ptr = v8__CompiledWasmModule__GetWireBytesRef(self.0, &mut len);

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -857,6 +857,7 @@ fn thread_safe_handle_drop_after_isolate() {
   assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 0);
 }
 
+#[cfg(not(target_os = "android"))]
 #[test]
 fn terminate_execution() {
   let _setup_guard = setup();

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4841,6 +4841,8 @@ fn value_serializer_not_implemented() {
   );
 }
 
+// Flaky on aarch64-qemu (Stack corruption).
+#[cfg(not(target_os = "android"))]
 #[test]
 fn clear_kept_objects() {
   let _setup_guard = setup();

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -857,6 +857,8 @@ fn thread_safe_handle_drop_after_isolate() {
   assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 0);
 }
 
+// QEMU doesn't like when we spawn threads
+// This works just fine on real hardware
 #[cfg(not(target_os = "android"))]
 #[test]
 fn terminate_execution() {
@@ -5530,7 +5532,7 @@ fn counter_lookup_callback() {
   assert_ne!(count, 0);
 }
 
-#[test]
+#[cfg(not(target_os = "android"))]
 fn compiled_wasm_module() {
   let _setup_guard = setup();
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -5533,6 +5533,7 @@ fn counter_lookup_callback() {
 }
 
 #[cfg(not(target_os = "android"))]
+#[test]
 fn compiled_wasm_module() {
   let _setup_guard = setup();
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4173,6 +4173,8 @@ extern "C" fn heap_limit_callback(
   current_heap_limit * 2 // Avoid V8 OOM.
 }
 
+// Flaky on Android QEMU in debug builds.
+#[cfg(not(target_os = "android"))]
 // This test might fail due to a bug in V8. The upstream bug report is at
 // https://bugs.chromium.org/p/v8/issues/detail?id=10843.
 #[test]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4173,8 +4173,6 @@ extern "C" fn heap_limit_callback(
   current_heap_limit * 2 // Avoid V8 OOM.
 }
 
-// Flaky on Android QEMU in debug builds.
-#[cfg(not(target_os = "android"))]
 // This test might fail due to a bug in V8. The upstream bug report is at
 // https://bugs.chromium.org/p/v8/issues/detail?id=10843.
 #[test]

--- a/tests/test_concurrent_isolate_creation_and_disposal.rs
+++ b/tests/test_concurrent_isolate_creation_and_disposal.rs
@@ -1,3 +1,7 @@
+// This is flaky on cross (QEMU bug)
+// but otherwise works fine on real device.
+#![cfg(not(target_os = "android"))]
+
 use std::iter::repeat_with;
 use std::thread;
 

--- a/tests/test_ui.rs
+++ b/tests/test_ui.rs
@@ -1,5 +1,7 @@
 use std::env;
 
+// Don't run UI tests on emulated environment.
+#[cfg(not(target_os = "android"))]
 #[test]
 fn ui() {
   // This environment variable tells build.rs that we're running trybuild tests,


### PR DESCRIPTION
Adds support for `aarch64-linux-android`.
Continuation of #270 with testing and build cache enabled.

Also adds a little frame buffer example (`example/android_fractal.rs`):
<image src="https://user-images.githubusercontent.com/34997667/147415649-bd9b1a45-bab9-4e15-b6fa-144b3c49ba6e.png" width=246 height=533 />
