### PR TITLE
FastApiOneByteString is not always utf-8

### DIFF
--- a/src/fast_api.rs
+++ b/src/fast_api.rs
@@ -218,13 +218,13 @@ pub struct FastApiOneByteString {
 
 impl FastApiOneByteString {
   #[inline(always)]
-  pub fn as_str(&self) -> &str {
-    // SAFETY: The string is guaranteed to be valid UTF-8.
+  pub fn as_bytes(&self) -> &[u8] {
+    // SAFETY: The data is guaranteed to be valid for the length of the string.
     unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+      std::slice::from_raw_parts(
         self.data,
         self.length as usize,
-      ))
+      )
     }
   }
 }

--- a/src/fast_api.rs
+++ b/src/fast_api.rs
@@ -220,12 +220,7 @@ impl FastApiOneByteString {
   #[inline(always)]
   pub fn as_bytes(&self) -> &[u8] {
     // SAFETY: The data is guaranteed to be valid for the length of the string.
-    unsafe {
-      std::slice::from_raw_parts(
-        self.data,
-        self.length as usize,
-      )
-    }
+    unsafe { std::slice::from_raw_parts(self.data, self.length as usize) }
   }
 }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8915,8 +8915,8 @@ fn test_fast_calls_onebytestring() {
     data: *const fast_api::FastApiOneByteString,
   ) -> u32 {
     unsafe { WHO = "fast" };
-    let data = unsafe { &*data }.as_str();
-    assert_eq!("hello", data);
+    let data = unsafe { &*data }.as_bytes();
+    assert_eq!(b"hello", data);
     data.len() as u32
   }
 


### PR DESCRIPTION
This commit removes the `as_str()` method and adds the `as_bytes` method to access the Latin-1 data. The utf8 assumption is wrong, the application should validate before converting to Rust string.