### PR TITLE
Update `ArrayBuffer::was_detached` to not use `OpenHandle`

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -832,7 +832,7 @@ bool v8__ArrayBuffer__IsDetachable(const v8::ArrayBuffer& self) {
 }
 
 bool v8__ArrayBuffer__WasDetached(const v8::ArrayBuffer& self) {
-  return v8::Utils::OpenHandle(&self)->was_detached();
+  return ptr_to_local(&self)->WasDetached();
 }
 
 void* v8__BackingStore__Data(const v8::BackingStore& self) {


### PR DESCRIPTION
In #1103, the `ArrayBuffer::was_detached` method was added to rusty_v8 to fill a gap in the C++ API, and it was implemented using the internal `v8::Utils::OpenHandle`. Since then, a `WasDetached` method was added to `ArrayBuffer` in V8 10.9. This PR updates the implementation to use that.
