### PR TITLE
perf: optimize scope construction and `Isolate::get_slot/set_slot()`

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -9,6 +9,7 @@
 #include "v8/include/libplatform/libplatform.h"
 #include "v8/include/v8-fast-api-calls.h"
 #include "v8/include/v8-inspector.h"
+#include "v8/include/v8-internal.h"
 #include "v8/include/v8-platform.h"
 #include "v8/include/v8-profiler.h"
 #include "v8/include/v8.h"
@@ -99,6 +100,9 @@ static_assert(offsetof(v8::ScriptCompiler::CachedData, buffer_policy) == 12,
 #endif
 
 extern "C" {
+const extern size_t v8__internal__Internals__kIsolateEmbedderDataOffset =
+    v8::internal::Internals::kIsolateEmbedderDataOffset;
+
 void v8__V8__SetFlagsFromCommandLine(int* argc, char** argv,
                                      const char* usage) {
   namespace i = v8::internal;
@@ -157,14 +161,6 @@ const v8::Context* v8__Isolate__GetCurrentContext(v8::Isolate* isolate) {
 const v8::Context* v8__Isolate__GetEnteredOrMicrotaskContext(
     v8::Isolate* isolate) {
   return local_to_ptr(isolate->GetEnteredOrMicrotaskContext());
-}
-
-void v8__Isolate__SetData(v8::Isolate* isolate, uint32_t slot, void* data) {
-  isolate->SetData(slot, data);
-}
-
-void* v8__Isolate__GetData(v8::Isolate* isolate, uint32_t slot) {
-  return isolate->GetData(slot);
 }
 
 uint32_t v8__Isolate__GetNumberOfDataSlots(v8::Isolate* isolate) {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -7498,57 +7498,25 @@ fn finalizer_on_kept_global() {
 }
 
 #[test]
-fn isolate_data_fields() {
+fn isolate_data_slots() {
   let _setup_guard = setup();
-
   let mut isolate = v8::Isolate::new(Default::default());
 
-  struct SomeData {
-    foo: &'static str,
-    bar: &'static str,
-    fizz: &'static str,
-  }
+  assert_eq!(isolate.get_number_of_data_slots(), 2);
 
-  let some_data1 = Box::new(SomeData {
-    foo: "foo",
-    bar: "",
-    fizz: "",
-  });
-  let some_data2 = Box::new(SomeData {
-    foo: "",
-    bar: "bar",
-    fizz: "",
-  });
-  let some_data3 = Box::new(SomeData {
-    foo: "",
-    bar: "",
-    fizz: "fizz",
-  });
-  unsafe {
-    isolate.set_data(1, Box::into_raw(some_data1) as *mut _ as *mut c_void);
-    isolate.set_data(2, Box::into_raw(some_data2) as *mut _ as *mut c_void);
-    isolate.set_data(3, Box::into_raw(some_data3) as *mut _ as *mut c_void);
-  }
+  let expected0 = "Bla";
+  isolate.set_data(0, &expected0 as *const _ as *mut &str as *mut c_void);
 
-  {
-    let data_some_data1 = isolate.get_data(1) as *mut SomeData;
-    let data_some_data1 = unsafe { &mut *data_some_data1 };
-    assert_eq!(data_some_data1.foo, "foo");
-    assert_eq!(data_some_data1.bar, "");
-    assert_eq!(data_some_data1.fizz, "");
+  let expected1 = 123.456f64;
+  isolate.set_data(1, &expected1 as *const _ as *mut f64 as *mut c_void);
 
-    let data_some_data2 = isolate.get_data(2) as *mut SomeData;
-    let data_some_data2 = unsafe { &mut *data_some_data2 };
-    assert_eq!(data_some_data2.foo, "");
-    assert_eq!(data_some_data2.bar, "bar");
-    assert_eq!(data_some_data2.fizz, "");
+  let actual0 = isolate.get_data(0) as *mut &str;
+  let actual0 = unsafe { *actual0 };
+  assert_eq!(actual0, expected0);
 
-    let data_some_data3 = isolate.get_data(3) as *mut SomeData;
-    let data_some_data3 = unsafe { &mut *data_some_data3 };
-    assert_eq!(data_some_data3.foo, "");
-    assert_eq!(data_some_data3.bar, "");
-    assert_eq!(data_some_data3.fizz, "fizz");
-  }
+  let actual1 = isolate.get_data(1) as *mut f64;
+  let actual1 = unsafe { *actual1 };
+  assert_eq!(actual1, expected1);
 }
 
 #[test]


### PR DESCRIPTION
Before (on a MacBook Pro M1 2021):

```
Running function_overhead ...
  18.0 ns per run 55.5 million ops/sec → new_
  18.4 ns per run 54.5 million ops/sec → new_raw
  13.5 ns per run 74.1 million ops/sec → new_set_uint32
  8.8 ns per run 113.4 million ops/sec → new_raw_set_uint32
  2.7 ns per run 366.3 million ops/sec → new_fast
Running primitives ...
  15.0 ns per run 66.7 million ops/sec → undefined_from_scope
  7.6 ns per run 131.8 million ops/sec → undefined_from_isolate
```

After:

```
Running function_overhead ...
  15.1 ns per run 66.2 million ops/sec → new_
  15.1 ns per run 66.1 million ops/sec → new_raw
  11.5 ns per run 87.2 million ops/sec → new_set_uint32
  6.8 ns per run 146.6 million ops/sec → new_raw_set_uint32
  2.7 ns per run 367.6 million ops/sec → new_fast
Running primitives ...
  12.2 ns per run 81.9 million ops/sec → undefined_from_scope
  7.6 ns per run 131.9 million ops/sec → undefined_from_isolate
```