### PR TITLE
Remove a redundant and confusing sentence from FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,10 @@ attempts that carefully balances the requirements of cargo crates and GN/Ninja.
 **V8 has a very large API with hundreds of methods. Why don't you automate the
 generation of this binding code?**
 
-In the limit we would like to auto-generate bindings. We have actually started
-down this route several times, however due to many eccentric features of the V8
-API, this has not proven successful. Therefore we are proceeding in a
-brute-force fashion for now, focusing on solving our stated goals first. We hope
-to auto-generate bindings in the future.
+We have actually started down this route several times, however due to many
+eccentric features of the V8 API, this has not proven successful. Therefore we
+are proceeding in a brute-force fashion for now, focusing on solving our stated
+goals first. We hope to auto-generate bindings in the future.
 
 **Why are you building this?**
 


### PR DESCRIPTION
"In the limit…" should probably read "In the end…" or "In the future…", but the last sentence makes the first redundant, so this PR removes the confusing sentence.