### PR TITLE
ci: update release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,9 +183,7 @@ jobs:
           target/${{ env.LIB_NAME }}_${{ matrix.config.variant }}_${{ matrix.config.target }}.${{ env.LIB_EXT }}
 
       - name: Binary publish
-        # TODO(ry): use version instead of commit hash once #139 is fixed.
-        # https://github.com/softprops/action-gh-release/issues/139
-        uses: softprops/action-gh-release@59c3b4891632ff9a897f99a91d7bc557467a3a22
+        uses: softprops/action-gh-release@v0.1.15
         if: >-
           github.repository == 'denoland/rusty_v8' &&
           startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Hopefully this fixes the problem that caused abort of v0.59.0 release 🤞 