### PR TITLE
Add support for v8::Object.set_integrity_level

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1170,6 +1170,18 @@ const v8::Value* v8__Object__GetInternalField(const v8::Object& self,
   return local_to_ptr(ptr_to_local(&self)->GetInternalField(index));
 }
 
+static_assert(static_cast<int>(v8::IntegrityLevel::kFrozen) == 0,
+              "v8::IntegrityLevel::kFrozen is not 0");
+static_assert(static_cast<int>(v8::IntegrityLevel::kSealed) == 1,
+              "v8::IntegrityLevel::kSealed is not 1");
+
+MaybeBool v8__Object__SetIntegrityLevel(const v8::Object& self,
+                                        const v8::Context& context,
+                                        v8::IntegrityLevel level) {
+  return maybe_to_maybe_bool(
+      ptr_to_local(&self)->SetIntegrityLevel(ptr_to_local(&context), level));
+}
+
 void v8__Object__SetInternalField(const v8::Object& self, int index,
                                   const v8::Value& value) {
   ptr_to_local(&self)->SetInternalField(index, ptr_to_local(&value));

--- a/src/object.rs
+++ b/src/object.rs
@@ -114,6 +114,11 @@ extern "C" {
     this: *const Object,
     index: int,
   ) -> *const Value;
+  fn v8__Object__SetIntegrityLevel(
+    this: *const Object,
+    context: *const Context,
+    level: IntegrityLevel,
+  ) -> MaybeBool;
   fn v8__Object__SetInternalField(
     this: *const Object,
     index: int,
@@ -487,6 +492,18 @@ impl Object {
     None
   }
 
+  /// Sets the integrity level of the object.
+  pub fn set_integrity_level(
+    &self,
+    scope: &mut HandleScope,
+    level: IntegrityLevel,
+  ) -> Option<bool> {
+    unsafe {
+      v8__Object__SetIntegrityLevel(self, &*scope.get_current_context(), level)
+    }
+    .into()
+  }
+
   /// Sets the value in an internal field. Returns false when the index
   /// is out of bounds, true otherwise.
   pub fn set_internal_field(&self, index: usize, value: Local<Value>) -> bool {
@@ -569,6 +586,19 @@ impl Object {
     }
     .into()
   }
+}
+
+/// Object integrity levels can be used to restrict what can be done to an
+/// object's properties.
+#[repr(C)]
+pub enum IntegrityLevel {
+  /// Frozen objects are like Sealed objects, except all existing properties are
+  /// also made non-writable.
+  Frozen,
+  /// Sealed objects prevent addition of any new property on the object, makes
+  /// all existing properties non-configurable, meaning they cannot be deleted,
+  /// have their enumerability, configurability, or writability changed.
+  Sealed,
 }
 
 impl Array {

--- a/src/object.rs
+++ b/src/object.rs
@@ -590,6 +590,7 @@ impl Object {
 
 /// Object integrity levels can be used to restrict what can be done to an
 /// object's properties.
+#[derive(Debug)]
 #[repr(C)]
 pub enum IntegrityLevel {
   /// Frozen objects are like Sealed objects, except all existing properties are

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1559,20 +1559,17 @@ fn object() {
     let object_string = v8::String::new(scope, "o").unwrap().into();
     global.set(scope, object_string, object.into());
 
-    let true_value = v8::Boolean::new(scope, true);
-    let false_value = v8::Boolean::new(scope, false);
-
-    assert_eq!(eval(scope, "Object.isExtensible(o)").unwrap(), true_value);
-    assert_eq!(eval(scope, "Object.isSealed(o)").unwrap(), false_value);
-    assert_eq!(eval(scope, "Object.isFrozen(o)").unwrap(), false_value);
+    assert!(eval(scope, "Object.isExtensible(o)").unwrap().is_true());
+    assert!(eval(scope, "Object.isSealed(o)").unwrap().is_false());
+    assert!(eval(scope, "Object.isFrozen(o)").unwrap().is_false());
 
     assert!(object
       .set_integrity_level(scope, v8::IntegrityLevel::Sealed)
       .unwrap());
 
-    assert_eq!(eval(scope, "Object.isExtensible(o)").unwrap(), false_value);
-    assert_eq!(eval(scope, "Object.isSealed(o)").unwrap(), true_value);
-    assert_eq!(eval(scope, "Object.isFrozen(o)").unwrap(), false_value);
+    assert!(eval(scope, "Object.isExtensible(o)").unwrap().is_false());
+    assert!(eval(scope, "Object.isSealed(o)").unwrap().is_true());
+    assert!(eval(scope, "Object.isFrozen(o)").unwrap().is_false());
     // Creating new properties is not allowed anymore
     eval(scope, "o.p = true").unwrap();
     assert!(!object.has(scope, p).unwrap());
@@ -1580,15 +1577,15 @@ fn object() {
     eval(scope, "delete o.b").unwrap();
     assert!(object.has(scope, n2.into()).unwrap());
     // But we can still write new values.
-    assert_eq!(eval(scope, "o.b = true; o.b").unwrap(), true_value);
+    assert!(eval(scope, "o.b = true; o.b").unwrap().is_true());
 
     assert!(object
       .set_integrity_level(scope, v8::IntegrityLevel::Frozen)
       .unwrap());
 
-    assert_eq!(eval(scope, "Object.isExtensible(o)").unwrap(), false_value);
-    assert_eq!(eval(scope, "Object.isSealed(o)").unwrap(), true_value);
-    assert_eq!(eval(scope, "Object.isFrozen(o)").unwrap(), true_value);
+    assert!(eval(scope, "Object.isExtensible(o)").unwrap().is_false());
+    assert!(eval(scope, "Object.isSealed(o)").unwrap().is_true());
+    assert!(eval(scope, "Object.isFrozen(o)").unwrap().is_true());
     // Creating new properties is not allowed anymore
     eval(scope, "o.p = true").unwrap();
     assert!(!object.has(scope, p).unwrap());
@@ -1596,7 +1593,7 @@ fn object() {
     eval(scope, "delete o.b").unwrap();
     assert!(object.has(scope, n2.into()).unwrap());
     // And we can also not write new values
-    assert_eq!(eval(scope, "o.b = false; o.b").unwrap(), true_value);
+    assert!(eval(scope, "o.b = false; o.b").unwrap().is_true());
   }
 }
 


### PR DESCRIPTION
This allows making objects frozen or sealed from rust code. This is
useful to control mutations that are allowed to happen in JS on the
given object.