### PR TITLE
fix: `property_attribute` operator

### DIFF
--- a/src/property_attribute.rs
+++ b/src/property_attribute.rs
@@ -52,12 +52,12 @@ impl Default for PropertyAttribute {
   }
 }
 
-impl std::ops::Add for PropertyAttribute {
+impl std::ops::BitOr for PropertyAttribute {
   type Output = Self;
 
-  fn add(self, Self(rhs): Self) -> Self {
+  fn bitor(self, Self(rhs): Self) -> Self {
     let Self(lhs) = self;
-    Self(lhs + rhs)
+    Self(lhs | rhs)
   }
 }
 
@@ -84,9 +84,15 @@ fn test_attr() {
   assert!(DONT_DELETE.is_dont_delete());
 
   assert_eq!(NONE, Default::default());
-  assert_eq!(READ_ONLY, NONE + READ_ONLY);
+  assert_eq!(READ_ONLY, NONE | READ_ONLY);
 
-  let attr = READ_ONLY + DONT_ENUM;
+  let attr = READ_ONLY | DONT_ENUM;
+  assert!(!attr.is_none());
+  assert!(attr.is_read_only());
+  assert!(attr.is_dont_enum());
+  assert!(!attr.is_dont_delete());
+
+  let attr = READ_ONLY | READ_ONLY | DONT_ENUM;
   assert!(!attr.is_none());
   assert!(attr.is_read_only());
   assert!(attr.is_dont_enum());

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1391,7 +1391,7 @@ fn object_template() {
     let object_templ = v8::ObjectTemplate::new(scope);
     let function_templ = v8::FunctionTemplate::new(scope, fortytwo_callback);
     let name = v8::String::new(scope, "f").unwrap();
-    let attr = v8::READ_ONLY + v8::DONT_ENUM + v8::DONT_DELETE;
+    let attr = v8::READ_ONLY | v8::DONT_ENUM | v8::DONT_DELETE;
     object_templ.set_internal_field_count(1);
     object_templ.set_with_attr(name.into(), function_templ.into(), attr);
     let context = v8::Context::new(scope);


### PR DESCRIPTION
* `property_attribute` previously had an addition operator overload which doesn't make much sense in comparison to the corresponding V8 enumeration. This changes that to a bitor overload.

* There was an edge case where `READ_ONLY (1) + READ_ONLY (1) + DONT_ENUM (2)` would evaluate to `DONT_DELETE (4)` instead of `READ_ONLY + DONT_ENUM` because of addition. This change also fixes that and adds a test for that case.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

cc @bnoordhuis since this was added in https://github.com/denoland/rusty_v8/pull/228