### PR TITLE
Add x86_64-unknown-linux-musl library release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: 
+on:
   push:
     branches: [main]
   pull_request:
@@ -173,6 +173,12 @@ jobs:
 
       - name: Rustfmt
         run: cargo fmt -- --check
+
+      - name: Build Musl
+        if: matrix.config.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          docker run -v "$PWD":/usr/src/rusty_v8 -w /usr/src/rusty_v8 rust:alpine3.16 tools/musl-build.sh
+          cp target/${{ matrix.config.variant }}/gn_out/obj/librusty_v8.a target/librusty_v8_${{ matrix.config.variant }}_x86_64-unknown-linux-musl.a
 
       - name: Prepare binary publish
         run: cp

--- a/tools/musl-build.sh
+++ b/tools/musl-build.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+apk add git
+apk add gcc
+apk add ninja
+apk add python3
+apk add clang
+apk add g++
+apk add pkgconfig
+apk add glib-dev
+apk add llvm13-dev
+apk add binutils-gold
+ln -s /usr/bin/python3 /usr/bin/python
+
+export V8_FROM_SOURCE=yes
+GN="$(pwd)/gn/out/gn"
+export GN
+export CLANG_BASE_PATH=/usr
+export GN_ARGS='use_custom_libcxx=false use_lld=false v8_enable_backtrace=false v8_enable_debugging_features=false'
+
+# Bulid GN
+if [ ! -d "./gn" ]; then
+    git clone https://gn.googlesource.com/gn
+    (
+        cd gn || exit
+        python3 build/gen.py
+        ninja -C out
+    )
+fi
+
+# Build rusty_v8
+cargo build

--- a/tools/musl-build.sh
+++ b/tools/musl-build.sh
@@ -1,22 +1,25 @@
 #!/bin/sh
 
-apk add git
-apk add gcc
-apk add ninja
-apk add python3
-apk add clang
-apk add g++
-apk add pkgconfig
-apk add glib-dev
-apk add llvm13-dev
-apk add binutils-gold
+apk add git \
+    gcc \
+    ninja \
+    python3 \
+    clang \
+    g++ \
+    pkgconfig \
+    glib-dev \
+    llvm13-dev \
+    binutils-gold \
+    sccache
 ln -s /usr/bin/python3 /usr/bin/python
 
-export V8_FROM_SOURCE=yes
+export V8_FROM_SOURCE="yes"
+export CLANG_BASE_PATH="/usr"
+export SCCACHE_DIR="./target/sccache"
+export SCCACHE="/usr/bin/sccache"
+export GN_ARGS="use_custom_libcxx=false use_lld=false v8_enable_backtrace=false v8_enable_debugging_features=false"
 GN="$(pwd)/gn/out/gn"
 export GN
-export CLANG_BASE_PATH=/usr
-export GN_ARGS='use_custom_libcxx=false use_lld=false v8_enable_backtrace=false v8_enable_debugging_features=false'
 
 # Bulid GN
 if [ ! -d "./gn" ]; then


### PR DESCRIPTION
This adds x86_64-unknown-linux-musl as a new supported target for the
pre-built rusty_v8 library releases, which should avoid multiple
downstream consumers having to build this themselves.

This target is useful when trying to build statically-compiled
executables, which seems like a good thing to support for the purpose of
using deno_core as an embedded JavaScript runtime.

Closes #49.

---

There have been several comments in related issues about how to build `rusty_v8` and `deno` on musl, many of which are outdated and do not work anymore. Hopefully getting this upstreamed can work around having to hunt down the correct solution for building things (see #49 and https://github.com/denoland/deno/issues/3711).

I'm mostly creating this PR to gauge if the approach taken here is something that can be upstreamed. It still requires https://github.com/rust-lang/docker-rust/pull/104 and a patch to `chromium_build` to work:

```diff
diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
index 211684cd2..9e27e958f 100644
--- a/config/compiler/BUILD.gn
+++ b/config/compiler/BUILD.gn
@@ -1553,7 +1553,6 @@ config("default_warnings") {
         # TODO(https://crbug.com/1316298): Re-enable once test failure is figured out
         cflags += [
           "-Xclang",
-          "-no-opaque-pointers",
         ]
       }
```

As far as I can tell, there are currently no other targets built in a Docker container and the maximum runtime of existing toolchains seems to be about 30 minutes. Based on my tests (https://github.com/phylum-dev/cli/runs/6716629634?check_suite_focus=true), this build would take around 2 hours on GitHub's runners.

I'd assume you're generally interested in providing musl builds? If you have any suggestions, please let me know.