### PR TITLE
silence warning for unused 'must use'

### DIFF
--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1089,7 +1089,9 @@ pub(crate) mod data {
     /// This function should be called only when an Isolate is being disposed.
     pub(crate) fn drop_root(isolate: &mut Isolate) {
       let root = Self::get_root_mut(isolate);
-      unsafe { Box::from_raw(root) };
+      unsafe {
+        let _ = Box::from_raw(root);
+      };
       isolate.set_current_scope_data(None);
     }
 


### PR DESCRIPTION
this warning only occurs when using the library as a dependency.

```
warning: unused return value of `Box::<T>::from_raw` that must be used
    --> /rusty_v8/src/scope.rs:1092:16
     |
1092 |       unsafe { Box::from_raw(root) };
     |                ^^^^^^^^^^^^^^^^^^^
     |
   = note: call `drop(Box::from_raw(ptr))` if you intend to drop the `Box`
   = note: `#[warn(unused_must_use)]` on by default
```