### PR TITLE
chore: remove "stop sscache" ci step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,9 +231,3 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish -vv
-
-      - name: Stop sccache
-        if: always()
-        run: |
-          sccache --show-stats
-          sccache --stop-server


### PR DESCRIPTION
Fails regularly and inexplicably even though installing and starting
sscache works just fine:

    /home/runner/work/_temp/c2b88417-fdca-4378-b8c3-66cea7ddc094.sh:
    line 1: sccache: command not found

It's probably a path issue but as there doesn't seem to be much point in
stopping it explicitly, I'm opting to simply remove that CI build step
altogether.