### PR TITLE
add FunctionTemplate::instance_template binding

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1776,6 +1776,11 @@ const v8::ObjectTemplate* v8__FunctionTemplate__PrototypeTemplate(
   return local_to_ptr(ptr_to_local(&self)->PrototypeTemplate());
 }
 
+const v8::ObjectTemplate* v8__FunctionTemplate__InstanceTemplate(
+    const v8::FunctionTemplate& self) {
+  return local_to_ptr(ptr_to_local(&self)->InstanceTemplate());
+}
+
 v8::Isolate* v8__FunctionCallbackInfo__GetIsolate(
     const v8::FunctionCallbackInfo<v8::Value>& self) {
   return self.GetIsolate();

--- a/src/template.rs
+++ b/src/template.rs
@@ -54,6 +54,9 @@ extern "C" {
   fn v8__FunctionTemplate__PrototypeTemplate(
     this: *const FunctionTemplate,
   ) -> *const ObjectTemplate;
+  fn v8__FunctionTemplate__InstanceTemplate(
+    this: *const FunctionTemplate,
+  ) -> *const ObjectTemplate;
   fn v8__FunctionTemplate__SetClassName(
     this: *const FunctionTemplate,
     name: *const String,
@@ -222,6 +225,18 @@ impl FunctionTemplate {
   ) -> Local<'s, ObjectTemplate> {
     unsafe {
       scope.cast_local(|_sd| v8__FunctionTemplate__PrototypeTemplate(self))
+    }
+    .unwrap()
+  }
+
+  /// Returns the object template that is used for instances created when this function
+  /// template is called as a constructor.
+  pub fn instance_template<'s>(
+    &self,
+    scope: &mut HandleScope<'s, ()>,
+  ) -> Local<'s, ObjectTemplate> {
+    unsafe {
+      scope.cast_local(|_sd| v8__FunctionTemplate__InstanceTemplate(self))
     }
     .unwrap()
   }


### PR DESCRIPTION
This adds bindings for the `FunctionTemplate->InstanceTemplate()` method, which may be used to get a handle to the object template used when the function is used as a constructor. 

I added a test to ensure you can set internal fields and read them from the constructed objects later.