### PR TITLE
feat: Enable creating fully static 'const' ExternalOneByteStringResources

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1013,6 +1013,36 @@ class ExternalStaticOneByteStringResource
   const int _length;
 };
 
+class ExternalConstOneByteStringResource
+    : public v8::String::ExternalOneByteStringResource {
+ public:
+  ExternalConstOneByteStringResource(const char* data, int length)
+      : _data(data), _length(length) {}
+  const char* data() const override { return _data; }
+  size_t length() const override { return _length; }
+  void Dispose() override {}
+
+ private:
+  const char* _data;
+  const int _length;
+};
+
+static_assert(sizeof(ExternalConstOneByteStringResource) == 32,
+              "ExternalConstOneByteStringResource size was not 32");
+static_assert(alignof()(ExternalConstOneByteStringResource) == 8,
+              "ExternalConstOneByteStringResource align was not 8");
+
+void v8__String__CreateExternalOneByteConst(ExternalConstOneByteStringResource* mem,
+                                const char* data, int length) {
+  new(mem) ExternalConstOneByteStringResource(data, length);
+}
+
+const v8::String* v8__String__NewExternalOneByteConst(v8::Isolate* isolate,
+                                                      ExternalConstOneByteStringResource* resource) {
+  return maybe_local_to_ptr(v8::String::NewExternalOneByte(
+      isolate, resource));
+}
+
 const v8::String* v8__String__NewExternalOneByteStatic(v8::Isolate* isolate,
                                                        const char* data,
                                                        int length) {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8464,6 +8464,18 @@ fn external_strings() {
   assert!(!latin1.is_external_twobyte());
   assert!(latin1.is_onebyte());
   assert!(latin1.contains_only_onebyte());
+
+  // one-byte "const" test
+  let const_ref = v8::String::create_external_onebyte_const(b"const static");
+  let const_ref_string =
+    v8::String::new_external_onebyte_const(scope, const_ref).unwrap();
+  assert!(const_ref_string.is_external());
+  assert!(const_ref_string.is_external_onebyte());
+  assert!(!const_ref_string.is_external_twobyte());
+  assert!(const_ref_string.is_onebyte());
+  assert!(const_ref_string.contains_only_onebyte());
+  assert!(const_ref_string
+    .strict_equals(v8::String::new(scope, "const static").unwrap().into()));
 }
 
 #[test]


### PR DESCRIPTION
Working, though somewhat rough around the edges.

Currently `new_external_onebyte_static` allocates onto the heap on each call. There are cases where we'd rather keep a single static resource that is never deallocated and that never disposes of itself. Creating strings from this sort of a static resource is 100% alloc-free. Also since we know all our External resources are always static we could actually extract the data out of those without a copy by calling the virtual `data()` method on the Resource.