### PR TITLE
test: Add tests showing incorrect exception behavior in debug build

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -80,7 +80,7 @@ impl Script {
   /// Runs the script returning the resulting value. It will be run in the
   /// context in which it was created (ScriptCompiler::CompileBound or
   /// UnboundScript::BindToCurrentContext()).
-  #[inline(always)]
+  #[inline]
   pub fn run<'s>(
     &self,
     scope: &mut HandleScope<'s>,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -9658,6 +9658,7 @@ fn object_define_property() {
   }
 }
 
+// Regression test for https://github.com/denoland/deno/issues/19021
 #[test]
 fn bubbling_up_exception() {
   let _setup_guard = setup::parallel_test();
@@ -9701,6 +9702,7 @@ try {
   assert!(scope.exception().is_none());
 }
 
+// Regression test for https://github.com/denoland/rusty_v8/issues/1226
 #[test]
 fn exception_thrown_but_continues_execution() {
   let _setup_guard = setup::parallel_test();
@@ -9723,7 +9725,7 @@ fn exception_thrown_but_continues_execution() {
     let recv = scope.get_current_context().global(scope).into();
 
     let retval = func.call(scope, recv, &[]);
-    return retval;
+    retval
   }
 
   fn print_fn(


### PR DESCRIPTION
Reproduces https://github.com/denoland/rusty_v8/issues/1226 and https://github.com/denoland/deno/issues/19021

```
// Fails
$ V8_FROM_SOURCE=1 cargo test exception
// Passes
$ V8_FROM_SOURCE=1 cargo test --release exception
```

We bisected this and this problem first appeared with V8 v11.2 upgrade. After further
bisects we established that https://github.com/v8/v8/commit/1f349da554800d9278cd1472850ca90a1fd7dc1e#diff-de75fc3e7b84373d94e18b4531827e8b749f9bbe05b59707e894e4e0ce2a1535
is the first V8 commit that causes this failure. However after more investigation we can't
find any reason why that particular commit might cause this problem.

It is only reproducible in debug build, but not release build. Current working theory
is that it is a Rust compiler bug as changing the optimization level for this code
makes the bug go away. This commit should be considered a band-aid that works
around the problem, but doesn't fix it completely. We are gonna go with it as it
unblocks un on day-to-day work, but ultimately we should track it down (or wait
for another Rust upgrade which might fix it?).