### PR TITLE
Don't run GC on isolate disposal

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -954,10 +954,6 @@ impl FinalizerMap {
     id
   }
 
-  pub(crate) fn is_empty(&self) -> bool {
-    self.map.is_empty()
-  }
-
   pub(crate) fn drain(
     &mut self,
   ) -> impl Iterator<Item = FinalizerCallback> + '_ {

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -1182,15 +1182,6 @@ impl Isolate {
     // Drop the scope stack.
     ScopeData::drop_root(self);
 
-    // If there are finalizers left to call, we trigger GC to try and call as
-    // many of them as possible.
-    if !self.get_annex().finalizer_map.is_empty() {
-      // A low memory notification triggers a synchronous GC, which means
-      // finalizers will be called during the course of the call, rather than at
-      // some later point.
-      self.low_memory_notification();
-    }
-
     // Set the `isolate` pointer inside the annex struct to null, so any
     // IsolateHandle that outlives the isolate will know that it can't call
     // methods on the isolate.

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -7944,37 +7944,6 @@ fn drop_weak_from_raw_in_finalizer() {
 }
 
 #[test]
-fn finalizer_on_global_object() {
-  use std::cell::Cell;
-  use std::rc::Rc;
-
-  let _setup_guard = setup::parallel_test();
-
-  let weak;
-  let finalized = Rc::new(Cell::new(false));
-
-  {
-    let isolate = &mut v8::Isolate::new(Default::default());
-    let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
-    let scope = &mut v8::ContextScope::new(scope, context);
-
-    let global_object = context.global(scope);
-    weak = v8::Weak::with_finalizer(
-      scope,
-      global_object,
-      Box::new({
-        let finalized = finalized.clone();
-        move |_| finalized.set(true)
-      }),
-    );
-  }
-
-  assert!(finalized.get());
-  drop(weak);
-}
-
-#[test]
 fn finalizer_on_kept_global() {
   // If a global is kept alive after an isolate is dropped, regular finalizers
   // won't be called, but guaranteed ones will.


### PR DESCRIPTION
This commit removes triggering "low memory notification" during isolate
disposal. We were getting segfaults in Deno due to this notification. The root cause
of the segfault is still unknown and reproducing the segfault is not easy - I wasn't
able to reproduce it once on Apple M1, I was able to reproduce it on Windows by
running a test suite in a loop for a few minutes.

Removing this garbage collection trigger removes the guarantee that
"regular" `FinalizerCallback`s will be called before the isolate goes away.
It is fine as both spec and V8 do not provide this guarantee and we were
overly strict in this case.

CC @andreubotella 
