### PR TITLE
chore: update to Rust 1.66.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.66.0"
 components = ["rustfmt", "clippy"]

--- a/src/external.rs
+++ b/src/external.rs
@@ -17,7 +17,7 @@ extern "C" {
 
 impl External {
   #[inline(always)]
-  pub fn new<'s>(
+  pub unsafe fn new<'s>(
     scope: &mut HandleScope<'s, ()>,
     value: *mut c_void,
   ) -> Local<'s, Self> {

--- a/src/external.rs
+++ b/src/external.rs
@@ -17,7 +17,8 @@ extern "C" {
 
 impl External {
   #[inline(always)]
-  pub unsafe fn new<'s>(
+  #[allow(clippy::not_unsafe_ptr_arg_deref)]
+  pub fn new<'s>(
     scope: &mut HandleScope<'s, ()>,
     value: *mut c_void,
   ) -> Local<'s, Self> {


### PR DESCRIPTION
I tested `lint` in local computer(windows 11), but it was not passed test case in my repo...
TBH, I am not sure I can update the toolchain to `rust 1.66.0`.