### PR TITLE
[WIP] Bindings for FunctionCallbackInfo::Callee

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1923,7 +1923,7 @@ const v8::Object* v8__FunctionCallbackInfo__This(
   return local_to_ptr(self.This());
 }
 
-const v8::Object* v8__FunctionCallbackInfo__This(
+const v8::Function* v8__FunctionCallbackInfo__Callee(
     const v8::FunctionCallbackInfo<v8::Value>& self) {
   return local_to_ptr(self.Callee());
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1923,6 +1923,11 @@ const v8::Object* v8__FunctionCallbackInfo__This(
   return local_to_ptr(self.This());
 }
 
+const v8::Object* v8__FunctionCallbackInfo__This(
+    const v8::FunctionCallbackInfo<v8::Value>& self) {
+  return local_to_ptr(self.Callee());
+}
+
 int v8__FunctionCallbackInfo__Length(
     const v8::FunctionCallbackInfo<v8::Value>& self) {
   return self.Length();

--- a/src/function.rs
+++ b/src/function.rs
@@ -58,6 +58,9 @@ extern "C" {
   fn v8__FunctionCallbackInfo__This(
     this: *const FunctionCallbackInfo,
   ) -> *const Object;
+  fn v8__FunctionCallbackInfo__Callee(
+    callee: *const FunctionCallbackInfo,
+  ) -> *const Function;
   fn v8__FunctionCallbackInfo__Length(this: *const FunctionCallbackInfo)
     -> int;
   fn v8__FunctionCallbackInfo__GetArgument(
@@ -247,6 +250,14 @@ impl<'s> FunctionCallbackArguments<'s> {
   pub fn this(&self) -> Local<'s, Object> {
     unsafe {
       Local::from_raw(v8__FunctionCallbackInfo__This(self.info)).unwrap()
+    }
+  }
+
+  /// Returns the callee function.
+  #[inline(always)]
+  pub fn callee(&self) -> Local<'s, Function> {
+    unsafe {
+      Local::from_raw(v8__FunctionCallbackInfo__Callee(self.info)).unwrap()
     }
   }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -59,7 +59,7 @@ extern "C" {
     this: *const FunctionCallbackInfo,
   ) -> *const Object;
   fn v8__FunctionCallbackInfo__Callee(
-    callee: *const FunctionCallbackInfo,
+    this: *const FunctionCallbackInfo,
   ) -> *const Function;
   fn v8__FunctionCallbackInfo__Length(this: *const FunctionCallbackInfo)
     -> int;


### PR DESCRIPTION
Adds bindings for the Callee field of FunctionCallbackInfo as documented in v8.h line 6083.

Marked as WIP because of gn build issues preventing me from being able to test the bindings.