### PR TITLE
feat: Add v8::CreateParams::has_set_array_buffer_allocator

### DIFF
--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -58,6 +58,13 @@ impl CreateParams {
     self
   }
 
+  /// Check if `array_buffer_allocator` has already been called. Useful to some
+  /// embedders that might want to set an allocator but not overwrite if one
+  /// was already set by a user.
+  pub fn has_set_array_buffer_allocator(&self) -> bool {
+    !self.raw.array_buffer_allocator_shared.is_null()
+  }
+
   /// Specifies an optional nullptr-terminated array of raw addresses in the
   /// embedder that V8 can match against during serialization and use for
   /// deserialization. This array and its content must stay valid for the

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -7342,10 +7342,13 @@ fn run_with_rust_allocator() {
   let count = Arc::new(AtomicUsize::new(0));
 
   let _setup_guard = setup::parallel_test();
+  let create_params = v8::CreateParams::default();
+  assert!(!create_params.has_set_array_buffer_allocator());
   let create_params =
-    v8::CreateParams::default().array_buffer_allocator(unsafe {
+    create_params.array_buffer_allocator(unsafe {
       v8::new_rust_allocator(Arc::into_raw(count.clone()), vtable)
     });
+  assert!(create_params.has_set_array_buffer_allocator());
   let isolate = &mut v8::Isolate::new(create_params);
 
   {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -7344,10 +7344,9 @@ fn run_with_rust_allocator() {
   let _setup_guard = setup::parallel_test();
   let create_params = v8::CreateParams::default();
   assert!(!create_params.has_set_array_buffer_allocator());
-  let create_params =
-    create_params.array_buffer_allocator(unsafe {
-      v8::new_rust_allocator(Arc::into_raw(count.clone()), vtable)
-    });
+  let create_params = create_params.array_buffer_allocator(unsafe {
+    v8::new_rust_allocator(Arc::into_raw(count.clone()), vtable)
+  });
   assert!(create_params.has_set_array_buffer_allocator());
   let isolate = &mut v8::Isolate::new(create_params);
 


### PR DESCRIPTION
Needed for `deno_core` so that if we want to use jemalloc we can do so
conditionally only if `deno_core` embedder hasn't set an allocator already.