### PR TITLE
Set `v8::Promise` internal field count to 1

### DIFF
--- a/.gn
+++ b/.gn
@@ -37,6 +37,7 @@ default_args = {
   v8_monolithic = false
   v8_enable_snapshot_compression = false
   v8_enable_javascript_promise_hooks = true
+  v8_promise_internal_field_count = 1
   v8_use_external_startup_data = false
   v8_use_snapshot = true
   is_component_build = false


### PR DESCRIPTION
Enables the use of `set_internal_field` on v8::Promise. Can be used to track/store `promiseId` associated with the Promise.