### PR TITLE
Add `ArrayBuffer::set_detach_key`

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -41,6 +41,7 @@ extern "C" {
     this: *const ArrayBuffer,
     key: *const Value,
   ) -> MaybeBool;
+  fn v8__ArrayBuffer__SetDetachKey(this: *const ArrayBuffer, key: *const Value);
   fn v8__ArrayBuffer__Data(this: *const ArrayBuffer) -> *mut c_void;
   fn v8__ArrayBuffer__IsDetachable(this: *const ArrayBuffer) -> bool;
   fn v8__ArrayBuffer__WasDetached(this: *const ArrayBuffer) -> bool;
@@ -408,7 +409,7 @@ impl ArrayBuffer {
   /// Detaching sets the byte length of the buffer and all typed arrays to zero,
   /// preventing JavaScript from ever accessing underlying backing store.
   /// ArrayBuffer should have been externalized and must be detachable. Returns
-  /// `None` if the key didn't pass the [[ArrayBufferDetachKey]] check,
+  /// `None` if the key didn't pass the `[[ArrayBufferDetachKey]]` check,
   /// and `Some(true)` otherwise.
   #[inline(always)]
   pub fn detach(&self, key: Local<Value>) -> Option<bool> {
@@ -419,6 +420,12 @@ impl ArrayBuffer {
     } else {
       Some(true)
     }
+  }
+
+  /// Sets the `[[ArrayBufferDetachKey]]`.
+  #[inline(always)]
+  pub fn set_detach_key(&self, key: Local<Value>) {
+    unsafe { v8__ArrayBuffer__SetDetachKey(self, &*key) };
   }
 
   /// More efficient shortcut for GetBackingStore()->Data().

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -835,6 +835,11 @@ bool v8__ArrayBuffer__WasDetached(const v8::ArrayBuffer& self) {
   return v8::Utils::OpenHandle(&self)->was_detached();
 }
 
+void v8__ArrayBuffer__SetDetachKey(const v8::ArrayBuffer& self,
+                                   const v8::Value* key) {
+  return ptr_to_local(&self)->SetDetachKey(ptr_to_local(key));
+}
+
 void* v8__BackingStore__Data(const v8::BackingStore& self) {
   return self.Data();
 }


### PR DESCRIPTION
This method, introduced in V8 10.9, makes it so an `ArrayBuffer` object is impossible to detach unless a specific detach key is passed to the `detach` method. Such `ArrayBuffer`s still count as detachable as per the `ArrayBuffer::is_detachable` method, but otherwise behave much like WebAssembly memories.
