### PR TITLE
Remove zlib dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "buildtools"]
 	path = buildtools
 	url = https://github.com/denoland/chromium_buildtools.git
-[submodule "third_party/zlib"]
-	path = third_party/zlib
-	url = https://chromium.googlesource.com/chromium/src/third_party/zlib.git
 [submodule "third_party/icu"]
 	path = third_party/icu
 	url = https://github.com/denoland/icu.git

--- a/.gn
+++ b/.gn
@@ -30,7 +30,10 @@ default_args = {
   symbol_level = 1
   use_debug_fission = false
 
+  # Deno does its own snapshot compression using lz4 and zstd.
+  v8_use_zlib = false
   v8_enable_snapshot_compression = false
+
   v8_enable_javascript_promise_hooks = true
   v8_promise_internal_field_count = 1
   v8_use_external_startup_data = false


### PR DESCRIPTION
Deno does its own snapshot compression using lz4 and zstd, so no need to
build zlib into V8. See https://github.com/denoland/deno/pull/13320
