### PR TITLE
feat: new_raw APIs avoiding MapFnTo path

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -362,8 +362,12 @@ pub struct FunctionBuilder<'s, T> {
 impl<'s, T> FunctionBuilder<'s, T> {
   /// Create a new FunctionBuilder.
   pub fn new(callback: impl MapFnTo<FunctionCallback>) -> Self {
+    Self::new_raw(callback.map_fn_to())
+  }
+
+  pub fn new_raw(callback: FunctionCallback) -> Self {
     Self {
-      callback: callback.map_fn_to(),
+      callback,
       data: None,
       signature: None,
       length: 0,
@@ -431,6 +435,12 @@ impl Function {
     FunctionBuilder::new(callback)
   }
 
+  pub fn builder_raw<'s>(
+    callback: FunctionCallback,
+  ) -> FunctionBuilder<'s, Self> {
+    FunctionBuilder::new_raw(callback)
+  }
+
   /// Create a function in the current execution context
   /// for a given FunctionCallback.
   pub fn new<'s>(
@@ -438,6 +448,13 @@ impl Function {
     callback: impl MapFnTo<FunctionCallback>,
   ) -> Option<Local<'s, Function>> {
     Self::builder(callback).build(scope)
+  }
+
+  pub fn new_raw<'s>(
+    scope: &mut HandleScope<'s>,
+    callback: FunctionCallback,
+  ) -> Option<Local<'s, Function>> {
+    Self::builder_raw(callback).build(scope)
   }
 
   pub fn call<'s>(

--- a/src/template.rs
+++ b/src/template.rs
@@ -174,12 +174,25 @@ impl FunctionTemplate {
     FunctionBuilder::new(callback)
   }
 
+  pub fn builder_raw<'s>(
+    callback: FunctionCallback,
+  ) -> FunctionBuilder<'s, Self> {
+    FunctionBuilder::new_raw(callback)
+  }
+
   /// Creates a function template.
   pub fn new<'s>(
     scope: &mut HandleScope<'s, ()>,
     callback: impl MapFnTo<FunctionCallback>,
   ) -> Local<'s, FunctionTemplate> {
     Self::builder(callback).build(scope)
+  }
+
+  pub fn new_raw<'s>(
+    scope: &mut HandleScope<'s, ()>,
+    callback: FunctionCallback,
+  ) -> Local<'s, FunctionTemplate> {
+    Self::builder_raw(callback).build(scope)
   }
 
   /// Returns the unique function instance in the current execution context.


### PR DESCRIPTION
Unblocks https://github.com/denoland/deno/pull/13861

The MapFnTo trait is quite contrived and can't be turned into a trait object thus blocking declarative ops