### PR TITLE
Add PropertyDescriptor::new_from_value_writable and new_from_value

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3261,6 +3261,17 @@ void v8__PropertyDescriptor__CONSTRUCT(uninit_t<v8::PropertyDescriptor>* buf) {
   construct_in_place<v8::PropertyDescriptor>(buf);
 }
 
+void v8__PropertyDescriptor__CONSTRUCT__Value_Writable(
+    uninit_t<v8::PropertyDescriptor>* buf, v8::Local<v8::Value> value,
+    bool writable) {
+  construct_in_place<v8::PropertyDescriptor>(buf, value, writable);
+}
+
+void v8__PropertyDescriptor__CONSTRUCT__Value(
+    uninit_t<v8::PropertyDescriptor>* buf, v8::Local<v8::Value> value) {
+  construct_in_place<v8::PropertyDescriptor>(buf, value);
+}
+
 void v8__PropertyDescriptor__CONSTRUCT__Get_Set(
     uninit_t<v8::PropertyDescriptor>* buf, v8::Local<v8::Value> get,
     v8::Local<v8::Value> set) {

--- a/src/property_descriptor.rs
+++ b/src/property_descriptor.rs
@@ -6,6 +6,15 @@ use crate::Value;
 
 extern "C" {
   fn v8__PropertyDescriptor__CONSTRUCT(out: *mut PropertyDescriptor);
+  fn v8__PropertyDescriptor__CONSTRUCT__Value(
+    this: *const PropertyDescriptor,
+    value: *const Value,
+  );
+  fn v8__PropertyDescriptor__CONSTRUCT__Value_Writable(
+    this: *const PropertyDescriptor,
+    value: *const Value,
+    writable: bool,
+  );
   fn v8__PropertyDescriptor__CONSTRUCT__Get_Set(
     this: *const PropertyDescriptor,
     get: *const Value,
@@ -43,6 +52,26 @@ impl PropertyDescriptor {
     let mut this = MaybeUninit::<Self>::uninit();
     unsafe {
       v8__PropertyDescriptor__CONSTRUCT(this.as_mut_ptr());
+      this.assume_init()
+    }
+  }
+
+  pub fn new_from_value(value: Local<Value>) -> Self {
+    let mut this = MaybeUninit::<Self>::uninit();
+    unsafe {
+      v8__PropertyDescriptor__CONSTRUCT__Value(this.as_mut_ptr(), &*value);
+      this.assume_init()
+    }
+  }
+
+  pub fn new_from_value_writable(value: Local<Value>, writable: bool) -> Self {
+    let mut this = MaybeUninit::<Self>::uninit();
+    unsafe {
+      v8__PropertyDescriptor__CONSTRUCT__Value_Writable(
+        this.as_mut_ptr(),
+        &*value,
+        writable,
+      );
       this.assume_init()
     }
   }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -9093,4 +9093,30 @@ fn object_define_property() {
     let expected = v8::String::new(scope, "true,false,true").unwrap();
     assert!(expected.strict_equals(actual));
   }
+
+  {
+    let scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(scope);
+    let scope = &mut v8::ContextScope::new(scope, context);
+
+    let mut desc = v8::PropertyDescriptor::new_from_value(
+      v8::Integer::new(scope, 42).into(),
+    );
+    desc.set_configurable(true);
+    desc.set_enumerable(false);
+
+    let name = v8::String::new(scope, "g").unwrap();
+    context
+      .global(scope)
+      .define_property(scope, name.into(), &desc);
+    let source = r#"
+      {
+        const d = Object.getOwnPropertyDescriptor(globalThis, "g");
+        [d.configurable, d.enumerable, d.writable].toString()
+      }
+    "#;
+    let actual = eval(scope, source).unwrap();
+    let expected = v8::String::new(scope, "true,false,false").unwrap();
+    assert!(expected.strict_equals(actual));
+  }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -9066,4 +9066,31 @@ fn object_define_property() {
     let expected = v8::String::new(scope, "true,false,false").unwrap();
     assert!(expected.strict_equals(actual));
   }
+
+  {
+    let scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(scope);
+    let scope = &mut v8::ContextScope::new(scope, context);
+
+    let mut desc = v8::PropertyDescriptor::new_from_value_writable(
+      v8::Integer::new(scope, 42).into(),
+      true,
+    );
+    desc.set_configurable(true);
+    desc.set_enumerable(false);
+
+    let name = v8::String::new(scope, "g").unwrap();
+    context
+      .global(scope)
+      .define_property(scope, name.into(), &desc);
+    let source = r#"
+      {
+        const d = Object.getOwnPropertyDescriptor(globalThis, "g");
+        [d.configurable, d.enumerable, d.writable].toString()
+      }
+    "#;
+    let actual = eval(scope, source).unwrap();
+    let expected = v8::String::new(scope, "true,false,true").unwrap();
+    assert!(expected.strict_equals(actual));
+  }
 }


### PR DESCRIPTION
Adds `PropertyDescriptor::new_from_value_writable` and `PropertyDescriptor::new_from_value` construct methods.

Used in Node-API https://github.com/nodejs/node/blob/main/src/js_native_api_v8.cc#L1228-L1231