### PR TITLE
feat: add ArrayBuffer::was_detached()

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -38,6 +38,7 @@ extern "C" {
   fn v8__ArrayBuffer__Detach(this: *const ArrayBuffer);
   fn v8__ArrayBuffer__Data(this: *const ArrayBuffer) -> *mut c_void;
   fn v8__ArrayBuffer__IsDetachable(this: *const ArrayBuffer) -> bool;
+  fn v8__ArrayBuffer__WasDetached(this: *const ArrayBuffer) -> bool;
   fn v8__ArrayBuffer__ByteLength(this: *const ArrayBuffer) -> usize;
   fn v8__ArrayBuffer__GetBackingStore(
     this: *const ArrayBuffer,
@@ -387,6 +388,15 @@ impl ArrayBuffer {
   #[inline(always)]
   pub fn is_detachable(&self) -> bool {
     unsafe { v8__ArrayBuffer__IsDetachable(self) }
+  }
+
+  /// Returns true if this ArrayBuffer was detached.
+  #[inline(always)]
+  pub fn was_detached(&self) -> bool {
+    if self.byte_length() != 0 {
+      return false;
+    }
+    unsafe { v8__ArrayBuffer__WasDetached(self) }
   }
 
   /// Detaches this ArrayBuffer and all its views (typed arrays).

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -829,11 +829,7 @@ bool v8__ArrayBuffer__IsDetachable(const v8::ArrayBuffer& self) {
 }
 
 bool v8__ArrayBuffer__WasDetached(const v8::ArrayBuffer& self) {
-  /// v8 does not provide a direct way to check if an ArrayBuffer
-  /// is already detached. Instead, we use JSArrayBufferView->WasDetached
-  return v8::Utils::OpenHandle(
-             local_to_ptr(v8::Uint8Array::New(ptr_to_local(&self), 0, 0)))
-      ->WasDetached();
+  return v8::Utils::OpenHandle(&self)->was_detached();
 }
 
 void* v8__BackingStore__Data(const v8::BackingStore& self) {

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -828,6 +828,14 @@ bool v8__ArrayBuffer__IsDetachable(const v8::ArrayBuffer& self) {
   return ptr_to_local(&self)->IsDetachable();
 }
 
+bool v8__ArrayBuffer__WasDetached(const v8::ArrayBuffer& self) {
+  /// v8 does not provide a direct way to check if an ArrayBuffer
+  /// is already detached. Instead, we use JSArrayBufferView->WasDetached
+  return v8::Utils::OpenHandle(
+             local_to_ptr(v8::Uint8Array::New(ptr_to_local(&self), 0, 0)))
+      ->WasDetached();
+}
+
 void* v8__BackingStore__Data(const v8::BackingStore& self) {
   return self.Data();
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -573,19 +573,19 @@ fn array_buffer() {
 
     let ab = v8::ArrayBuffer::new(scope, 42);
     assert_eq!(42, ab.byte_length());
-    assert_eq!(false, ab.was_detached());
+    assert!(!ab.was_detached());
     assert!(ab.is_detachable());
 
     ab.detach();
     assert_eq!(0, ab.byte_length());
-    assert_eq!(true, ab.was_detached());
+    assert!(ab.was_detached());
     ab.detach(); // Calling it twice should be a no-op.
 
     // detecting if it was detached on a zero-length ArrayBuffer should work
     let empty_ab = v8::ArrayBuffer::new(scope, 0);
-    assert_eq!(false, empty_ab.was_detached());
+    assert!(!empty_ab.was_detached());
     empty_ab.detach();
-    assert_eq!(true, empty_ab.was_detached());
+    assert!(empty_ab.was_detached());
 
     let bs = v8::ArrayBuffer::new_backing_store(scope, 84);
     assert_eq!(84, bs.byte_length());

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -573,11 +573,19 @@ fn array_buffer() {
 
     let ab = v8::ArrayBuffer::new(scope, 42);
     assert_eq!(42, ab.byte_length());
-
+    assert_eq!(false, ab.was_detached());
     assert!(ab.is_detachable());
+
     ab.detach();
     assert_eq!(0, ab.byte_length());
+    assert_eq!(true, ab.was_detached());
     ab.detach(); // Calling it twice should be a no-op.
+
+    // detecting if it was detached on a zero-length ArrayBuffer should work
+    let empty_ab = v8::ArrayBuffer::new(scope, 0);
+    assert_eq!(false, empty_ab.was_detached());
+    empty_ab.detach();
+    assert_eq!(true, empty_ab.was_detached());
 
     let bs = v8::ArrayBuffer::new_backing_store(scope, 84);
     assert_eq!(84, bs.byte_length());


### PR DESCRIPTION
This PR adds `ArrayBuffer::was_detached()`.

While there's no `WasDetached` method on [`ArrayBuffer`](https://v8.github.io/api/head/classv8_1_1ArrayBuffer.html), while going through the code I noticed there is one in [`JSArrayBufferView`](https://chromium.googlesource.com/v8/v8/+/refs/heads/main/src/objects/js-array-buffer.h#259) that we could use.

Currently, Deno has no reliable way to check if an ArrayBuffer was detached. With this commit, we'll be able to make Streams and `structuredClone` spec-compliant.