### PR TITLE
fix: Use unaligned read as copy_nonoverlapping requires alignment

### DIFF
--- a/src/fast_api.rs
+++ b/src/fast_api.rs
@@ -3,7 +3,7 @@ use crate::Local;
 use crate::Value;
 use std::{
   ffi::c_void,
-  mem::{align_of, MaybeUninit},
+  mem::align_of,
   ptr::{self, NonNull},
 };
 
@@ -236,12 +236,8 @@ impl<T: Default> FastApiTypedArray<T> {
   #[inline(always)]
   pub fn get(&self, index: usize) -> T {
     debug_assert!(index < self.length);
-    let mut t = MaybeUninit::<T>::uninit();
     // SAFETY: src is valid for reads, and is a valid value for T
-    unsafe {
-      t.write(ptr::read_unaligned(self.data.add(index)));
-      t.assume_init()
-    }
+    unsafe { ptr::read_unaligned(self.data.add(index)) }
   }
 
   #[inline(always)]

--- a/src/fast_api.rs
+++ b/src/fast_api.rs
@@ -1,10 +1,9 @@
 use crate::support::Opaque;
 use crate::Local;
 use crate::Value;
-use std::mem::MaybeUninit;
 use std::{
   ffi::c_void,
-  mem::align_of,
+  mem::{align_of, MaybeUninit},
   ptr::{self, NonNull},
 };
 
@@ -238,7 +237,7 @@ impl<T: Default> FastApiTypedArray<T> {
   pub fn get(&self, index: usize) -> T {
     debug_assert!(index < self.length);
     let mut t = MaybeUninit::<T>::uninit();
-    // SAFETY: src is valid for reads, and is value for T
+    // SAFETY: src is valid for reads, and is a valid value for T
     unsafe {
       t.write(ptr::read_unaligned(self.data.add(index)));
       t.assume_init()


### PR DESCRIPTION
`copy_nonoverlapping` is not valid to use here as:

Behavior is undefined if any of the following conditions are violated:

    src must be [valid](https://doc.rust-lang.org/stable/std/ptr/index.html#safety) for reads of count * size_of::<T>() bytes.
    dst must be [valid](https://doc.rust-lang.org/stable/std/ptr/index.html#safety) for writes of count * size_of::<T>() bytes.
    Both src and dst must be properly aligned.

    The region of memory beginning at src with a size of count * size_of::<T>() bytes must not overlap with the region of memory beginning at dst with the same size.