### PR TITLE
refactor: Have `ArrayBuffer::data` return `Option<NonNull<c_void>>`

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -431,8 +431,9 @@ impl ArrayBuffer {
   /// More efficient shortcut for GetBackingStore()->Data().
   /// The returned pointer is valid as long as the ArrayBuffer is alive.
   #[inline(always)]
-  pub fn data(&self) -> *mut c_void {
-    unsafe { v8__ArrayBuffer__Data(self) }
+  pub fn data(&self) -> Option<NonNull<c_void>> {
+    let raw_ptr = unsafe { v8__ArrayBuffer__Data(self) };
+    NonNull::new(raw_ptr)
   }
 
   /// Get a shared pointer to the backing store of this array buffer. This

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -7275,8 +7275,14 @@ fn backing_store_data() {
   let store = v8::ArrayBuffer::new_backing_store_from_vec(v).make_shared();
   let buf = v8::ArrayBuffer::with_backing_store(&mut scope, &store);
   assert_eq!(buf.byte_length(), len);
+  assert!(buf.data().is_some());
   assert_eq!(
-    unsafe { std::slice::from_raw_parts_mut(buf.data() as *mut u8, len) },
+    unsafe {
+      std::slice::from_raw_parts_mut(
+        buf.data().unwrap().cast::<u8>().as_ptr(),
+        len,
+      )
+    },
     &[1, 2, 3, 4, 5]
   );
 }


### PR DESCRIPTION
The pointer returned by `ArrayBuffer::data` might be null if the backing store has zero length, but the return type `*mut c_void` does not force the user to consider this case. This change makes the return type `Option<NonNull<c_void>>`, which is semantically equivalent, but which forces users of the API to handle the `None` case.

This PR is the `ArrayBuffer` counterpart to #817.

This is a breaking API change.