### PR TITLE
[WIP] Add builds for iOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       # e.g. a flaky test.
       # Don't fast-fail on tag build because publishing binaries shouldn't be
       # prevented if 'cargo publish' fails (which can be a false negative).
-      fail-fast:
-        ${{ github.event_name == 'pull_request' || (github.ref !=
-        'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')) }}
+      # fail-fast:
+      #   ${{ github.event_name == 'pull_request' || (github.ref !=
+      #   'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')) }}
       matrix:
         config:
           - os: macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,30 @@ jobs:
             target: x86_64-apple-darwin
             variant: release
 
+          - os: macOS-latest
+            target: aarch64-apple-ios-sim
+            variant: debug
+
+          - os: macOS-latest
+            target: aarch64-apple-ios-sim
+            variant: release
+
+          - os: macOS-latest
+            target: x86_64-apple-ios
+            variant: debug
+
+          - os: macOS-latest
+            target: x86_64-apple-ios
+            variant: release
+
+          - os: macOS-latest
+            target: aarch64-apple-ios
+            variant: debug
+
+          - os: macOS-latest
+            target: aarch64-apple-ios
+            variant: release
+
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-20.04-xl' || 'ubuntu-18.04' }}
             target: x86_64-unknown-linux-gnu
             variant: debug
@@ -94,6 +118,21 @@ jobs:
 
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc-10" >> ${GITHUB_ENV}
           echo "QEMU_LD_PREFIX=/usr/aarch64-linux-gnu" >> ${GITHUB_ENV}
+
+      - name: Install cross compilation toolchain for iOS simulator (arm64)
+        if: matrix.config.target == 'aarch64-apple-ios-sim'
+        run: |
+          rustup target add aarch64-apple-ios-sim
+
+      - name: Install cross compilation toolchain for iOS simulator (x86_64)
+        if: matrix.config.target == 'x86_64-apple-ios'
+        run: |
+          rustup target add x86_64-apple-ios
+
+      - name: Install cross compilation toolchain for iOS device (arm64)
+        if: matrix.config.target == 'aarch64-apple-ios'
+        run: |
+          rustup target add aarch64-apple-ios
 
       - name: Write git_submodule_status.txt
         run: git submodule status --recursive > git_submodule_status.txt

--- a/build.rs
+++ b/build.rs
@@ -129,6 +129,35 @@ fn build_v8() {
     gn_args.push("host_cpu=\"arm64\"".to_string())
   }
 
+  let target = env::var("TARGET").unwrap();
+  if cfg!(target_os = "macos") && target.contains("apple-ios") {
+    // Gn configurations for iOS: https://v8.dev/docs/cross-compile-ios
+    let arch = {
+      if target.starts_with("aarch64") {
+        "arm64"
+      } else {
+        "x64"
+      }
+    };
+
+    let ios_deployment_target =
+      env::var("IOS_DEPLOYMENT_TARGET").unwrap_or("10".to_string());
+
+    gn_args.push("target_os = \"ios\"".to_string());
+    gn_args.push(format!("target_cpu = \"{}\"", arch));
+    gn_args.push(format!("v8_target_cpu = \"{}\"", arch));
+    gn_args.push(format!("ios_deployment_target = {}", ios_deployment_target));
+    gn_args.push("enable_ios_bitcode = true".to_string());
+    gn_args.push("is_component_build = false".to_string());
+    gn_args.push("use_custom_libcxx = false".to_string());
+    gn_args.push("use_xcode_clang = true".to_string());
+    gn_args.push("v8_enable_i18n_support = false".to_string());
+    gn_args.push("v8_monolithic = true".to_string());
+    gn_args.push("v8_use_external_startup_data = false".to_string());
+    gn_args.push("v8_enable_pointer_compression = false".to_string());
+    gn_args.push("v8_enable_shared_ro_heap = true".to_string());
+  }
+
   if let Some(clang_base_path) = find_compatible_system_clang() {
     println!("clang_base_path {}", clang_base_path.display());
     gn_args.push(format!("clang_base_path={:?}", clang_base_path));


### PR DESCRIPTION
According the gn args listed at <https://v8.dev/docs/cross-compile-ios>, I added required configurations in `build.rs`.

In addition to these targets, I plan to add support for Mac Catalyst in follow-up PRs:

```shell
$ rustc +nightly --print target-list | grep macabi
aarch64-apple-ios-macabi
x86_64-apple-ios-macabi
```


### Can we use v8 on iOS?

TLDR: Yes. 

Apple only limits HTML and JavaScript engine for browser apps: 
> 2.5.6 Apps that browse the web must use the appropriate WebKit framework and WebKit Javascript.
https://developer.apple.com/app-store/review/guidelines/#minimum-functionality

There're existing cases for non JavaScript core use cases including [Hermes](https://reactnative.dev/docs/hermes/), [V8 in NativeScript](https://blog.nativescript.org/the-new-ios-runtime-powered-by-v8/).