### PR TITLE
Expose `from_function_callback_info`

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -125,7 +125,7 @@ pub struct ReturnValue<'cb>(*mut Value, PhantomData<&'cb ()>);
 /// and for our purposes we currently don't need
 /// other types. So for now it's a simplified version.
 impl<'cb> ReturnValue<'cb> {
-  fn from_function_callback_info(info: *const FunctionCallbackInfo) -> Self {
+  pub fn from_function_callback_info(info: *const FunctionCallbackInfo) -> Self {
     let slot = unsafe { v8__FunctionCallbackInfo__GetReturnValue(info) };
     Self(slot, PhantomData)
   }
@@ -180,7 +180,7 @@ pub struct FunctionCallbackArguments<'s> {
 }
 
 impl<'s> FunctionCallbackArguments<'s> {
-  pub(crate) fn from_function_callback_info(
+  pub fn from_function_callback_info(
     info: *const FunctionCallbackInfo,
   ) -> Self {
     Self {

--- a/src/function.rs
+++ b/src/function.rs
@@ -211,7 +211,7 @@ pub struct FunctionCallbackArguments<'s> {
 }
 
 impl<'s> FunctionCallbackArguments<'s> {
-  pub fn from_function_callback_info(
+  pub unsafe fn from_function_callback_info(
     info: *const FunctionCallbackInfo,
   ) -> Self {
     Self {

--- a/src/function.rs
+++ b/src/function.rs
@@ -132,8 +132,10 @@ pub struct ReturnValue<'cb>(*mut Value, PhantomData<&'cb ()>);
 /// and for our purposes we currently don't need
 /// other types. So for now it's a simplified version.
 impl<'cb> ReturnValue<'cb> {
-  pub fn from_function_callback_info(info: *const FunctionCallbackInfo) -> Self {
-    let slot = unsafe { v8__FunctionCallbackInfo__GetReturnValue(info) };
+  pub unsafe fn from_function_callback_info(
+    info: *const FunctionCallbackInfo,
+  ) -> Self {
+    let slot = v8__FunctionCallbackInfo__GetReturnValue(info);
     Self(slot, PhantomData)
   }
 
@@ -329,7 +331,7 @@ where
     let f = |info: *const FunctionCallbackInfo| {
       let scope = &mut unsafe { CallbackScope::new(&*info) };
       let args = FunctionCallbackArguments::from_function_callback_info(info);
-      let rv = ReturnValue::from_function_callback_info(info);
+      let rv = unsafe { ReturnValue::from_function_callback_info(info) };
       (F::get())(scope, args, rv);
     };
     f.to_c_fn()

--- a/src/function.rs
+++ b/src/function.rs
@@ -330,7 +330,8 @@ where
   fn mapping() -> Self {
     let f = |info: *const FunctionCallbackInfo| {
       let scope = &mut unsafe { CallbackScope::new(&*info) };
-      let args = FunctionCallbackArguments::from_function_callback_info(info);
+      let args =
+        unsafe { FunctionCallbackArguments::from_function_callback_info(info) };
       let rv = unsafe { ReturnValue::from_function_callback_info(info) };
       (F::get())(scope, args, rv);
     };

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -173,7 +173,8 @@ where
     F: UnitType + Fn(&mut HandleScope, Local<Value>, WasmStreaming),
   {
     let scope = &mut unsafe { CallbackScope::new(&*info) };
-    let args = FunctionCallbackArguments::from_function_callback_info(info);
+    let args =
+      unsafe { FunctionCallbackArguments::from_function_callback_info(info) };
     let data = args.data().unwrap(); // Always present.
     let data = &*data as *const Value;
     let zero = null_mut();

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2290,7 +2290,8 @@ fn function_builder_raw() {
 
     extern "C" fn callback(info: *const v8::FunctionCallbackInfo) {
       let scope = unsafe { &mut v8::CallbackScope::new(&*info) };
-      let args = v8::FunctionCallbackArguments::from_function_callback_info(info);
+      let args =
+        v8::FunctionCallbackArguments::from_function_callback_info(info);
       assert!(args.length() == 1);
       assert!(args.get(0).is_string());
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2278,6 +2278,40 @@ fn nested_builder<'a>(
 }
 
 #[test]
+fn function_builder_raw() {
+  let _setup_guard = setup();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  {
+    let scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(scope);
+    let scope = &mut v8::ContextScope::new(scope, context);
+    let global = context.global(scope);
+    let recv: v8::Local<v8::Value> = global.into();
+
+    extern "C" fn callback(info: *const v8::FunctionCallbackInfo) {
+      let scope = unsafe { &mut v8::CallbackScope::new(&*info) };
+      let args = v8::FunctionCallbackArguments::from_function_callback_info(info);
+      assert!(args.length() == 1);
+      assert!(args.get(0).is_string());
+
+      let mut rv =
+        unsafe { v8::ReturnValue::from_function_callback_info(info) };
+      rv.set(
+        v8::String::new(scope, "Hello from function!")
+          .unwrap()
+          .into(),
+      );
+    }
+    let func = v8::Function::new_raw(scope, callback).unwrap();
+
+    let arg0 = v8::String::new(scope, "Hello").unwrap();
+    let value = func.call(scope, recv, &[arg0.into()]).unwrap();
+    assert!(value.is_string());
+    assert_eq!(value.to_rust_string_lossy(scope), "Hello from function!");
+  }
+}
+
+#[test]
 fn return_value() {
   let _setup_guard = setup();
   let isolate = &mut v8::Isolate::new(Default::default());

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2290,8 +2290,9 @@ fn function_builder_raw() {
 
     extern "C" fn callback(info: *const v8::FunctionCallbackInfo) {
       let scope = unsafe { &mut v8::CallbackScope::new(&*info) };
-      let args =
-        v8::FunctionCallbackArguments::from_function_callback_info(info);
+      let args = unsafe {
+        v8::FunctionCallbackArguments::from_function_callback_info(info)
+      };
       assert!(args.length() == 1);
       assert!(args.get(0).is_string());
 


### PR DESCRIPTION
This commit makes `FunctionCallbackArguments::from_function_callback_info`
and `ReturnValue::from_function_callback_info` public API.

Currently, there is no way to use FunctionCallbackArguments 
and ReturnValue from Function::builder_raw.