### PR TITLE
Ignore more unnecessary ICU data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ exclude = [
  "third_party/icu/android_small/",
  "third_party/icu/cast/",
  "third_party/icu/chromeos/",
+ "third_party/icu/common/icudtl.dat",
  "third_party/icu/common/icudtb.dat",
  "third_party/icu/flutter/",
  "third_party/icu/ios/",


### PR DESCRIPTION
The latest ICU update increased the file size of the crate to above 20 MB again. This commit removes an ICU data file from the package that is unneeded for the build.

I tested the build still works by doing:

```
$ export V8_FROM_SOURCE=1
$ cargo package
```

And it still works.
