### PR TITLE
Remove libc dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,6 @@ dependencies = [
  "bitflags",
  "fslock",
  "lazy_static",
- "libc",
  "trybuild",
  "which",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ use_custom_libcxx = []
 [dependencies]
 bitflags = "1.3.2"
 lazy_static = "1.4.0"
-libc = "0.2.126"
 
 [build-dependencies]
 fslock = "0.1.8"

--- a/src/V8.rs
+++ b/src/V8.rs
@@ -1,24 +1,24 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
-use libc::c_char;
-use libc::c_int;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::sync::Mutex;
 use std::vec::Vec;
 
 use crate::platform::Platform;
+use crate::support::char;
+use crate::support::int;
 use crate::support::SharedRef;
 use crate::support::UnitType;
 
 extern "C" {
   fn v8__V8__SetFlagsFromCommandLine(
-    argc: *mut c_int,
-    argv: *mut *mut c_char,
-    usage: *const c_char,
+    argc: *mut int,
+    argv: *mut *mut char,
+    usage: *const char,
   );
   fn v8__V8__SetFlagsFromString(flags: *const u8, length: usize);
   fn v8__V8__SetEntropySource(callback: EntropySource);
-  fn v8__V8__GetVersion() -> *const c_char;
+  fn v8__V8__GetVersion() -> *const char;
   fn v8__V8__InitializePlatform(platform: *mut Platform);
   fn v8__V8__Initialize();
   fn v8__V8__Dispose() -> bool;
@@ -120,16 +120,16 @@ pub fn set_flags_from_command_line_with_usage(
     .collect::<Vec<_>>();
   let mut c_argv = raw_argv
     .iter_mut()
-    .map(|arg| arg.as_mut_ptr() as *mut c_char)
+    .map(|arg| arg.as_mut_ptr() as *mut char)
     .collect::<Vec<_>>();
 
   // Store the length of the c_argv array in a local variable. We'll pass
   // a pointer to this local variable to deno_set_v8_flags(), which then
   // updates its value.
-  let mut c_argv_len = c_argv.len() as c_int;
+  let mut c_argv_len = c_argv.len() as int;
   // Let v8 parse the arguments it recognizes and remove them from c_argv.
   let c_usage = match usage {
-    Some(str) => CString::new(str).unwrap().into_raw() as *const c_char,
+    Some(str) => CString::new(str).unwrap().into_raw() as *const char,
     None => std::ptr::null(),
   };
   unsafe {
@@ -145,7 +145,7 @@ pub fn set_flags_from_command_line_with_usage(
   c_argv
     .iter()
     .map(|ptr| unsafe {
-      let cstr = CStr::from_ptr(*ptr as *const c_char);
+      let cstr = CStr::from_ptr(*ptr as *const char);
       let slice = cstr.to_str().unwrap();
       slice.to_string()
     })

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,6 +3,7 @@ use crate::handle::UnsafeRefHandle;
 use crate::isolate::BuildTypeIdHasher;
 use crate::isolate::Isolate;
 use crate::isolate::RawSlot;
+use crate::support::int;
 use crate::Context;
 use crate::Function;
 use crate::HandleScope;
@@ -11,7 +12,6 @@ use crate::Object;
 use crate::ObjectTemplate;
 use crate::Value;
 use crate::Weak;
-use libc::c_int;
 use std::any::TypeId;
 use std::collections::HashMap;
 use std::ffi::c_void;
@@ -37,11 +37,11 @@ extern "C" {
   fn v8__Context__GetNumberOfEmbedderDataFields(this: *const Context) -> u32;
   fn v8__Context__GetAlignedPointerFromEmbedderData(
     this: *const Context,
-    index: c_int,
+    index: int,
   ) -> *mut c_void;
   fn v8__Context__SetAlignedPointerInEmbedderData(
     this: *const Context,
-    index: c_int,
+    index: int,
     value: *mut c_void,
   );
   fn v8__Context__FromSnapshot(
@@ -51,8 +51,8 @@ extern "C" {
 }
 
 impl Context {
-  const ANNEX_SLOT: c_int = 1;
-  const INTERNAL_SLOT_COUNT: c_int = 1;
+  const ANNEX_SLOT: int = 1;
+  const INTERNAL_SLOT_COUNT: int = 1;
 
   /// Creates a new context.
   #[inline(always)]
@@ -138,7 +138,7 @@ impl Context {
     );
 
     let num_data_fields =
-      unsafe { v8__Context__GetNumberOfEmbedderDataFields(self) } as c_int;
+      unsafe { v8__Context__GetNumberOfEmbedderDataFields(self) } as int;
     if num_data_fields > Self::ANNEX_SLOT {
       let annex_ptr = unsafe {
         v8__Context__GetAlignedPointerFromEmbedderData(self, Self::ANNEX_SLOT)
@@ -171,7 +171,7 @@ impl Context {
       )
     };
     assert!(
-      unsafe { v8__Context__GetNumberOfEmbedderDataFields(self) } as c_int
+      unsafe { v8__Context__GetNumberOfEmbedderDataFields(self) } as int
         > Self::ANNEX_SLOT
     );
 

--- a/src/external_references.rs
+++ b/src/external_references.rs
@@ -3,7 +3,7 @@ use crate::support::intptr_t;
 use crate::AccessorNameGetterCallback;
 use crate::FunctionCallback;
 use crate::MessageCallback;
-use std::os::raw::c_void;
+use std::ffi::c_void;
 
 #[derive(Clone, Copy)]
 pub union ExternalReference<'s> {

--- a/src/fast_api.rs
+++ b/src/fast_api.rs
@@ -1,8 +1,8 @@
 use crate::support::Opaque;
 use crate::Local;
 use crate::Value;
-use libc::c_void;
 use std::{
+  ffi::c_void,
   mem::align_of,
   ptr::{self, NonNull},
 };

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 use std::cell::Cell;
+use std::ffi::c_void;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::marker::PhantomData;
@@ -7,8 +8,6 @@ use std::mem::forget;
 use std::mem::transmute;
 use std::ops::Deref;
 use std::ptr::NonNull;
-
-use libc::c_void;
 
 use crate::support::Opaque;
 use crate::Data;

--- a/src/icu.rs
+++ b/src/icu.rs
@@ -1,8 +1,10 @@
-use std::{ffi::CString, os::raw::c_char};
+use crate::support::char;
+
+use std::ffi::CString;
 
 extern "C" {
-  fn icu_get_default_locale(output: *mut c_char, output_len: usize) -> usize;
-  fn icu_set_default_locale(locale: *const c_char);
+  fn icu_get_default_locale(output: *mut char, output_len: usize) -> usize;
+  fn icu_set_default_locale(locale: *const char);
   fn udata_setCommonData_71(this: *const u8, error_code: *mut i32);
 }
 
@@ -56,7 +58,7 @@ pub fn set_common_data_71(data: &'static [u8]) -> Result<(), i32> {
 pub fn get_language_tag() -> String {
   let mut output = [0u8; 1024];
   let len = unsafe {
-    icu_get_default_locale(output.as_mut_ptr() as *mut c_char, output.len())
+    icu_get_default_locale(output.as_mut_ptr() as *mut char, output.len())
   };
   std::str::from_utf8(&output[..len]).unwrap().to_owned()
 }

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -7,6 +7,7 @@ use crate::isolate_create_params::CreateParams;
 use crate::promise::PromiseRejectMessage;
 use crate::scope::data::ScopeData;
 use crate::snapshot::SnapshotCreator;
+use crate::support::char;
 use crate::support::int;
 use crate::support::Allocated;
 use crate::support::MapFnFrom;
@@ -49,7 +50,6 @@ use std::mem::size_of;
 use std::mem::MaybeUninit;
 use std::ops::Deref;
 use std::ops::DerefMut;
-use std::os::raw::c_char;
 use std::ptr;
 use std::ptr::drop_in_place;
 use std::ptr::null_mut;
@@ -302,11 +302,11 @@ pub type NearHeapLimitCallback = extern "C" fn(
 #[repr(C)]
 pub struct OomDetails {
   pub is_heap_oom: bool,
-  pub detail: *const c_char,
+  pub detail: *const char,
 }
 
 pub type OomErrorCallback =
-  extern "C" fn(location: *const c_char, details: &OomDetails);
+  extern "C" fn(location: *const char, details: &OomDetails);
 
 /// Collection of V8 heap information.
 ///

--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -13,12 +13,11 @@ use std::convert::TryFrom;
 use std::iter::once;
 use std::mem::size_of;
 use std::mem::MaybeUninit;
-use std::os::raw::c_char;
 use std::ptr::null;
 
 /// Should return a pointer to memory that persists for the lifetime of the
 /// isolate.
-pub type CounterLookupCallback = extern "C" fn(name: *const c_char) -> *mut i32;
+pub type CounterLookupCallback = extern "C" fn(name: *const char) -> *mut i32;
 
 /// Initial configuration parameters for a new Isolate.
 #[must_use]

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,5 +1,3 @@
-use libc::c_void;
-
 use crate::isolate::Isolate;
 use crate::support::int;
 use crate::support::MapFnTo;
@@ -22,6 +20,7 @@ use crate::PropertyAttribute;
 use crate::PropertyFilter;
 use crate::Value;
 use std::convert::TryFrom;
+use std::ffi::c_void;
 use std::num::NonZeroI32;
 
 extern "C" {

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
-use std::os::raw::c_int;
 use std::{marker::PhantomData, mem::MaybeUninit};
 
+use crate::support::int;
 use crate::Function;
 use crate::Local;
 use crate::Module;
@@ -65,9 +65,9 @@ extern "C" {
 pub struct Source {
   _source_string: usize,
   _resource_name: usize,
-  _resource_line_offset: c_int,
-  _resource_column_offset: c_int,
-  _resource_options: c_int,
+  _resource_line_offset: int,
+  _resource_column_offset: int,
+  _resource_options: int,
   _source_map_url: usize,
   _host_defined_options: usize,
   _cached_data: usize,

--- a/src/string.rs
+++ b/src/string.rs
@@ -6,13 +6,14 @@ use std::slice;
 
 use crate::support::char;
 use crate::support::int;
+use crate::support::size_t;
 use crate::HandleScope;
 use crate::Isolate;
 use crate::Local;
 use crate::String;
 
 extern "C" {
-  fn v8__String__kMaxLength() -> libc::size_t;
+  fn v8__String__kMaxLength() -> size_t;
 
   fn v8__String__Empty(isolate: *mut Isolate) -> *const String;
 

--- a/src/support.rs
+++ b/src/support.rs
@@ -30,6 +30,11 @@ use std::time::Instant;
 #[allow(non_camel_case_types)]
 pub type intptr_t = isize;
 
+// TODO use libc::size_t when stable.
+// https://doc.rust-lang.org/1.7.0/libc/type.size_t.html
+#[allow(non_camel_case_types)]
+pub type size_t = usize;
+
 pub use std::os::raw::c_char as char;
 pub use std::os::raw::c_int as int;
 pub use std::os::raw::c_long as long;

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,5 +1,3 @@
-use libc::c_void;
-
 use crate::data::Data;
 use crate::data::FunctionTemplate;
 use crate::data::Name;
@@ -31,6 +29,7 @@ use crate::String;
 use crate::Value;
 use crate::NONE;
 use std::convert::TryFrom;
+use std::ffi::c_void;
 use std::ptr::null;
 
 extern "C" {

--- a/src/typed_array.rs
+++ b/src/typed_array.rs
@@ -1,11 +1,12 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
+use crate::support::size_t;
 use crate::ArrayBuffer;
 use crate::HandleScope;
 use crate::Local;
 use crate::TypedArray;
 
 extern "C" {
-  fn v8__TypedArray__kMaxLength() -> libc::size_t;
+  fn v8__TypedArray__kMaxLength() -> size_t;
 }
 
 impl TypedArray {


### PR DESCRIPTION
The main goal of this PR is to remove dependencies with functionality that is already present in the `std` or the crate.

Only size_t needs to be defined like was done with the `intptr_t` type before.

Also unifies the usage of `std::os::raw` types that where already defined in the support module and used in other parts of the crate.