### PR TITLE
Fix misuse of `MaybeUninit` and avoid refs to uninit memory

### DIFF
--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -279,7 +279,7 @@ impl ChannelBase {
   {
     let buf = std::mem::MaybeUninit::<T>::uninit();
     let embedder_ptr: *const T = buf.as_ptr();
-    // TODO: the call to base() creates a reference to uninitialized memory (UB)
+    // TODO(y21): the call to base() creates a reference to uninitialized memory (UB)
     // fixing this requires changes in the ChannelImpl trait, namely ChannelImpl::base() can't take &self
     let self_ptr: *const Self = unsafe { (*embedder_ptr).base() };
     FieldOffset::from_ptrs(embedder_ptr, self_ptr)

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -269,7 +269,8 @@ impl ChannelBase {
 
   fn get_cxx_base_offset() -> FieldOffset<Channel> {
     let buf = std::mem::MaybeUninit::<Self>::uninit();
-    FieldOffset::from_ptrs(buf.as_ptr(), unsafe { &(*buf.as_ptr()).cxx_base })
+    let base = unsafe { addr_of!((*buf.as_ptr()).cxx_base) };
+    FieldOffset::from_ptrs(buf.as_ptr(), base)
   }
 
   fn get_offset_within_embedder<T>() -> FieldOffset<Self>
@@ -278,6 +279,8 @@ impl ChannelBase {
   {
     let buf = std::mem::MaybeUninit::<T>::uninit();
     let embedder_ptr: *const T = buf.as_ptr();
+    // TODO: the call to base() creates a reference to uninitialized memory (UB)
+    // fixing this requires changes in the ChannelImpl trait, namely ChannelImpl::base() can't take &self
     let self_ptr: *const Self = unsafe { (*embedder_ptr).base() };
     FieldOffset::from_ptrs(embedder_ptr, self_ptr)
   }
@@ -532,7 +535,8 @@ impl V8InspectorClientBase {
 
   fn get_cxx_base_offset() -> FieldOffset<V8InspectorClient> {
     let buf = std::mem::MaybeUninit::<Self>::uninit();
-    FieldOffset::from_ptrs(buf.as_ptr(), unsafe { &(*buf.as_ptr()).cxx_base })
+    let base = unsafe { addr_of!((*buf.as_ptr()).cxx_base) };
+    FieldOffset::from_ptrs(buf.as_ptr(), base)
   }
 
   fn get_offset_within_embedder<T>() -> FieldOffset<Self>
@@ -668,6 +672,7 @@ use std::iter::ExactSizeIterator;
 use std::iter::IntoIterator;
 use std::marker::PhantomData;
 use std::ops::Deref;
+use std::ptr::addr_of;
 use std::ptr::null;
 use std::ptr::NonNull;
 use std::slice;

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1058,7 +1058,7 @@ pub(crate) mod data {
         let isolate = data.isolate;
         data.scope_type_specific_data.init_with(|| {
           ScopeTypeSpecificData::HandleScope {
-            raw_handle_scope: unsafe { raw::HandleScope::uninit() },
+            raw_handle_scope: raw::HandleScope::uninit(),
             raw_context_scope: None,
           }
         });
@@ -1118,7 +1118,7 @@ pub(crate) mod data {
         let isolate = data.isolate;
         data.scope_type_specific_data.init_with(|| {
           ScopeTypeSpecificData::EscapableHandleScope {
-            raw_handle_scope: unsafe { raw::HandleScope::uninit() },
+            raw_handle_scope: raw::HandleScope::uninit(),
             raw_escape_slot: Some(raw::EscapeSlot::new(isolate)),
           }
         });
@@ -1140,7 +1140,7 @@ pub(crate) mod data {
         let isolate = data.isolate;
         data.scope_type_specific_data.init_with(|| {
           ScopeTypeSpecificData::TryCatch {
-            raw_try_catch: unsafe { raw::TryCatch::uninit() },
+            raw_try_catch: raw::TryCatch::uninit(),
           }
         });
         match &mut data.scope_type_specific_data {
@@ -1532,16 +1532,12 @@ mod raw {
 
   #[repr(C)]
   #[derive(Debug)]
-  pub(super) struct HandleScope([usize; 3]);
+  pub(super) struct HandleScope([MaybeUninit<usize>; 3]);
 
   impl HandleScope {
-    /// This function is marked unsafe because the caller must ensure that the
-    /// returned value isn't dropped before `init()` has been called.
-    pub unsafe fn uninit() -> Self {
-      // This is safe because there is no combination of bits that would produce
-      // an invalid `[usize; 3]`.
-      #[allow(clippy::uninit_assumed_init)]
-      Self(MaybeUninit::uninit().assume_init())
+    /// Creates an uninitialized `HandleScope`.
+    pub fn uninit() -> Self {
+      Self(unsafe { MaybeUninit::uninit().assume_init() })
     }
 
     /// This function is marked unsafe because `init()` must be called exactly
@@ -1591,16 +1587,12 @@ mod raw {
 
   #[repr(C)]
   #[derive(Debug)]
-  pub(super) struct TryCatch([usize; 6]);
+  pub(super) struct TryCatch([MaybeUninit<usize>; 6]);
 
   impl TryCatch {
-    /// This function is marked unsafe because the caller must ensure that the
-    /// returned value isn't dropped before `init()` has been called.
-    pub unsafe fn uninit() -> Self {
-      // This is safe because there is no combination of bits that would produce
-      // an invalid `[usize; 6]`.
-      #[allow(clippy::uninit_assumed_init)]
-      Self(MaybeUninit::uninit().assume_init())
+    /// Creates an uninitialized `TryCatch`.
+    pub fn uninit() -> Self {
+      Self(unsafe { MaybeUninit::uninit().assume_init() })
     }
 
     /// This function is marked unsafe because `init()` must be called exactly

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1058,7 +1058,7 @@ pub(crate) mod data {
         let isolate = data.isolate;
         data.scope_type_specific_data.init_with(|| {
           ScopeTypeSpecificData::HandleScope {
-            raw_handle_scope: raw::HandleScope::uninit(),
+            raw_handle_scope: unsafe { raw::HandleScope::uninit() },
             raw_context_scope: None,
           }
         });
@@ -1118,7 +1118,7 @@ pub(crate) mod data {
         let isolate = data.isolate;
         data.scope_type_specific_data.init_with(|| {
           ScopeTypeSpecificData::EscapableHandleScope {
-            raw_handle_scope: raw::HandleScope::uninit(),
+            raw_handle_scope: unsafe { raw::HandleScope::uninit() },
             raw_escape_slot: Some(raw::EscapeSlot::new(isolate)),
           }
         });
@@ -1140,7 +1140,7 @@ pub(crate) mod data {
         let isolate = data.isolate;
         data.scope_type_specific_data.init_with(|| {
           ScopeTypeSpecificData::TryCatch {
-            raw_try_catch: raw::TryCatch::uninit(),
+            raw_try_catch: unsafe { raw::TryCatch::uninit() },
           }
         });
         match &mut data.scope_type_specific_data {
@@ -1536,8 +1536,11 @@ mod raw {
 
   impl HandleScope {
     /// Creates an uninitialized `HandleScope`.
-    pub fn uninit() -> Self {
-      Self(unsafe { MaybeUninit::uninit().assume_init() })
+    ///
+    /// This function is marked unsafe because the caller must ensure that the
+    /// returned value isn't dropped before `init()` has been called.
+    pub unsafe fn uninit() -> Self {
+      Self(MaybeUninit::uninit().assume_init())
     }
 
     /// This function is marked unsafe because `init()` must be called exactly
@@ -1591,8 +1594,11 @@ mod raw {
 
   impl TryCatch {
     /// Creates an uninitialized `TryCatch`.
-    pub fn uninit() -> Self {
-      Self(unsafe { MaybeUninit::uninit().assume_init() })
+    ///
+    /// This function is marked unsafe because the caller must ensure that the
+    /// returned value isn't dropped before `init()` has been called.
+    pub unsafe fn uninit() -> Self {
+      Self(MaybeUninit::uninit().assume_init())
     }
 
     /// This function is marked unsafe because `init()` must be called exactly

--- a/src/value_deserializer.rs
+++ b/src/value_deserializer.rs
@@ -17,6 +17,7 @@ use crate::support::MaybeBool;
 use std::ffi::c_void;
 use std::mem::MaybeUninit;
 use std::pin::Pin;
+use std::ptr::addr_of;
 
 // Must be == sizeof(v8::ValueDeserializer::Delegate),
 // see v8__ValueDeserializer__Delegate__CONSTRUCT().
@@ -212,9 +213,9 @@ impl<'a, 's> ValueDeserializerHeap<'a, 's> {
   fn get_cxx_value_deserializer_delegate_offset(
   ) -> FieldOffset<CxxValueDeserializerDelegate> {
     let buf = std::mem::MaybeUninit::<Self>::uninit();
-    FieldOffset::from_ptrs(buf.as_ptr(), unsafe {
-      &(*buf.as_ptr()).cxx_value_deserializer_delegate
-    })
+    let delegate =
+      unsafe { addr_of!((*buf.as_ptr()).cxx_value_deserializer_delegate) };
+    FieldOffset::from_ptrs(buf.as_ptr(), delegate)
   }
 
   /// Starting from 'this' pointer a ValueDeserializerHeap ref can be created

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -15,6 +15,7 @@ use std::alloc::dealloc;
 use std::alloc::realloc;
 use std::alloc::Layout;
 use std::mem::MaybeUninit;
+use std::ptr::addr_of;
 
 use crate::support::CxxVTable;
 use crate::support::FieldOffset;
@@ -274,9 +275,9 @@ impl<'a, 's> ValueSerializerHeap<'a, 's> {
   fn get_cxx_value_serializer_delegate_offset(
   ) -> FieldOffset<CxxValueSerializerDelegate> {
     let buf = std::mem::MaybeUninit::<Self>::uninit();
-    FieldOffset::from_ptrs(buf.as_ptr(), unsafe {
-      &(*buf.as_ptr()).cxx_value_serializer_delegate
-    })
+    let delegate =
+      unsafe { addr_of!((*buf.as_ptr()).cxx_value_serializer_delegate) };
+    FieldOffset::from_ptrs(buf.as_ptr(), delegate)
   }
 
   /// Starting from 'this' pointer a ValueSerializerHeap ref can be created


### PR DESCRIPTION
While reviewing the code in this repo, I found questionable uses of `MaybeUninit` that go against what is said in the docs:

> It is up to the caller to guarantee that the MaybeUninit<T> really is in an initialized state. Calling this when the content is not yet fully initialized causes **immediate undefined behavior.**
<sub>[MaybeUninit::assume_init](https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#safety)</sub>

https://github.com/denoland/rusty_v8/blob/9b2d8c68ade1ad4f935534dbdd610f47c80f7b64/src/scope.rs#L1535-L1545

There is even a lint that is explicitly disabled here that says that `MaybeUninit::<[usize; 3]>::uninit().assume_init()` may be instant UB and is better avoided.
So, instead of storing a `[usize; 3]` in an uninitialized state, I think the right thing to do here is to store `[MaybeUninit<usize>; 3]` in the struct, which *is* allowed to be in an uninitialized state, and let the caller decide when to actually initialize the contents by calling `init()`.
(Also, `MaybeUninit<T>` is repr(transparent) so dropping/transmuting/etc should just continue to work like before)

To expand on this, the comment above the `#[allow(...)]` line seems to assume that it's valid to call `assume_init()` in an uninitialized state if any bit pattern is valid for `T`. The Rust reference, however, says that it goes beyond that. It considers the following "undefined behavior":

> Producing an invalid value, even in private fields and locals. "Producing" a value happens any time a value is assigned to or read from a place, passed to a function/primitive operation or returned from a function/primitive operation. The following values are invalid (at their respective type):
> [...]
> - **An integer (i\*/u\*)**, floating point value (f\*), or raw pointer **obtained from [uninitialized memory](http://llvm.org/docs/LangRef.html#undefined-values)**, or uninitialized memory in a str.
> 
> <sub>[Reference](https://doc.rust-lang.org/reference/behavior-considered-undefined.html)</sub>

It seems like the rules around this aren't finalized and not set in stone, but I think it's best to not rely on these things.
For example, [`std::mem::uninitialized()`](https://doc.rust-lang.org/std/mem/fn.uninitialized.html), which was deprecated for this very reason (basically can almost never be used correctly), confirms that:
> This makes it undefined behavior to have uninitialized data in a variable **even if that variable has an integer type**. (Notice that the rules around uninitialized integers are not finalized yet, but until they are, it is advisable to avoid them.)
------

In addition, I also found a few instances of patterns like `&(*uninit.as_ptr()).field as *const _`, which, to my knowledge is also UB due to the temporary reference to the uninitialized field.

From the docs of [MaybeUninit::as_ptr](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.as_ptr):
> Gets a pointer to the contained value. Reading from this pointer or **turning it into a reference is undefined behavior unless the MaybeUninit<T> is initialized**.

For this sort of thing, the standard library has a `addr_of!` macro that creates a raw pointer to the field, without the temporary reference.
https://github.com/denoland/rusty_v8/blob/9b2d8c68ade1ad4f935534dbdd610f47c80f7b64/src/inspector.rs#L270-L273

For example, the `MaybeUninit` documentation has [an example](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#initializing-a-struct-field-by-field) that shows that `addr_of_mut!` can be used to initialize an uninitialized struct on a field-by-field basis. It's similar to the linked code, just that here we need a const pointer to a field instead of writing to it.