### PR TITLE
feat(fastcall): Int64Representation

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1979,9 +1979,10 @@ v8::CTypeInfo* v8__CTypeInfo__New__From__Slice(unsigned int len,
 
 v8::CFunctionInfo* v8__CFunctionInfo__New(const v8::CTypeInfo& return_info,
                                           unsigned int args_len,
-                                          v8::CTypeInfo* args_info) {
+                                          v8::CTypeInfo* args_info,
+                                          Int64Representation repr) {
   std::unique_ptr<v8::CFunctionInfo> info = std::make_unique<v8::CFunctionInfo>(
-      v8::CFunctionInfo(return_info, args_len, args_info));
+      v8::CFunctionInfo(return_info, args_len, args_info, repr));
   return info.release();
 }
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1980,7 +1980,7 @@ v8::CTypeInfo* v8__CTypeInfo__New__From__Slice(unsigned int len,
 v8::CFunctionInfo* v8__CFunctionInfo__New(const v8::CTypeInfo& return_info,
                                           unsigned int args_len,
                                           v8::CTypeInfo* args_info,
-                                          Int64Representation repr) {
+                                          v8::CFunctionInfo::Int64Representation repr) {
   std::unique_ptr<v8::CFunctionInfo> info = std::make_unique<v8::CFunctionInfo>(
       v8::CFunctionInfo(return_info, args_len, args_info, repr));
   return info.release();

--- a/src/fast_api.rs
+++ b/src/fast_api.rs
@@ -253,8 +253,9 @@ impl<T: Default> FastApiTypedArray<T> {
 
 pub struct FastFunction {
   pub args: &'static [Type],
-  pub return_type: CType,
   pub function: *const c_void,
+  pub repr: Int64Representation,
+  pub return_type: CType,
 }
 
 impl FastFunction {
@@ -266,12 +267,27 @@ impl FastFunction {
   ) -> Self {
     Self {
       args,
-      return_type,
       function,
+      repr: Int64Representation::Number,
+      return_type,
+    }
+  }
+
+  pub const fn new_with_bigint(
+    args: &'static [Type],
+    return_type: CType,
+    function: *const c_void,
+  ) -> Self {
+    Self {
+      args,
+      function,
+      repr: Int64Representation::BigInt,
+      return_type,
     }
   }
 }
 
+#[derive(Copy, Clone, Debug)]
 #[repr(u8)]
 pub enum Int64Representation {
   Number = 0,

--- a/src/fast_api.rs
+++ b/src/fast_api.rs
@@ -17,6 +17,7 @@ extern "C" {
     return_info: *const CTypeInfo,
     args_len: usize,
     args_info: *const CTypeInfo,
+    repr: Int64Representation,
   ) -> *mut CFunctionInfo;
 }
 
@@ -34,8 +35,14 @@ impl CFunctionInfo {
     args: *const CTypeInfo,
     args_len: usize,
     return_type: *const CTypeInfo,
+    repr: Int64Representation,
   ) -> NonNull<CFunctionInfo> {
-    NonNull::new_unchecked(v8__CFunctionInfo__New(return_type, args_len, args))
+    NonNull::new_unchecked(v8__CFunctionInfo__New(
+      return_type,
+      args_len,
+      args,
+      repr,
+    ))
   }
 }
 
@@ -263,4 +270,10 @@ impl FastFunction {
       function,
     }
   }
+}
+
+#[repr(u8)]
+pub enum Int64Representation {
+  Number = 0,
+  BigInt = 1,
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -6,6 +6,7 @@ use crate::data::Template;
 use crate::fast_api::CFunctionInfo;
 use crate::fast_api::CTypeInfo;
 use crate::fast_api::FastFunction;
+use crate::fast_api::Int64Representation;
 use crate::isolate::Isolate;
 use crate::support::int;
 use crate::support::MapFnTo;
@@ -578,7 +579,7 @@ impl<'s> FunctionBuilder<'s, FunctionTemplate> {
       let args = CTypeInfo::new_from_slice(overload1.args);
       let ret = CTypeInfo::new(overload1.return_type);
       let fn_info = unsafe {
-        CFunctionInfo::new(args.as_ptr(), overload1.args.len(), ret.as_ptr())
+        CFunctionInfo::new(args.as_ptr(), overload1.args.len(), ret.as_ptr(), Int64Representation::Number)
       };
       fn_info.as_ptr()
     };
@@ -590,7 +591,7 @@ impl<'s> FunctionBuilder<'s, FunctionTemplate> {
         let args = CTypeInfo::new_from_slice(overload2.args);
         let ret = CTypeInfo::new(overload2.return_type);
         let fn_info = unsafe {
-          CFunctionInfo::new(args.as_ptr(), overload2.args.len(), ret.as_ptr())
+          CFunctionInfo::new(args.as_ptr(), overload2.args.len(), ret.as_ptr(), Int64Representation::Number)
         };
         fn_info.as_ptr()
       }

--- a/src/template.rs
+++ b/src/template.rs
@@ -6,7 +6,6 @@ use crate::data::Template;
 use crate::fast_api::CFunctionInfo;
 use crate::fast_api::CTypeInfo;
 use crate::fast_api::FastFunction;
-use crate::fast_api::Int64Representation;
 use crate::isolate::Isolate;
 use crate::support::int;
 use crate::support::MapFnTo;
@@ -579,7 +578,12 @@ impl<'s> FunctionBuilder<'s, FunctionTemplate> {
       let args = CTypeInfo::new_from_slice(overload1.args);
       let ret = CTypeInfo::new(overload1.return_type);
       let fn_info = unsafe {
-        CFunctionInfo::new(args.as_ptr(), overload1.args.len(), ret.as_ptr(), Int64Representation::Number)
+        CFunctionInfo::new(
+          args.as_ptr(),
+          overload1.args.len(),
+          ret.as_ptr(),
+          overload1.repr,
+        )
       };
       fn_info.as_ptr()
     };
@@ -591,7 +595,12 @@ impl<'s> FunctionBuilder<'s, FunctionTemplate> {
         let args = CTypeInfo::new_from_slice(overload2.args);
         let ret = CTypeInfo::new(overload2.return_type);
         let fn_info = unsafe {
-          CFunctionInfo::new(args.as_ptr(), overload2.args.len(), ret.as_ptr(), Int64Representation::Number)
+          CFunctionInfo::new(
+            args.as_ptr(),
+            overload2.args.len(),
+            ret.as_ptr(),
+            overload2.repr,
+          )
         };
         fn_info.as_ptr()
       }


### PR DESCRIPTION
The new V8 supports fast calls returning 64-bit integers. With the default setting of `Int64Representation::kNumber` this just means that return values can be lossy 64-bit integers. Any data loss is, as they say, your problem.

With `Int64Representation::kBigInt` all 64-bit integers both on the parameter and return value side will be handled as BigInts: Calling `fast_call(32234646)` will never enter the fast call path with this representation but instead `fast_call(3234226n)` needs to be used. With this representation, any 64-bit integer return values are of course also returned as BigInts.

Performance measurements performed by a V8 intern gave numbers like this:

Microbenchmark | Operand range | As Number (us) | BigInt Only (us)
-- | -- | -- | --
Call-and-store | Smi (31-bit signed) | 12603.28 | 13188.74
Call-and-store | Safe integer (53-bit) | 15899.5 | 12929.22
Call-and-store | Small bigint (64-bit signed) | 15138.96 | 12953.86
Call-and-mul | Smi (31-bit signed) | 11710.8 | 13918.4
Call-and-mul | Safe integer (53-bit) | 14769.72 | 14115.7
Call-and-mul | Small bigint (64-bit signed) | 14739.52 | 13910.16
Call-and-mul-and-compare | Smi (31-bit signed) | 12045.62 | 13666.82
Call-and-mul-and-compare | Safe integer (53-bit) | 14082.04 | 13799.14
Call-and-mul-and-compare | Small bigint (64-bit signed) | 14005.88 | 13947.42

Effectively: Returning 64-bit integers as numbers is faster when the numbers are in the Smi range (31-bit signed) but even then are not much faster than returning BigInts. BigInts are faster in other cases.