### PR TITLE
Disable snapshot compression on all platforms

### DIFF
--- a/.gn
+++ b/.gn
@@ -35,7 +35,7 @@ default_args = {
   # https://cs.chromium.org/chromium/src/docs/ccache_mac.md
   clang_use_chrome_plugins = false
   v8_monolithic = false
-  v8_enable_snapshot_compression = true
+  v8_enable_snapshot_compression = false
   v8_use_external_startup_data = false
   v8_use_snapshot = true
   is_component_build = false


### PR DESCRIPTION
It turns out that the embedder can selectively compress snapshots,
resulting in better startup performance and a smaller binary size.

See https://github.com/denoland/deno/pull/13320.
