### PR TITLE
refactor: v8::Context::set_promise_hooks requires scope

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -108,8 +108,9 @@ impl Context {
   }
 
   #[inline(always)]
-  pub fn set_promise_hooks(
+  pub fn set_promise_hooks<'s>(
     &self,
+    _scope: &mut HandleScope<'s, ()>,
     init_hook: Option<Local<Function>>,
     before_hook: Option<Local<Function>>,
     after_hook: Option<Local<Function>>,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3270,6 +3270,7 @@ fn context_promise_hooks() {
     )
     .unwrap();
     context.set_promise_hooks(
+      scope,
       Some(init_hook),
       Some(before_hook),
       Some(after_hook),
@@ -3348,7 +3349,13 @@ fn context_promise_hooks_partial() {
       .unwrap(),
     )
     .unwrap();
-    context.set_promise_hooks(Some(init_hook), Some(before_hook), None, None);
+    context.set_promise_hooks(
+      scope,
+      Some(init_hook),
+      Some(before_hook),
+      None,
+      None,
+    );
 
     let source = r#"
       function expect(expected, actual = promises.size) {


### PR DESCRIPTION
Closes https://github.com/denoland/rusty_v8/issues/1180