### PR TITLE
chore: turn pointer compression off again

### DIFF
--- a/.gn
+++ b/.gn
@@ -61,4 +61,9 @@ default_args = {
   # makes sure that the EPT is not used.
   # https://bugs.chromium.org/p/v8/issues/detail?id=13640&q=garbage%20collection&can=2
   v8_enable_pointer_compression = false
+
+  # Maglev *should* be supported when pointer compression is disabled as per
+  # https://chromium-review.googlesource.com/c/v8/v8/+/4753150, but it still
+  # fails to compile.
+  v8_enable_maglev = false
 }

--- a/.gn
+++ b/.gn
@@ -55,4 +55,10 @@ default_args = {
   # is enabled. In our case it's disabled so without this flag we can't
   # compile.
   v8_enable_verify_heap = false
+
+  # V8 introduced a bug in 11.1 that causes the External Pointer Table to never
+  # be cleaned which causes resource exhaustion. Disabling pointer compression
+  # makes sure that the EPT is not used.
+  # https://bugs.chromium.org/p/v8/issues/detail?id=13640&q=garbage%20collection&can=2
+  v8_enable_pointer_compression = false
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3060,14 +3060,6 @@ void v8__HeapProfiler__TakeHeapSnapshot(v8::Isolate* isolate,
   const_cast<v8::HeapSnapshot*>(snapshot)->Delete();
 }
 
-// This is necessary for v8__internal__GetIsolateFromHeapObject() to be
-// reliable enough for our purposes.
-#if UINTPTR_MAX == 0xffffffffffffffff && \
-    !(defined V8_SHARED_RO_HEAP or defined V8_COMPRESS_POINTERS)
-#error V8 must be built with either the 'v8_enable_pointer_compression' or \
-'v8_enable_shared_ro_heap' feature enabled.
-#endif
-
 v8::Isolate* v8__internal__GetIsolateFromHeapObject(const v8::Data& data) {
   namespace i = v8::internal;
   i::Object object(reinterpret_cast<const i::Address&>(data));


### PR DESCRIPTION
The memory leak caused by the EPT table not being subject to garbage collection is apparently still there.