### PR TITLE
Add 'aux_data' to v8::Inspector::contextCreated()

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2444,9 +2444,12 @@ v8_inspector::V8InspectorSession* v8_inspector__V8Inspector__connect(
 
 void v8_inspector__V8Inspector__contextCreated(
     v8_inspector::V8Inspector* self, const v8::Context& context,
-    int contextGroupId, v8_inspector::StringView humanReadableName) {
-  self->contextCreated(v8_inspector::V8ContextInfo(
-      ptr_to_local(&context), contextGroupId, humanReadableName));
+    int contextGroupId, v8_inspector::StringView humanReadableName,
+    v8_inspector::StringView auxData) {
+  v8_inspector::V8ContextInfo info(
+      ptr_to_local(&context), contextGroupId, humanReadableName);
+  info.auxData = auxData;
+  self->contextCreated(info);
 }
 
 void v8_inspector__V8Inspector__contextDestroyed(

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -109,6 +109,7 @@ extern "C" {
     context: *const Context,
     contextGroupId: int,
     humanReadableName: StringView,
+    auxData: StringView,
   );
   fn v8_inspector__V8Inspector__contextDestroyed(
     this: *mut V8Inspector,
@@ -941,6 +942,7 @@ impl V8Inspector {
     context: Local<Context>,
     context_group_id: i32,
     human_readable_name: StringView,
+    aux_data: StringView,
   ) {
     unsafe {
       v8_inspector__V8Inspector__contextCreated(
@@ -948,6 +950,7 @@ impl V8Inspector {
         &*context,
         context_group_id,
         human_readable_name,
+        aux_data,
       )
     }
   }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -5124,7 +5124,8 @@ fn inspector_dispatch_protocol_message() {
 
   let name = b"";
   let name_view = StringView::from(&name[..]);
-  inspector.context_created(context, 1, name_view);
+  let aux_data = StringView::from(&name[..]);
+  inspector.context_created(context, 1, name_view, aux_data);
   let mut channel = ChannelCounter::new();
   let state = b"{}";
   let state_view = StringView::from(&state[..]);
@@ -5171,7 +5172,8 @@ fn inspector_schedule_pause_on_next_statement() {
 
   let name = b"";
   let name_view = StringView::from(&name[..]);
-  inspector.context_created(context, 1, name_view);
+  let aux_data = StringView::from(&name[..]);
+  inspector.context_created(context, 1, name_view, aux_data);
 
   // In order for schedule_pause_on_next_statement to work, it seems you need
   // to first enable the debugger.
@@ -5265,7 +5267,9 @@ fn inspector_console_api_message() {
 
   let name = b"";
   let name_view = StringView::from(&name[..]);
-  inspector.context_created(context, 1, name_view);
+  let aux_data = b"{\"isDefault\": true}";
+  let aux_data_view = StringView::from(&aux_data[..]);
+  inspector.context_created(context, 1, name_view, aux_data_view);
 
   let source = r#"
     console.log("one");


### PR DESCRIPTION
Some clients like VSCode expect that `auxData` will be set to `{"isDefault": true/false}`. I think this stems from how Node integrates with debuggers. I confirm that it fixes one of the problem where inspector doesn't disconnected in VSCode after program finishes.