### PR TITLE
ci: add "release" action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,4 @@ jobs:
         run: |
           git config user.email "denobot@users.noreply.github.com"
           git config user.name "denobot"
-          deno run -A https://raw.githubusercontent.com/denoland/automation/0.16.1/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}
+          deno run -A https://raw.githubusercontent.com/denoland/automation/0.16.1/tasks/publish_release.ts --${{github.event.inputs.releaseKind}} --skip-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - minor
+          - patch
         required: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseKind:
+        description: 'Kind of release'
+        default: 'minor'
+        type: choice
+        options:
+          - minor
+        required: true
+
+jobs:
+  rust:
+    name: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.DENOBOT_PAT }}
+
+      - uses: denoland/setup-deno@v1
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Tag and release
+        env:
+          GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
+          GH_WORKFLOW_ACTOR: ${{ github.actor }}
+        run: |
+          git config user.email "denobot@users.noreply.github.com"
+          git config user.name "denobot"
+          deno run -A https://raw.githubusercontent.com/denoland/automation/0.16.1/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}

--- a/README.md
+++ b/README.md
@@ -161,3 +161,17 @@ increasing amount of V8's API in Rust.
 **When building I get unknown argument: '-gno-inline-line-tables'**
 
 Use `export GN_ARGS="no_inline_line_tables=false"` during build.
+
+## For maintainers
+
+**Cut a release**
+
+Go to https://github.com/denoland/rusty_v8/actions/workflows/release.yml, select
+proper release kind and wait for the workflow to complete. It will bump the
+version and create a tag. You will need to manually upload binary archives for
+M1 build.
+
+```
+$ V8_FROM_SOURCE=1 cargo build
+$ V8_FROM_SOURCE=1 cargo build --release
+```


### PR DESCRIPTION
This workflow will bump a version and create a tag which will kick-off another
build that will build release binary archives and create a GH release.

Maintainer is still responsible for building artifacts on M1 mac.