### PR TITLE
Use dsherret/rust-toolchain-file@v1 for release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,8 @@ jobs:
         with:
           token: ${{ secrets.DENOBOT_PAT }}
 
-      - name: Install rust
-        uses: hecrj/setup-rust-action@v1
-        with:
-          components: clippy, rustfmt
-          rust-version: 1.66.1
+      - uses: denoland/setup-deno@v1
+      - uses: dsherret/rust-toolchain-file@v1
 
       - name: Tag and release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,11 @@ jobs:
         with:
           token: ${{ secrets.DENOBOT_PAT }}
 
-      - uses: denoland/setup-deno@v1
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          components: clippy, rustfmt
+          rust-version: 1.66.1
 
       - name: Tag and release
         env:


### PR DESCRIPTION
`dtolnay/rust-toolchain@stable` is broken, see https://github.com/dtolnay/rust-toolchain/issues/77