### PR TITLE
fix: crash on x86_64 systems that support memory protection keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub use module::*;
 pub use object::*;
 pub use platform::new_default_platform;
 pub use platform::new_single_threaded_default_platform;
+pub use platform::new_unprotected_default_platform;
 pub use platform::Platform;
 pub use primitives::*;
 pub use private::*;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -63,15 +63,15 @@ pub struct Platform(Opaque);
 /// tasks (IdleTasksEnabled will return true) and will rely on the embedder
 /// calling v8::platform::RunIdleTasks to process the idle tasks.
 ///
-/// The default platform for v8 may include restrictions and caveats on thread creation
-/// and initialization. This platform should only be used in cases where v8 can be
-/// reliably initialized on the application's main thread, or the parent thread to all 
-/// threads in the system that will use v8.
+/// The default platform for v8 may include restrictions and caveats on thread
+/// creation and initialization. This platform should only be used in cases
+/// where v8 can be reliably initialized on the application's main thread, or
+/// the parent thread to all threads in the system that will use v8.
 ///
 /// One example of a restriction is the use of Memory Protection Keys (pkeys) on
-/// modern Linux systems using modern Intel/AMD processors. This particular technology
-/// requires that all threads using v8 are created as descendent threads of the thread
-/// that called `v8::Initialize`. 
+/// modern Linux systems using modern Intel/AMD processors. This particular
+/// technology requires that all threads using v8 are created as descendent
+/// threads of the thread that called `v8::Initialize`.
 #[inline(always)]
 pub fn new_default_platform(
   thread_pool_size: u32,
@@ -80,10 +80,10 @@ pub fn new_default_platform(
   Platform::new(thread_pool_size, idle_task_support)
 }
 
-/// Creates a platform that is identical to the default platform, but does not enforce
-/// thread-isolated allocations. This may reduce security in some cases, so this method
-/// should be used with caution in cases where the threading guarantees of
-/// `new_default_platform` cannot be upheld (generally for tests).
+/// Creates a platform that is identical to the default platform, but does not
+/// enforce thread-isolated allocations. This may reduce security in some cases,
+/// so this method should be used with caution in cases where the threading
+/// guarantees of `new_default_platform` cannot be upheld (generally for tests).
 #[inline(always)]
 pub fn new_unprotected_default_platform(
   thread_pool_size: u32,
@@ -115,15 +115,15 @@ impl Platform {
   /// tasks (IdleTasksEnabled will return true) and will rely on the embedder
   /// calling v8::platform::RunIdleTasks to process the idle tasks.
   ///
-  /// The default platform for v8 may include restrictions and caveats on thread creation
-  /// and initialization. This platform should only be used in cases where v8 can be
-  /// reliably initialized on the application's main thread, or the parent thread to all 
-  /// threads in the system that will use v8.
+  /// The default platform for v8 may include restrictions and caveats on thread
+  /// creation and initialization. This platform should only be used in cases
+  /// where v8 can be reliably initialized on the application's main thread, or
+  /// the parent thread to all threads in the system that will use v8.
   ///
-  /// One example of a restriction is the use of Memory Protection Keys (pkeys) on
-  /// modern Linux systems using modern Intel/AMD processors. This particular technology
-  /// requires that all threads using v8 are created as descendent threads of the thread
-  /// that called `v8::Initialize`.
+  /// One example of a restriction is the use of Memory Protection Keys (pkeys)
+  /// on modern Linux systems using modern Intel/AMD processors. This particular
+  /// technology requires that all threads using v8 are created as descendent
+  /// threads of the thread that called `v8::Initialize`.
   #[inline(always)]
   pub fn new(
     thread_pool_size: u32,
@@ -137,10 +137,11 @@ impl Platform {
     }
   }
 
-  /// Creates a platform that is identical to the default platform, but does not enforce
-  /// thread-isolated allocations. This may reduce security in some cases, so this method
-  /// should be used with caution in cases where the threading guarantees of
-  /// `new_default_platform` cannot be upheld (generally for tests).
+  /// Creates a platform that is identical to the default platform, but does not
+  /// enforce thread-isolated allocations. This may reduce security in some
+  /// cases, so this method should be used with caution in cases where the
+  /// threading guarantees of `new_default_platform` cannot be upheld (generally
+  /// for tests).
   #[inline(always)]
   pub fn new_unprotected(
     thread_pool_size: u32,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -63,9 +63,15 @@ pub struct Platform(Opaque);
 /// tasks (IdleTasksEnabled will return true) and will rely on the embedder
 /// calling v8::platform::RunIdleTasks to process the idle tasks.
 ///
-/// TODO: reference the threading restrictions that apply when V8 is initialized
-/// with the default platform, the implications for the Cargo test harness, and
-/// when to use new_unprotected_default_platform().
+/// The default platform for v8 may include restrictions and caveats on thread creation
+/// and initialization. This platform should only be used in cases where v8 can be
+/// reliably initialized on the application's main thread, or the parent thread to all 
+/// threads in the system that will use v8.
+///
+/// One example of a restriction is the use of Memory Protection Keys (pkeys) on
+/// modern Linux systems using modern Intel/AMD processors. This particular technology
+/// requires that all threads using v8 are created as descendent threads of the thread
+/// that called `v8::Initialize`. 
 #[inline(always)]
 pub fn new_default_platform(
   thread_pool_size: u32,
@@ -74,7 +80,10 @@ pub fn new_default_platform(
   Platform::new(thread_pool_size, idle_task_support)
 }
 
-/// TODO: doc comment
+/// Creates a platform that is identical to the default platform, but does not enforce
+/// thread-isolated allocations. This may reduce security in some cases, so this method
+/// should be used with caution in cases where the threading guarantees of
+/// `new_default_platform` cannot be upheld (generally for tests).
 #[inline(always)]
 pub fn new_unprotected_default_platform(
   thread_pool_size: u32,
@@ -106,9 +115,15 @@ impl Platform {
   /// tasks (IdleTasksEnabled will return true) and will rely on the embedder
   /// calling v8::platform::RunIdleTasks to process the idle tasks.
   ///
-  /// TODO: reference the threading restrictions that apply when V8 is
-  /// initialized with the default platform, the implications for the Cargo
-  /// test harness, and when to use new_unprotected().
+  /// The default platform for v8 may include restrictions and caveats on thread creation
+  /// and initialization. This platform should only be used in cases where v8 can be
+  /// reliably initialized on the application's main thread, or the parent thread to all 
+  /// threads in the system that will use v8.
+  ///
+  /// One example of a restriction is the use of Memory Protection Keys (pkeys) on
+  /// modern Linux systems using modern Intel/AMD processors. This particular technology
+  /// requires that all threads using v8 are created as descendent threads of the thread
+  /// that called `v8::Initialize`.
   #[inline(always)]
   pub fn new(
     thread_pool_size: u32,
@@ -122,7 +137,10 @@ impl Platform {
     }
   }
 
-  /// TODO: doc comment
+  /// Creates a platform that is identical to the default platform, but does not enforce
+  /// thread-isolated allocations. This may reduce security in some cases, so this method
+  /// should be used with caution in cases where the threading guarantees of
+  /// `new_default_platform` cannot be upheld (generally for tests).
   #[inline(always)]
   pub fn new_unprotected(
     thread_pool_size: u32,

--- a/tests/slots.rs
+++ b/tests/slots.rs
@@ -15,7 +15,7 @@ fn setup() {
   START.call_once(|| {
     v8::V8::set_flags_from_string("--expose_gc");
     v8::V8::initialize_platform(
-      v8::new_default_platform(0, false).make_shared(),
+      v8::new_unprotected_default_platform(0, false).make_shared(),
     );
     v8::V8::initialize();
   });

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -55,7 +55,7 @@ mod setup {
       "--no_freeze_flags_after_init --expose_gc --harmony-import-assertions --harmony-shadow-realm --allow_natives_syntax --turbo_fast_api_calls",
     );
     v8::V8::initialize_platform(
-      v8::new_default_platform(0, false).make_shared(),
+      v8::new_unprotected_default_platform(0, false).make_shared(),
     );
     v8::V8::initialize();
   });

--- a/tests/test_api_entropy_source.rs
+++ b/tests/test_api_entropy_source.rs
@@ -18,7 +18,9 @@ fn set_entropy_source() {
     true
   });
 
-  v8::V8::initialize_platform(v8::new_default_platform(0, false).make_shared());
+  v8::V8::initialize_platform(
+    v8::new_unprotected_default_platform(0, false).make_shared(),
+  );
   v8::V8::initialize();
 
   // Assumes that every isolate creates a PRNG from scratch, which is currently true.

--- a/tests/test_api_flags.rs
+++ b/tests/test_api_flags.rs
@@ -4,7 +4,9 @@
 #[test]
 fn set_flags_from_string() {
   v8::V8::set_flags_from_string("--use_strict");
-  v8::V8::initialize_platform(v8::new_default_platform(0, false).make_shared());
+  v8::V8::initialize_platform(
+    v8::new_unprotected_default_platform(0, false).make_shared(),
+  );
   v8::V8::initialize();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);

--- a/tests/test_platform_atomics_pump_message_loop.rs
+++ b/tests/test_platform_atomics_pump_message_loop.rs
@@ -3,7 +3,9 @@ fn atomics_pump_message_loop() {
   v8::V8::set_flags_from_string(
     "--allow-natives-syntax --harmony-sharedarraybuffer",
   );
-  v8::V8::initialize_platform(v8::new_default_platform(0, false).make_shared());
+  v8::V8::initialize_platform(
+    v8::new_unprotected_default_platform(0, false).make_shared(),
+  );
   v8::V8::initialize();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);


### PR DESCRIPTION
This fixes the issue.

It needs some comments explaining why one would need `new_unprotected_default_platform()` (see TODOs).
@mmastrac Can you help out with that?