### PR TITLE
Add back gn args --list on build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -210,7 +210,18 @@ fn build_v8() {
   let gn_out = maybe_gen(&gn_root, gn_args);
   assert!(gn_out.exists());
   assert!(gn_out.join("args.gn").exists());
+  print_gn_args(&gn_out);
   build("rusty_v8", None);
+}
+
+fn print_gn_args(gn_out_dir: &Path) {
+  assert!(Command::new(gn())
+    .arg("args")
+    .arg(&gn_out_dir)
+    .arg("--list")
+    .status()
+    .unwrap()
+    .success());
 }
 
 fn maybe_clone_repo(dest: &str, repo: &str) {


### PR DESCRIPTION
This was added for debugging purposes back in https://github.com/denoland/rusty_v8/pull/962 but was removed in an unrelated change ([Upgrade V8 to 10.3.174.3](https://github.com/denoland/rusty_v8/commit/2f189e1668a33e96e1e5a431c234849e6e20834b#diff-d0d98998092552a1d3259338c2c71e118a5b8343dd4703c0c7f552ada7f9cb42L220)). 

Printing the gn args is verbose but helps debugging. Being able to examine the args used in, for example, the homebrew build without having to repeat the build saves time.