### PR TITLE
Make v8::script_compiler::Source.get_cached_data return Option

### DIFF
--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -143,8 +143,15 @@ impl Source {
     }
   }
 
-  pub fn get_cached_data(&self) -> &CachedData {
-    unsafe { &*v8__ScriptCompiler__Source__GetCachedData(self) }
+  pub fn get_cached_data(&self) -> Option<&CachedData> {
+    unsafe {
+      let cached_data = v8__ScriptCompiler__Source__GetCachedData(self);
+      if cached_data.is_null() {
+        None
+      } else {
+        Some(&*cached_data)
+      }
+    }
   }
 }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -5320,6 +5320,7 @@ fn create_module<'s>(
     false,
     true,
   );
+  let has_cache = code_cache.is_some();
   let source = match code_cache {
     Some(x) => v8::script_compiler::Source::new_with_cached_data(
       source,
@@ -5328,6 +5329,7 @@ fn create_module<'s>(
     ),
     None => v8::script_compiler::Source::new(source, Some(&script_origin)),
   };
+  assert_eq!(source.get_cached_data().is_some(), has_cache);
   let module = v8::script_compiler::compile_module2(
     scope,
     source,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2348,6 +2348,8 @@ fn script_compiler_source() {
       Some(&script_origin),
     );
 
+    assert!(source.get_cached_data().is_none());
+
     let result = v8::script_compiler::compile_module(scope, source);
     assert!(result.is_some());
   }


### PR DESCRIPTION
The `cached_data` property of `Source` is optional, so reading the value
should return `Option<&CachedData>`.

Fixes #884