### PR TITLE
ci: update python, python setup, cache, and rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,12 @@ jobs:
         uses: hecrj/setup-rust-action@v1
         with:
           components: clippy, rustfmt
-          rust-version: 1.60.0
+          rust-version: 1.66.1
 
       - name: Install python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.10.x
+          python-version: 3.11.x
           architecture: x64
 
       - name: Install cross compilation toolchain
@@ -103,7 +103,7 @@ jobs:
         run: git submodule status --recursive > git_submodule_status.txt
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # Note: rusty_v8 targets always get get rebuilt, and their outputs
           # ('librusty_v8.rlib', the whole 'gn_out' directory, etc.) can be


### PR DESCRIPTION
Updates python to 3.11.x, python setup to v3, cache to v3, and rust to version 1.66.1