### PR TITLE
Fix compilation for 32-bit targets

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -22,6 +22,11 @@
 
 using namespace support;
 
+template<typename T>
+constexpr size_t align_to(size_t size) {
+    return (size + sizeof(T) - 1) & ~(sizeof(T) - 1);
+}
+
 static_assert(sizeof(two_pointers_t) ==
                   sizeof(std::shared_ptr<v8::BackingStore>),
               "std::shared_ptr<v8::BackingStore> size mismatch");
@@ -40,7 +45,7 @@ static_assert(sizeof(v8::PromiseRejectMessage) == sizeof(size_t) * 3,
 
 static_assert(sizeof(v8::Locker) == sizeof(size_t) * 2, "Locker size mismatch");
 
-static_assert(sizeof(v8::ScriptCompiler::Source) <= sizeof(size_t) * 8,
+static_assert(sizeof(v8::ScriptCompiler::Source) == align_to<size_t>(sizeof(size_t) * 6 + sizeof(int) * 3),
               "Source size mismatch");
 
 static_assert(sizeof(v8::FunctionCallbackInfo<v8::Value>) == sizeof(size_t) * 3,

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
+use std::os::raw::c_int;
 use std::{marker::PhantomData, mem::MaybeUninit};
 
 use crate::Function;
@@ -61,7 +62,17 @@ extern "C" {
 /// Source code which can then be compiled to a UnboundScript or Script.
 #[repr(C)]
 #[derive(Debug)]
-pub struct Source([usize; 8]);
+pub struct Source {
+  _source_string: usize,
+  _resource_name: usize,
+  _resource_line_offset: c_int,
+  _resource_column_offset: c_int,
+  _resource_options: c_int,
+  _source_map_url: usize,
+  _host_defined_options: usize,
+  _cached_data: usize,
+  _consume_cache_task: usize,
+}
 
 /// Compilation data that the embedder can cache and pass back to speed up future
 /// compilations. The data is produced if the CompilerOptions passed to the compilation


### PR DESCRIPTION
Hello, thank you for rusty_v8! Building for the 32-bit `armv7-unknown-linux-musleabihf`
target gives the following compilation error due to some assumptions about the
layout of the C++ `v8::ScriptCompiler::Source` class:

```
  ../../../../src/binding.cc:43:50: error: static assertion failed: Source size mismatch
     43 | static_assert(sizeof(v8::ScriptCompiler::Source) <= sizeof(size_t) * 8,
```

This assert matches the corresponding Rust struct definition `pub struct Source([usize; 8]);`
on 64-bit platforms where the size of the fields plus padding mean
`sizeof(v8::ScriptCompiler::Source) == 64`.

However on 32-bit ARM `sizeof(v8::ScriptCompiler::Source) == 36` but
`size_of::<[usize; 8]>() == 32`.

This PR updates the layout of the Rust `v8::script_compiler::Source` struct
to match [that of the C++ class](https://github.com/denoland/v8/blob/151c55f530a172751dcb719b3b31cee7fdde0029/include/v8-script.h#L416) and updates the `static_assert` to check that the size
of the C++ class matches the expected aligned sum of field sizes.

With this change I'm able to build & run a program that links to rusty_v8 on
armv7-unknown-linux-musleabihf, as well as aarch64-unknown-linux-musl, and
x86_64-unknown-linux-musl.
