### PR TITLE
Add tests for invalid UTF-8 sequences in v8::String::new_from_utf8

### DIFF
--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -326,6 +326,80 @@ fn test_string() {
     );
     assert!(none.is_none());
   }
+  {
+    let scope = &mut v8::HandleScope::new(isolate);
+    let invalid_sequence_identifier = v8::String::new_from_utf8(
+      scope,
+      &[0xa0, 0xa1],
+      v8::NewStringType::Normal,
+    );
+    assert!(invalid_sequence_identifier.is_some());
+    let invalid_sequence_identifier = invalid_sequence_identifier.unwrap();
+    assert_eq!(invalid_sequence_identifier.length(), 2);
+
+    let invalid_3_octet_sequence = v8::String::new_from_utf8(
+      scope,
+      &[0xe2, 0x28, 0xa1],
+      v8::NewStringType::Normal,
+    );
+    assert!(invalid_3_octet_sequence.is_some());
+    let invalid_3_octet_sequence = invalid_3_octet_sequence.unwrap();
+    assert_eq!(invalid_3_octet_sequence.length(), 3);
+
+    let invalid_3_octet_sequence = v8::String::new_from_utf8(
+      scope,
+      &[0xe2, 0x82, 0x28],
+      v8::NewStringType::Normal,
+    );
+    assert!(invalid_3_octet_sequence.is_some());
+    let invalid_3_octet_sequence = invalid_3_octet_sequence.unwrap();
+    assert_eq!(invalid_3_octet_sequence.length(), 2);
+
+    let invalid_4_octet_sequence = v8::String::new_from_utf8(
+      scope,
+      &[0xf0, 0x28, 0x8c, 0xbc],
+      v8::NewStringType::Normal,
+    );
+    assert!(invalid_4_octet_sequence.is_some());
+    let invalid_4_octet_sequence = invalid_4_octet_sequence.unwrap();
+    assert_eq!(invalid_4_octet_sequence.length(), 4);
+
+    let invalid_4_octet_sequence = v8::String::new_from_utf8(
+      scope,
+      &[0xf0, 0x90, 0x28, 0xbc],
+      v8::NewStringType::Normal,
+    );
+    assert!(invalid_4_octet_sequence.is_some());
+    let invalid_4_octet_sequence = invalid_4_octet_sequence.unwrap();
+    assert_eq!(invalid_4_octet_sequence.length(), 3);
+
+    let invalid_4_octet_sequence = v8::String::new_from_utf8(
+      scope,
+      &[0xf0, 0x28, 0x8c, 0x28],
+      v8::NewStringType::Normal,
+    );
+    assert!(invalid_4_octet_sequence.is_some());
+    let invalid_4_octet_sequence = invalid_4_octet_sequence.unwrap();
+    assert_eq!(invalid_4_octet_sequence.length(), 4);
+
+    let valid_5_octet_sequence = v8::String::new_from_utf8(
+      scope,
+      &[0xf8, 0xa1, 0xa1, 0xa1, 0xa1],
+      v8::NewStringType::Normal,
+    );
+    assert!(valid_5_octet_sequence.is_some());
+    let invalid_4_octet_sequence = valid_5_octet_sequence.unwrap();
+    assert_eq!(invalid_4_octet_sequence.length(), 5);
+
+    let valid_6_octet_sequence = v8::String::new_from_utf8(
+      scope,
+      &[0xfc, 0xa1, 0xa1, 0xa1, 0xa1, 0xa1],
+      v8::NewStringType::Normal,
+    );
+    assert!(valid_6_octet_sequence.is_some());
+    let invalid_4_octet_sequence = valid_6_octet_sequence.unwrap();
+    assert_eq!(invalid_4_octet_sequence.length(), 6);
+  }
 }
 
 #[test]


### PR DESCRIPTION
Preparing to remove my added check for UTF-8 correctness in Deno FFI's `getCString` binding.

It seems that the `new_from_utf8` API is indeed resilient against invalid UTF-8 sequences. The lengths asserted in these tests correspond to the expectations that I get from doing `new TextDecoder().decode(Uint8Array.from([...])).length` in Chrome DevTools and in Deno CLI REPL.

Test sequences are copied over from Stack Overflow: https://stackoverflow.com/a/3886015