### PR TITLE
Add bindings for String::kMaxLength / TypedArray::kMaxLength

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -457,6 +457,8 @@ bool v8__Data__IsFunctionTemplate(const v8::Data& self) {
   return self.IsFunctionTemplate();
 }
 
+size_t v8__TypedArray__kMaxLength() { return v8::TypedArray::kMaxLength; }
+
 bool v8__Value__IsUndefined(const v8::Value& self) {
   return self.IsUndefined();
 }
@@ -848,6 +850,8 @@ long std__shared_ptr__v8__ArrayBuffer__Allocator__use_count(
 int v8__Name__GetIdentityHash(const v8::Name& self) {
   return ptr_to_local(&self)->GetIdentityHash();
 }
+
+size_t v8__String__kMaxLength() { return v8::String::kMaxLength; }
 
 const v8::String* v8__String__Empty(v8::Isolate* isolate) {
   return local_to_ptr(v8::String::Empty(isolate));

--- a/src/external_references.rs
+++ b/src/external_references.rs
@@ -3,15 +3,17 @@ use crate::support::intptr_t;
 use crate::AccessorNameGetterCallback;
 use crate::FunctionCallback;
 use crate::MessageCallback;
+use std::os::raw::c_void;
 
 #[derive(Clone, Copy)]
 pub union ExternalReference<'s> {
   pub function: FunctionCallback,
   pub getter: AccessorNameGetterCallback<'s>,
   pub message: MessageCallback,
+  pub pointer: *mut c_void,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ExternalReferences {
   null_terminated: Vec<intptr_t>,
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -11,6 +11,8 @@ use crate::Local;
 use crate::String;
 
 extern "C" {
+  fn v8__String__kMaxLength() -> libc::size_t;
+
   fn v8__String__Empty(isolate: *mut Isolate) -> *const String;
 
   fn v8__String__NewFromUtf8(
@@ -115,6 +117,13 @@ bitflags! {
 }
 
 impl String {
+  /// The maximum length (in bytes) of a buffer that a v8::String can be built
+  /// from. Attempting to create a v8::String from a larger buffer will result
+  /// in None being returned.
+  pub fn max_length() -> usize {
+    unsafe { v8__String__kMaxLength() }
+  }
+
   pub fn empty<'s>(scope: &mut HandleScope<'s, ()>) -> Local<'s, String> {
     // FIXME(bnoordhuis) v8__String__Empty() is infallible so there
     // is no need to box up the result, only to unwrap it again.

--- a/src/typed_array.rs
+++ b/src/typed_array.rs
@@ -2,6 +2,20 @@
 use crate::ArrayBuffer;
 use crate::HandleScope;
 use crate::Local;
+use crate::TypedArray;
+
+extern "C" {
+  fn v8__TypedArray__kMaxLength() -> libc::size_t;
+}
+
+impl TypedArray {
+  /// The maximum length (in bytes) of the buffer backing a v8::TypedArray
+  /// instance. Attempting to create a v8::ArrayBuffer from a larger buffer will
+  /// result in a fatal error.
+  pub fn max_length() -> usize {
+    unsafe { v8__TypedArray__kMaxLength() }
+  }
+}
 
 macro_rules! typed_array {
   ($name:ident, $func:ident) => {


### PR DESCRIPTION
Those are useful for pre-checking buffer sizes before attempting to create
a new String or typed array (or ArrayBuffer). Also useful for pre-allocating
possibly large chunks of memory safely.