### PR TITLE
feat: Add bindings for continuation embedder data

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1726,6 +1726,18 @@ const v8::Context* v8__Context__FromSnapshot(v8::Isolate* isolate,
   return maybe_local_to_ptr(maybe_local);
 }
 
+void v8__Context__SetContinuationPreservedEmbedderData(v8::Context& context,
+                                                       const v8::Value* data) {
+  auto c = ptr_to_local(&context);
+  c->SetContinuationPreservedEmbedderData(ptr_to_local(data));
+}
+
+const v8::Value* v8__Context__GetContinuationPreservedEmbedderData(
+    const v8::Context& context) {
+  auto value = ptr_to_local(&context)->GetContinuationPreservedEmbedderData();
+  return local_to_ptr(value);
+}
+
 const v8::String* v8__Message__Get(const v8::Message& self) {
   return local_to_ptr(self.Get());
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -48,13 +48,6 @@ extern "C" {
     isolate: *mut Isolate,
     context_snapshot_index: usize,
   ) -> *const Context;
-  fn v8__Context__SetContinuationPreservedEmbedderData(
-    this: *const Context,
-    value: *const Value,
-  );
-  fn v8__Context__GetContinuationPreservedEmbedderData(
-    this: *const Context,
-  ) -> *const Value;
 }
 
 impl Context {
@@ -352,29 +345,6 @@ impl Context {
       scope.cast_local(|sd| {
         v8__Context__FromSnapshot(sd.get_isolate_mut(), context_snapshot_index)
       })
-    }
-  }
-
-  pub fn set_continuation_preserved_embedder_data<'s>(
-    &self,
-    _scope: &mut HandleScope<'s, ()>,
-    data: Local<Value>,
-  ) {
-    unsafe {
-      v8__Context__SetContinuationPreservedEmbedderData(self, &*data);
-    }
-  }
-
-  pub fn get_continuation_preserved_embedder_data<'s>(
-    &self,
-    scope: &mut HandleScope<'s, ()>,
-  ) -> Local<'s, Value> {
-    unsafe {
-      scope
-        .cast_local(|_sd| {
-          v8__Context__GetContinuationPreservedEmbedderData(self)
-        })
-        .unwrap()
     }
   }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -355,7 +355,11 @@ impl Context {
     }
   }
 
-  pub fn set_continuation_preserved_embedder_data(&self, data: Local<Value>) {
+  pub fn set_continuation_preserved_embedder_data<'s>(
+    &self,
+    _scope: &mut HandleScope<'s, ()>,
+    data: Local<Value>,
+  ) {
     unsafe {
       v8__Context__SetContinuationPreservedEmbedderData(self, &*data);
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -48,6 +48,13 @@ extern "C" {
     isolate: *mut Isolate,
     context_snapshot_index: usize,
   ) -> *const Context;
+  fn v8__Context__SetContinuationPreservedEmbedderData(
+    this: *const Context,
+    value: *const Value,
+  );
+  fn v8__Context__GetContinuationPreservedEmbedderData(
+    this: *const Context,
+  ) -> *const Value;
 }
 
 impl Context {
@@ -345,6 +352,25 @@ impl Context {
       scope.cast_local(|sd| {
         v8__Context__FromSnapshot(sd.get_isolate_mut(), context_snapshot_index)
       })
+    }
+  }
+
+  pub fn set_continuation_preserved_embedder_data(&self, data: Local<Value>) {
+    unsafe {
+      v8__Context__SetContinuationPreservedEmbedderData(self, &*data);
+    }
+  }
+
+  pub fn get_continuation_preserved_embedder_data<'s>(
+    &self,
+    scope: &mut HandleScope<'s, ()>,
+  ) -> Local<'s, Value> {
+    unsafe {
+      scope
+        .cast_local(|_sd| {
+          v8__Context__GetContinuationPreservedEmbedderData(self)
+        })
+        .unwrap()
     }
   }
 }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -293,14 +293,11 @@ impl<'s> HandleScope<'s> {
     data: Local<Value>,
   ) {
     unsafe {
-      let _ = self
-        .cast_local(|sd| {
-          raw::v8__Context__SetContinuationPreservedEmbedderData(
-            sd.get_current_context(),
-            &*data,
-          );
-          std::ptr::null::<()>()
-        });
+      let mut sd = data::ScopeData::get_mut(self);
+      raw::v8__Context__SetContinuationPreservedEmbedderData(
+        sd.get_current_context(),
+        &*data,
+      );
     }
   }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -293,7 +293,7 @@ impl<'s> HandleScope<'s> {
     data: Local<Value>,
   ) {
     unsafe {
-      let mut sd = data::ScopeData::get_mut(self);
+      let sd = data::ScopeData::get_mut(self);
       raw::v8__Context__SetContinuationPreservedEmbedderData(
         sd.get_current_context(),
         &*data,

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -293,15 +293,14 @@ impl<'s> HandleScope<'s> {
     data: Local<Value>,
   ) {
     unsafe {
-      self
+      let _ = self
         .cast_local(|sd| {
           raw::v8__Context__SetContinuationPreservedEmbedderData(
             sd.get_current_context(),
             &*data,
           );
           std::ptr::null::<()>()
-        })
-        .unwrap();
+        });
     }
   }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -286,6 +286,39 @@ impl<'s> HandleScope<'s> {
         .and_then(|data| data.try_into())
     }
   }
+
+  #[inline(always)]
+  pub fn set_continuation_preserved_embedder_data(
+    &mut self,
+    data: Local<Value>,
+  ) {
+    unsafe {
+      self
+        .cast_local(|sd| {
+          raw::v8__Context__SetContinuationPreservedEmbedderData(
+            sd.get_current_context(),
+            &*data,
+          );
+          std::ptr::null::<()>()
+        })
+        .unwrap();
+    }
+  }
+
+  #[inline(always)]
+  pub fn get_continuation_preserved_embedder_data(
+    &mut self,
+  ) -> Local<'s, Value> {
+    unsafe {
+      self
+        .cast_local(|sd| {
+          raw::v8__Context__GetContinuationPreservedEmbedderData(
+            sd.get_current_context(),
+          )
+        })
+        .unwrap()
+    }
+  }
 }
 
 /// A HandleScope which first allocates a handle in the current scope
@@ -1690,6 +1723,13 @@ mod raw {
       this: *const Context,
       index: usize,
     ) -> *const Data;
+    pub(super) fn v8__Context__SetContinuationPreservedEmbedderData(
+      this: *const Context,
+      value: *const Value,
+    );
+    pub(super) fn v8__Context__GetContinuationPreservedEmbedderData(
+      this: *const Context,
+    ) -> *const Value;
 
     pub(super) fn v8__HandleScope__CONSTRUCT(
       buf: *mut MaybeUninit<HandleScope>,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4016,7 +4016,7 @@ fn continuation_preserved_embedder_data() {
     assert!(data.is_undefined());
 
     let value = v8::String::new(scope, "hello").unwrap();
-    context.set_continuation_preserved_embedder_data(value.into());
+    context.set_continuation_preserved_embedder_data(scope, value.into());
     let data = context.get_continuation_preserved_embedder_data(scope);
     assert!(data.is_string());
     assert_eq!(data.to_rust_string_lossy(scope), "hello");

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4012,17 +4012,17 @@ fn continuation_preserved_embedder_data() {
     let scope = &mut v8::HandleScope::new(isolate);
     let context = v8::Context::new(scope);
     let scope = &mut v8::ContextScope::new(scope, context);
-    let data = context.get_continuation_preserved_embedder_data(scope);
+    let data = scope.get_continuation_preserved_embedder_data();
     assert!(data.is_undefined());
 
     let value = v8::String::new(scope, "hello").unwrap();
-    context.set_continuation_preserved_embedder_data(scope, value.into());
-    let data = context.get_continuation_preserved_embedder_data(scope);
+    scope.set_continuation_preserved_embedder_data(value.into());
+    let data = scope.get_continuation_preserved_embedder_data();
     assert!(data.is_string());
     assert_eq!(data.to_rust_string_lossy(scope), "hello");
 
     eval(scope, "b = 2 + 3").unwrap();
-    let data = context.get_continuation_preserved_embedder_data(scope);
+    let data = scope.get_continuation_preserved_embedder_data();
     assert!(data.is_string());
     assert_eq!(data.to_rust_string_lossy(scope), "hello");
   }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4005,6 +4005,30 @@ fn array_buffer_view() {
 }
 
 #[test]
+fn continuation_preserved_embedder_data() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  {
+    let scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(scope);
+    let scope = &mut v8::ContextScope::new(scope, context);
+    let data = context.get_continuation_preserved_embedder_data(scope);
+    assert!(data.is_undefined());
+
+    let value = v8::String::new(scope, "hello").unwrap();
+    context.set_continuation_preserved_embedder_data(value.into());
+    let data = context.get_continuation_preserved_embedder_data(scope);
+    assert!(data.is_string());
+    assert_eq!(data.to_rust_string_lossy(scope), "hello");
+
+    eval(scope, "b = 2 + 3").unwrap();
+    let data = context.get_continuation_preserved_embedder_data(scope);
+    assert!(data.is_string());
+    assert_eq!(data.to_rust_string_lossy(scope), "hello");
+  }
+}
+
+#[test]
 fn snapshot_creator() {
   let _setup_guard = setup::sequential_test();
   // First we create the snapshot, there is a single global variable 'a' set to


### PR DESCRIPTION
Adds bindings for:
- `v8::Context::GetContinuationPreservedEmbedderData`
- `v8::Context::SetContinuationPreservedEmbedderData`

These APIs are available on the `HandleScope`.

These are needed for new implementation of `AsyncLocalStorage`.