### PR TITLE
Add `v8::ArrayBuffer::Data`

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -36,6 +36,7 @@ extern "C" {
     backing_store: *const SharedRef<BackingStore>,
   ) -> *const ArrayBuffer;
   fn v8__ArrayBuffer__Detach(this: *const ArrayBuffer);
+  fn v8__ArrayBuffer__Data(this: *const ArrayBuffer) -> *mut c_void;
   fn v8__ArrayBuffer__IsDetachable(this: *const ArrayBuffer) -> bool;
   fn v8__ArrayBuffer__ByteLength(this: *const ArrayBuffer) -> usize;
   fn v8__ArrayBuffer__GetBackingStore(
@@ -389,6 +390,13 @@ impl ArrayBuffer {
     if self.is_detachable() {
       unsafe { v8__ArrayBuffer__Detach(self) }
     }
+  }
+
+  /// More efficient shortcut for GetBackingStore()->Data().
+  /// The returned pointer is valid as long as the ArrayBuffer is alive.
+  #[inline]
+  pub fn data(&self) -> *mut c_void {
+    unsafe { v8__ArrayBuffer__Data(self) }
   }
 
   /// Get a shared pointer to the backing store of this array buffer. This

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -854,6 +854,10 @@ two_pointers_t v8__ArrayBuffer__GetBackingStore(const v8::ArrayBuffer& self) {
   return make_pod<two_pointers_t>(ptr_to_local(&self)->GetBackingStore());
 }
 
+void* v8__ArrayBuffer__Data(const v8::ArrayBuffer& self) {
+  return ptr_to_local(&self)->Data();
+}
+
 void v8__ArrayBuffer__Detach(const v8::ArrayBuffer& self) {
   ptr_to_local(&self)->Detach();
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -6679,6 +6679,26 @@ fn backing_store_from_empty_vec() {
 }
 
 #[test]
+fn backing_store_data() {
+  let _setup_guard = setup();
+
+  let mut isolate = v8::Isolate::new(Default::default());
+  let mut scope = v8::HandleScope::new(&mut isolate);
+  let context = v8::Context::new(&mut scope);
+  let mut scope = v8::ContextScope::new(&mut scope, context);
+
+  let v = vec![1, 2, 3, 4, 5];
+  let len = v.len();
+  let store = v8::ArrayBuffer::new_backing_store_from_vec(v).make_shared();
+  let buf = v8::ArrayBuffer::with_backing_store(&mut scope, &store);
+  assert_eq!(buf.byte_length(), len);
+  assert_eq!(
+    unsafe { std::slice::from_raw_parts_mut(buf.data() as *mut u8, len) },
+    &[1, 2, 3, 4, 5]
+  );
+}
+
+#[test]
 fn current_stack_trace() {
   // Setup isolate
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
https://v8.github.io/api/head/classv8_1_1ArrayBuffer.html
> More efficient shortcut for [GetBackingStore()](https://v8.github.io/api/head/classv8_1_1ArrayBuffer.html#aaa29e281f94990cbf0a5484140fffb50)->Data(). The returned pointer is valid as long as the [ArrayBuffer](https://v8.github.io/api/head/classv8_1_1ArrayBuffer.html) is alive.