### PR TITLE
feat: Support custom host objects in ValueSerializer

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3178,6 +3178,13 @@ extern "C" {
 void v8__ValueSerializer__Delegate__ThrowDataCloneError(
     v8::ValueSerializer::Delegate* self, v8::Local<v8::String> message);
 
+bool v8__ValueSerializer__Delegate__HasCustomHostObject(
+    v8::ValueSerializer::Delegate* self, v8::Isolate* isolate);
+
+MaybeBool v8__ValueSerializer__Delegate__IsHostObject(
+    v8::ValueSerializer::Delegate* self, v8::Isolate* isolate,
+    v8::Local<v8::Object> object);
+
 MaybeBool v8__ValueSerializer__Delegate__WriteHostObject(
     v8::ValueSerializer::Delegate* self, v8::Isolate* isolate,
     v8::Local<v8::Object> object);
@@ -3201,6 +3208,16 @@ void v8__ValueSerializer__Delegate__FreeBufferMemory(
 struct v8__ValueSerializer__Delegate : public v8::ValueSerializer::Delegate {
   void ThrowDataCloneError(v8::Local<v8::String> message) override {
     v8__ValueSerializer__Delegate__ThrowDataCloneError(this, message);
+  }
+
+  bool HasCustomHostObject(v8::Isolate* isolate) override {
+    return v8__ValueSerializer__Delegate__HasCustomHostObject(this, isolate);
+  }
+
+  v8::Maybe<bool> IsHostObject(v8::Isolate* isolate,
+                                  v8::Local<v8::Object> object) override {
+    return maybe_bool_to_maybe(
+        v8__ValueSerializer__Delegate__IsHostObject(this, isolate, object));
   }
 
   v8::Maybe<bool> WriteHostObject(v8::Isolate* isolate,

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -46,6 +46,34 @@ pub unsafe extern "C" fn v8__ValueSerializer__Delegate__ThrowDataCloneError(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn v8__ValueSerializer__Delegate__HasCustomHostObject(
+  this: &mut CxxValueSerializerDelegate,
+  _isolate: *mut Isolate,
+) -> bool {
+  let value_serializer_heap = ValueSerializerHeap::dispatch_mut(this);
+  let scope =
+    &mut crate::scope::CallbackScope::new(value_serializer_heap.context);
+  value_serializer_heap
+    .value_serializer_impl
+    .as_mut()
+    .has_custom_host_object(scope)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn v8__ValueSerializer__Delegate__IsHostObject(
+  this: &mut CxxValueSerializerDelegate,
+  _isolate: *mut Isolate,
+  object: Local<Object>,
+) -> MaybeBool {
+  let value_serializer_heap = ValueSerializerHeap::dispatch_mut(this);
+  let scope =
+    &mut crate::scope::CallbackScope::new(value_serializer_heap.context);
+  let value_serializer_impl =
+    value_serializer_heap.value_serializer_impl.as_mut();
+  MaybeBool::from(value_serializer_impl.is_host_object(scope, object))
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn v8__ValueSerializer__Delegate__WriteHostObject(
   this: &mut CxxValueSerializerDelegate,
   _isolate: *mut Isolate,
@@ -210,6 +238,23 @@ pub trait ValueSerializerImpl {
     scope: &mut HandleScope<'s>,
     message: Local<'s, String>,
   );
+
+  fn has_custom_host_object(&mut self, _scope: &mut HandleScope) -> bool {
+    false
+  }
+
+  fn is_host_object<'s>(
+    &mut self,
+    scope: &mut HandleScope<'s>,
+    _object: Local<'s, Object>,
+  ) -> Option<bool> {
+    let msg =
+      String::new(scope, "Deno serializer: is_host_object not implemented")
+        .unwrap();
+    let exc = Exception::error(scope, msg);
+    scope.throw_exception(exc);
+    None
+  }
 
   fn write_host_object<'s>(
     &mut self,

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -48,15 +48,13 @@ pub unsafe extern "C" fn v8__ValueSerializer__Delegate__ThrowDataCloneError(
 #[no_mangle]
 pub unsafe extern "C" fn v8__ValueSerializer__Delegate__HasCustomHostObject(
   this: &mut CxxValueSerializerDelegate,
-  _isolate: *mut Isolate,
+  isolate: *mut Isolate,
 ) -> bool {
   let value_serializer_heap = ValueSerializerHeap::dispatch_mut(this);
-  let scope =
-    &mut crate::scope::CallbackScope::new(value_serializer_heap.context);
   value_serializer_heap
     .value_serializer_impl
     .as_mut()
-    .has_custom_host_object(scope)
+    .has_custom_host_object(&mut *isolate)
 }
 
 #[no_mangle]
@@ -239,7 +237,7 @@ pub trait ValueSerializerImpl {
     message: Local<'s, String>,
   );
 
-  fn has_custom_host_object(&mut self, _scope: &mut HandleScope) -> bool {
+  fn has_custom_host_object(&mut self, _isolate: &mut Isolate) -> bool {
     false
   }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -7945,7 +7945,7 @@ impl v8::ValueSerializerImpl for Custom3Value {
     scope.throw_exception(error);
   }
 
-  fn has_custom_host_object(&mut self, _scope: &mut v8::HandleScope) -> bool {
+  fn has_custom_host_object(&mut self, _isolate: &mut v8::Isolate) -> bool {
     true
   }
 


### PR DESCRIPTION
Add v8::ValueSerializerImpl::{has_custom_host_object,is_host_object} equivalents for v8::ValueSerializer::Delegate::{HasCustomHostObject,IsCustomHostObject}.

This enables serializing custom host objects without embedder fields.

* V8 commit: v8/v8@cf13b9b46572a9824d2d632abdd48c56161ace02
* V8 bug: https://bugs.chromium.org/p/v8/issues/detail?id=11927
* Deno bug: denoland/deno#12067