### PR TITLE
feat: v8::ArrayBuffer::new_backing_store_from_vec

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -459,7 +459,7 @@ impl ArrayBuffer {
         data_ptr,
         byte_length,
         vec_deleter_callback,
-        capacity as *c_void,
+        capacity as *mut c_void,
       ))
     }
   }

--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn vec_deleter_callback(
   byte_length: usize,
   deleter_data: *mut c_void,
 ) {
-  let capacity: usize = std::mem::transmute(deleter_data);
+  let capacity = deleter_data as usize;
   drop(Vec::from_raw_parts(data as *mut u8, byte_length, capacity))
 }
 

--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -2,7 +2,6 @@
 
 use std::cell::Cell;
 use std::ffi::c_void;
-use std::mem;
 use std::ops::Deref;
 use std::ptr;
 use std::ptr::null_mut;
@@ -246,13 +245,10 @@ pub unsafe extern "C" fn boxed_slice_deleter_callback(
 pub unsafe extern "C" fn vec_deleter_callback(
   data: *mut c_void,
   byte_length: usize,
-  _deleter_data: *mut c_void,
+  deleter_data: *mut c_void,
 ) {
-  drop(Vec::from_raw_parts(
-    data as *mut u8,
-    byte_length,
-    byte_length,
-  ))
+  let capacity: usize = std::mem::transmute(deleter_data);
+  drop(Vec::from_raw_parts(data as *mut u8, byte_length, capacity))
 }
 
 /// A wrapper around the backing store (i.e. the raw memory) of an array buffer.
@@ -455,14 +451,15 @@ impl ArrayBuffer {
     mut data: Vec<u8>,
   ) -> UniqueRef<BackingStore> {
     let byte_length = data.len();
+    let capacity = data.capacity();
     let data_ptr = data.as_mut_ptr() as *mut c_void;
-    mem::forget(data);
+    std::mem::forget(data);
     unsafe {
       UniqueRef::from_raw(v8__ArrayBuffer__NewBackingStore__with_data(
         data_ptr,
         byte_length,
         vec_deleter_callback,
-        null_mut(),
+        capacity as *c_void,
       ))
     }
   }

--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -2,6 +2,7 @@
 
 use std::cell::Cell;
 use std::ffi::c_void;
+use std::mem;
 use std::ops::Deref;
 use std::ptr;
 use std::ptr::null_mut;
@@ -232,7 +233,7 @@ pub type BackingStoreDeleterCallback = unsafe extern "C" fn(
   deleter_data: *mut c_void,
 );
 
-pub unsafe extern "C" fn backing_store_deleter_callback(
+pub unsafe extern "C" fn boxed_slice_deleter_callback(
   data: *mut c_void,
   byte_length: usize,
   _deleter_data: *mut c_void,
@@ -240,6 +241,18 @@ pub unsafe extern "C" fn backing_store_deleter_callback(
   let slice_ptr = ptr::slice_from_raw_parts_mut(data as *mut u8, byte_length);
   let b = Box::from_raw(slice_ptr);
   drop(b);
+}
+
+pub unsafe extern "C" fn vec_deleter_callback(
+  data: *mut c_void,
+  byte_length: usize,
+  _deleter_data: *mut c_void,
+) {
+  drop(Vec::from_raw_parts(
+    data as *mut u8,
+    byte_length,
+    byte_length,
+  ))
 }
 
 /// A wrapper around the backing store (i.e. the raw memory) of an array buffer.
@@ -425,7 +438,30 @@ impl ArrayBuffer {
       UniqueRef::from_raw(v8__ArrayBuffer__NewBackingStore__with_data(
         data_ptr,
         byte_length,
-        backing_store_deleter_callback,
+        boxed_slice_deleter_callback,
+        null_mut(),
+      ))
+    }
+  }
+
+  /// Returns a new standalone BackingStore that takes over the ownership of
+  /// the given buffer.
+  ///
+  /// The destructor of the BackingStore frees owned buffer memory.
+  ///
+  /// The result can be later passed to ArrayBuffer::New. The raw pointer
+  /// to the buffer must not be passed again to any V8 API function.
+  pub fn new_backing_store_from_vec(
+    mut data: Vec<u8>,
+  ) -> UniqueRef<BackingStore> {
+    let byte_length = data.len();
+    let data_ptr = data.as_mut_ptr() as *mut c_void;
+    mem::forget(data);
+    unsafe {
+      UniqueRef::from_raw(v8__ArrayBuffer__NewBackingStore__with_data(
+        data_ptr,
+        byte_length,
+        vec_deleter_callback,
         null_mut(),
       ))
     }


### PR DESCRIPTION
So we can avoid `.into_boxed_slice()` calls which may require a (costly) memmove when instantiating from a `Vec`

## Notes

- In theory, dropping & deallocating a Vec depends on its layout, which is not fully restored in the deleter (since we simplify len=cap, which may be untrue)
- We could pass the cap in the deleter_data void ptr and transmute to `usize`
- But after double-checking rust's src the GlobalAllocator/SystemAllocator `dealloc` does not depend on layout and simply calls `free` (or `HeapFree`) as I expected
- So in practice this shouldn't be an issue