### PR TITLE
fix: re-enable v8 snapshot compression

### DIFF
--- a/.gn
+++ b/.gn
@@ -35,6 +35,7 @@ default_args = {
   # https://cs.chromium.org/chromium/src/docs/ccache_mac.md
   clang_use_chrome_plugins = false
   v8_monolithic = false
+  v8_enable_snapshot_compression = true
   v8_use_external_startup_data = false
   v8_use_snapshot = true
   is_component_build = false


### PR DESCRIPTION
It was disabled upstream¹, citing a minimal size bump of ~400 kB.
However Deno got ~24 MB bigger, which is unacceptable.

¹ https://chromium-review.googlesource.com/c/v8/v8/+/3275554