### PR TITLE
Fix creation of invalid librusty_v8.a

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -397,6 +397,7 @@ fn download_file(url: String, filename: PathBuf) {
       println!("Python downloader failed, trying with curl.");
       Command::new("curl")
         .arg("-L")
+        .arg("-f")
         .arg("-s")
         .arg("-o")
         .arg(&tmpfile)


### PR DESCRIPTION
Building rusty_v8 for targets lacking a binary `librusty_v8.a`, for example `aarch64-unknown-linux-musl`, currently fails with a confusing error message:

```
error: failed to add native library $PWD/target/aarch64-unknown-linux-musl/debug/gn_out/obj/librusty_v8.a: file too small to be an archive
```

This is because build.rs falls back to use of curl after `download_file.py` fails. The curl command is currently ignoring HTTP error statuses and writes the HTTP error message to librusty_v8.a:

```
% cat $PWD/target/aarch64-unknown-linux-musl/debug/gn_out/obj/librusty_v8.a
Not Found
```

This PR adds curl's `-f` flag to the command arguments which results in a more useful error message, as well as not writing an invalid `librusty_v8.a`.
