### PR TITLE
build: add PYTHON envvar to specify your python binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ cargo build
 Use `V8_FROM_SOURCE=1 cargo build -vv` to build the crate completely from
 source.
 
-The build scripts require Python 3 to be available as `python` in your `PATH`.
+The build scripts require Python 3 to be available as `python3` in your `PATH`.
+If you want to specify the exact binary of Python to use, you should use the
+`PYTHON` environment variable.
 
 The build also requires `curl` to be installed on your system.
 
@@ -108,6 +110,10 @@ install them.
 
 For Windows builds: the 64-bit toolchain needs to be used. 32-bit targets are
 not supported.
+
+For Mac builds: You'll need Xcode and Xcode CLT installed. Recent macOS versions
+will also require you to pass PYTHON=python3 because macOS no longer ships with
+`python` simlinked to Python 3.
 
 The build depends on several binary tools: `gn`, `ninja` and `clang`. The tools
 will automatically be downloaded, if they are not detected in the environment.


### PR DESCRIPTION
macOS no longer ships with `python` symlinked, so let's add
an environment variable so that people can easily build rusty_v8.