### PR TITLE
feat: ArrayBuffer::new_backing_store_from_ptr

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -430,4 +430,22 @@ impl ArrayBuffer {
       ))
     }
   }
+
+  /// Returns a new standalone BackingStore backed by given ptr.
+  ///
+  /// SAFETY: This API consumes raw pointers so is inherently
+  /// unsafe. Usually you should use new_backing_store_from_boxed_slice.
+  pub unsafe fn new_backing_store_from_ptr(
+    data_ptr: *mut c_void,
+    byte_length: usize,
+    deleter_callback: BackingStoreDeleterCallback,
+    deleter_data: *mut c_void,
+  ) -> UniqueRef<BackingStore> {
+    UniqueRef::from_raw(v8__ArrayBuffer__NewBackingStore__with_data(
+      data_ptr,
+      byte_length,
+      deleter_callback,
+      deleter_data,
+    ))
+  }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -513,7 +513,7 @@ fn get_isolate_from_handle() {
   check_eval(scope, Some(false), "3.3 / 3.3");
 }
 
-pub unsafe extern "C" fn backing_store_deleter_callback(
+pub extern "C" fn backing_store_deleter_callback(
   _data: *mut c_void,
   _byte_length: usize,
   _deleter_data: *mut c_void,


### PR DESCRIPTION
useful for https://github.com/denoland/deno/pull/13633
which currently uses a "hack" to create externally backed array buffers: https://github.com/littledivy/deno/blob/4fb9b90da6bcab9690ba2113083520f709a0b636/cli/napi/js_native_api.rs#L312
also needed to make zero-copy arraybuffers (returned from FFI. there is UnsafePointerView#getArrayBuffer, which currently copies)