### PR TITLE
feat: Add Uint32 / Int32 Value method bindings

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1418,6 +1418,10 @@ const v8::Integer* v8__Integer__NewFromUnsigned(v8::Isolate* isolate,
 
 int64_t v8__Integer__Value(const v8::Integer& self) { return self.Value(); }
 
+uint32_t v8__Uint32__Value(const v8::Uint32& self) { return self.Value(); }
+
+int32_t v8__Int32__Value(const v8::Int32& self) { return self.Value(); }
+
 const v8::BigInt* v8__BigInt__New(v8::Isolate* isolate, int64_t value) {
   return local_to_ptr(v8::BigInt::New(isolate, value));
 }

--- a/src/number.rs
+++ b/src/number.rs
@@ -2,10 +2,12 @@ use std::alloc::Layout;
 use std::ptr::NonNull;
 
 use crate::HandleScope;
+use crate::Int32;
 use crate::Integer;
 use crate::Isolate;
 use crate::Local;
 use crate::Number;
+use crate::Uint32;
 
 extern "C" {
   fn v8__Number__New(isolate: *mut Isolate, value: f64) -> *const Number;
@@ -16,6 +18,8 @@ extern "C" {
     value: u32,
   ) -> *const Integer;
   fn v8__Integer__Value(this: *const Integer) -> i64;
+  fn v8__Uint32__Value(this: *const Uint32) -> u32;
+  fn v8__Int32__Value(this: *const Int32) -> i32;
 }
 
 impl Number {
@@ -76,5 +80,17 @@ impl Integer {
     debug_assert_eq!(Layout::new::<usize>(), Layout::new::<Local<Self>>());
     debug_assert_eq!(zero_local.value(), 0);
     zero_local
+  }
+}
+
+impl Uint32 {
+  pub fn value(&self) -> u32 {
+    unsafe { v8__Uint32__Value(self) }
+  }
+}
+
+impl Int32 {
+  pub fn value(&self) -> i32 {
+    unsafe { v8__Int32__Value(self) }
   }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -71,9 +71,13 @@ fn handle_scope_numbers() {
     {
       let scope2 = &mut v8::HandleScope::new(scope1);
       let l3 = v8::Number::new(scope2, 78.9);
+      let l4 = v8::Local::<v8::Int32>::try_from(l1).unwrap();
+      let l5 = v8::Local::<v8::Uint32>::try_from(l2).unwrap();
       assert_eq!(l1.value(), -123);
       assert_eq!(l2.value(), 456);
       assert_eq!(l3.value(), 78.9);
+      assert_eq!(l4.value(), -123);
+      assert_eq!(l5.value(), 456);
       assert_eq!(v8::Number::value(&l1), -123f64);
       assert_eq!(v8::Number::value(&l2), 456f64);
     }


### PR DESCRIPTION
Adds bindings for `Uint32` and `Int32` classes to directly access the `u32` / `i32` value without going through the `Integer` class' `Value` method.

The difference in V8 code for proper SMIs, which these should always be, is only the return type. Effectively then the current call path does:
> int -> int64_t -> u32 / i32

whereas the new callpath is then

> int -> int32_t -> u32 / i32

This'll maybe save an instruction or two.

Closes #1027.