### PR TITLE
feat: new_backing_store_from_bytes and empty for ArrayBuffer and SharedArrayBuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
 name = "calloop"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1321,7 @@ version = "0.78.0"
 dependencies = [
  "align-data",
  "bitflags 1.3.2",
+ "bytes",
  "fslock",
  "once_cell",
  "trybuild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ fslock = "0.1.8"
 which = "4.2.5"
 
 [dev-dependencies]
+bytes = "1"
 align-data = "0.1.0"
 fslock = "0.1.8"
 trybuild = "1.0.61"

--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -61,9 +61,7 @@ extern "C" {
     deleter: BackingStoreDeleterCallback,
     deleter_data: *mut c_void,
   ) -> *mut BackingStore;
-  fn v8__BackingStore__EmptyBackingStore(
-    shared: bool,
-  ) -> *mut BackingStore;
+  fn v8__BackingStore__EmptyBackingStore(shared: bool) -> *mut BackingStore;
 
   fn v8__BackingStore__Data(this: *const BackingStore) -> *mut c_void;
   fn v8__BackingStore__ByteLength(this: *const BackingStore) -> usize;
@@ -404,7 +402,9 @@ impl ArrayBuffer {
   #[inline(always)]
   pub fn empty<'s>(scope: &mut HandleScope<'s>) -> Local<'s, ArrayBuffer> {
     // SAFETY: This is a v8-provided empty backing store
-    let backing_store = unsafe { UniqueRef::from_raw(v8__BackingStore__EmptyBackingStore(false)) };
+    let backing_store = unsafe {
+      UniqueRef::from_raw(v8__BackingStore__EmptyBackingStore(false))
+    };
     Self::with_backing_store(scope, &backing_store.make_shared())
   }
 
@@ -542,7 +542,10 @@ impl ArrayBuffer {
   /// to a mutable slice of bytes. The object is dereferenced once, and the resulting slice's
   /// memory is used for the lifetime of the buffer.
   #[inline(always)]
-  pub fn new_backing_store_from_bytes<T>(bytes: T) -> UniqueRef<BackingStore> where T: DerefMut<Target = [u8]>{
+  pub fn new_backing_store_from_bytes<T>(bytes: T) -> UniqueRef<BackingStore>
+  where
+    T: DerefMut<Target = [u8]>,
+  {
     // First we move the object into a box so it is pinned in place
     let alloc = Box::new(bytes);
     Self::new_backing_store_from_boxed_bytes(alloc)
@@ -552,7 +555,12 @@ impl ArrayBuffer {
   /// to a mutable slice of bytes. The object is dereferenced once, and the resulting slice's
   /// memory is used for the lifetime of the buffer.
   #[inline(always)]
-  pub fn new_backing_store_from_boxed_bytes<T>(mut bytes: Box<T>) -> UniqueRef<BackingStore> where T: DerefMut<Target = [u8]>{
+  pub fn new_backing_store_from_boxed_bytes<T>(
+    mut bytes: Box<T>,
+  ) -> UniqueRef<BackingStore>
+  where
+    T: DerefMut<Target = [u8]>,
+  {
     // We need to be very careful here not to move the data out of the box as that may
     // invalidate the slice's pointer. You can imagine a SmallVec that provides a pointer to
     // a slice inside of itself -- moving that SmallVec would invalidate the slice!
@@ -560,18 +568,20 @@ impl ArrayBuffer {
     let len = slice.len();
     let slice = slice.as_mut_ptr();
     let ptr = Box::into_raw(bytes) as *const c_void;
-  
-    extern "C" fn drop_box<T>(_ptr: *mut c_void, _len: usize, data: *mut c_void) {
+
+    extern "C" fn drop_box<T>(
+      _ptr: *mut c_void,
+      _len: usize,
+      data: *mut c_void,
+    ) {
       // SAFETY: We know that data is a raw Box from above
       unsafe { drop(Box::<T>::from_raw(data as _)) }
     }
-  
+
     // SAFETY: We are extending the lifetime of a slice, but we're locking away the box that we
     // derefed from so there's no way to get another mutable reference.
     unsafe {
-      Self::new_backing_store_from_ptr(
-        slice as _, len, drop_box::<T>, ptr as _,
-      )
+      Self::new_backing_store_from_ptr(slice as _, len, drop_box::<T>, ptr as _)
     }
   }
 

--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -539,8 +539,8 @@ impl ArrayBuffer {
   }
 
   /// Returns a new standalone BackingStore backed by an object that dereferences
-  /// to a mutable slice of bytes. You must ensure that the bytes object will deref to
-  /// the same mutable slice for its entire lifetime.
+  /// to a mutable slice of bytes. The object is dereferenced once, and the resulting slice's
+  /// memory is used for the lifetime of the buffer.
   #[inline(always)]
   pub fn new_backing_store_from_bytes<T>(bytes: T) -> UniqueRef<BackingStore> where T: DerefMut<Target = [u8]>{
     // First we move the object into a box so it is pinned in place
@@ -549,8 +549,8 @@ impl ArrayBuffer {
   }
 
   /// Returns a new standalone BackingStore backed by an object that dereferences
-  /// to a mutable slice of bytes. You must ensure that the bytes object will deref to
-  /// the same mutable slice for its entire lifetime.
+  /// to a mutable slice of bytes. The object is dereferenced once, and the resulting slice's
+  /// memory is used for the lifetime of the buffer.
   #[inline(always)]
   pub fn new_backing_store_from_boxed_bytes<T>(mut bytes: Box<T>) -> UniqueRef<BackingStore> where T: DerefMut<Target = [u8]>{
     // We need to be very careful here not to move the data out of the box as that may

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -866,6 +866,12 @@ two_pointers_t v8__ArrayBuffer__GetBackingStore(const v8::ArrayBuffer& self) {
   return make_pod<two_pointers_t>(ptr_to_local(&self)->GetBackingStore());
 }
 
+v8::BackingStore* v8__BackingStore__EmptyBackingStore(bool shared) {
+  std::unique_ptr<i::BackingStoreBase> u = 
+      i::BackingStore::EmptyBackingStore(shared ? i::SharedFlag::kShared : i::SharedFlag::kNotShared);
+  return static_cast<v8::BackingStore*>(u.release());
+}
+
 bool v8__BackingStore__IsResizableByUserJavaScript(
     const v8::BackingStore& self) {
   return ptr_to_local(&self)->IsResizableByUserJavaScript();

--- a/src/shared_array_buffer.rs
+++ b/src/shared_array_buffer.rs
@@ -173,8 +173,8 @@ impl SharedArrayBuffer {
   }
 
   /// Returns a new standalone shared BackingStore backed by an object that dereferences
-  /// to a mutable slice of bytes. You must ensure that the bytes object will deref to
-  /// the same mutable slice for its entire lifetime.
+  /// to a mutable slice of bytes. The object is dereferenced once, and the resulting slice's
+  /// memory is used for the lifetime of the buffer.
   ///
   /// As this buffer may be shared, the underlying object must be [`Send`] + [`Sync`].
   #[inline(always)]
@@ -185,8 +185,8 @@ impl SharedArrayBuffer {
   }
 
   /// Returns a new standalone shared BackingStore backed by an object that dereferences
-  /// to a mutable slice of bytes. You must ensure that the bytes object will deref to
-  /// the same mutable slice for its entire lifetime.
+  /// to a mutable slice of bytes. The object is dereferenced once, and the resulting slice's
+  /// memory is used for the lifetime of the buffer.
   /// 
   /// As this buffer may be shared, the underlying object must be [`Send`] + [`Sync`].
   #[inline(always)]

--- a/src/shared_array_buffer.rs
+++ b/src/shared_array_buffer.rs
@@ -1,11 +1,7 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
 
 use std::ffi::c_void;
-use std::ops::DerefMut;
-use std::ptr::null_mut;
 
-use crate::array_buffer::boxed_slice_deleter_callback;
-use crate::array_buffer::vec_deleter_callback;
 use crate::support::SharedRef;
 use crate::support::UniqueRef;
 use crate::BackingStore;
@@ -137,16 +133,7 @@ impl SharedArrayBuffer {
   pub fn new_backing_store_from_boxed_slice(
     data: Box<[u8]>,
   ) -> UniqueRef<BackingStore> {
-    let byte_length = data.len();
-    let data_ptr = Box::into_raw(data) as *mut c_void;
-    unsafe {
-      UniqueRef::from_raw(v8__SharedArrayBuffer__NewBackingStore__with_data(
-        data_ptr,
-        byte_length,
-        boxed_slice_deleter_callback,
-        null_mut(),
-      ))
-    }
+    Self::new_backing_store_from_bytes(data)
   }
 
   /// Returns a new standalone BackingStore that takes over the ownership of
@@ -157,70 +144,64 @@ impl SharedArrayBuffer {
   /// The result can be later passed to SharedArrayBuffer::New. The raw pointer
   /// to the buffer must not be passed again to any V8 API function.
   #[inline(always)]
-  pub fn new_backing_store_from_vec(
-    mut data: Vec<u8>,
-  ) -> UniqueRef<BackingStore> {
-    let byte_length = data.len();
-    let data_ptr = data.as_mut_ptr() as *mut c_void;
-    std::mem::forget(data);
-    unsafe {
-      UniqueRef::from_raw(v8__SharedArrayBuffer__NewBackingStore__with_data(
-        data_ptr,
-        byte_length,
-        vec_deleter_callback,
-        null_mut(),
-      ))
-    }
+  pub fn new_backing_store_from_vec(data: Vec<u8>) -> UniqueRef<BackingStore> {
+    Self::new_backing_store_from_bytes(data)
   }
 
-  /// Returns a new standalone shared BackingStore backed by an object that dereferences
+  /// Returns a new standalone BackingStore backed by a container that dereferences
   /// to a mutable slice of bytes. The object is dereferenced once, and the resulting slice's
   /// memory is used for the lifetime of the buffer.
   ///
-  /// As this buffer may be shared, the underlying object must be [`Send`] + [`Sync`].
-  #[inline(always)]
-  pub fn new_backing_store_from_bytes<T>(bytes: T) -> UniqueRef<BackingStore>
-  where
-    T: DerefMut<Target = [u8]> + Send + Sync,
-  {
-    // First we move the object into a box so it is pinned in place
-    let alloc = Box::new(bytes);
-    Self::new_backing_store_from_boxed_bytes(alloc)
-  }
-
-  /// Returns a new standalone shared BackingStore backed by an object that dereferences
-  /// to a mutable slice of bytes. The object is dereferenced once, and the resulting slice's
-  /// memory is used for the lifetime of the buffer.
+  /// This method may be called with most single-ownership containers that implement `AsMut<[u8]>`, including
+  /// `Box<[u8]>`, and `Vec<u8>`. This will also support most other mutable bytes containers (including `bytes::BytesMut`),
+  /// though these buffers will need to be boxed to manage ownership of memory.
   ///
-  /// As this buffer may be shared, the underlying object must be [`Send`] + [`Sync`].
+  /// ```
+  /// // Vector of bytes
+  /// let backing_store = v8::ArrayBuffer::new_backing_store_from_bytes(vec![1, 2, 3]);
+  /// // Boxes slice of bytes
+  /// let boxed_slice: Box<[u8]> = vec![1, 2, 3].into_boxed_slice();
+  /// let backing_store = v8::ArrayBuffer::new_backing_store_from_bytes(boxed_slice);
+  /// // BytesMut from bytes crate
+  /// let backing_store = v8::ArrayBuffer::new_backing_store_from_bytes(Box::new(bytes::BytesMut::new()));
+  /// ```
   #[inline(always)]
-  pub fn new_backing_store_from_boxed_bytes<T>(
-    mut bytes: Box<T>,
+  pub fn new_backing_store_from_bytes<T, U>(
+    mut bytes: T,
   ) -> UniqueRef<BackingStore>
   where
-    T: DerefMut<Target = [u8]> + Send + Sync,
+    U: ?Sized,
+    U: AsMut<[u8]>,
+    T: AsMut<U>,
+    T: crate::array_buffer::sealed::Rawable<U>,
   {
-    // We need to be very careful here not to move the data out of the box as that may
-    // invalidate the slice's pointer. You can imagine a SmallVec that provides a pointer to
-    // a slice inside of itself -- moving that SmallVec would invalidate the slice!
-    let slice = bytes.deref_mut();
-    let len = slice.len();
-    let slice = slice.as_mut_ptr();
-    let ptr = Box::into_raw(bytes) as *const c_void;
+    let len = bytes.as_mut().as_mut().len();
+    let slice = bytes.as_mut().as_mut().as_mut_ptr();
+    let ptr = T::into_raw(bytes);
 
-    extern "C" fn drop_box<T>(
+    extern "C" fn drop_rawable<
+      T: crate::array_buffer::sealed::Rawable<U>,
+      U: ?Sized,
+    >(
       _ptr: *mut c_void,
-      _len: usize,
+      len: usize,
       data: *mut c_void,
     ) {
-      // SAFETY: We know that data is a raw Box from above
-      unsafe { drop(Box::<T>::from_raw(data as _)) }
+      // SAFETY: We know that data is a raw T from above
+      unsafe {
+        <T as crate::array_buffer::sealed::Rawable<U>>::drop_raw(data as _, len)
+      }
     }
 
     // SAFETY: We are extending the lifetime of a slice, but we're locking away the box that we
     // derefed from so there's no way to get another mutable reference.
     unsafe {
-      Self::new_backing_store_from_ptr(slice as _, len, drop_box::<T>, ptr as _)
+      Self::new_backing_store_from_ptr(
+        slice as _,
+        len,
+        drop_rawable::<T, U>,
+        ptr as _,
+      )
     }
   }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -834,32 +834,9 @@ fn array_buffer() {
     assert_eq!(0, ab.byte_length());
     assert!(!ab.get_backing_store().is_shared());
 
-    // From something that derefs to a slice
-    #[derive(Default)]
-    struct DerefsToSlice {
-      bytes: [u8; 16],
-    }
-
-    impl std::ops::Deref for DerefsToSlice {
-      type Target = [u8];
-      fn deref(&self) -> &Self::Target {
-        &self.bytes
-      }
-    }
-
-    impl std::ops::DerefMut for DerefsToSlice {
-      fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.bytes
-      }
-    }
-
-    impl AsMut<[u8]> for DerefsToSlice {
-      fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.bytes
-      }
-    }
-
-    let mut data = DerefsToSlice::default();
+    // From a bytes::BytesMut
+    let mut data = bytes::BytesMut::new();
+    data.extend_from_slice(&[0; 16]);
     data[0] = 1;
     let unique_bs =
       v8::ArrayBuffer::new_backing_store_from_bytes(Box::new(data));
@@ -869,12 +846,6 @@ fn array_buffer() {
       v8::ArrayBuffer::with_backing_store(scope, &unique_bs.make_shared());
     assert_eq!(ab.byte_length(), 16);
     assert_eq!(ab.get_backing_store().get(0).unwrap().get(), 1);
-
-    // Ensure that these additional calls successfully compile (they are functionally tested above)
-    v8::ArrayBuffer::new_backing_store_from_bytes(vec![1, 2, 3]);
-    v8::ArrayBuffer::new_backing_store_from_bytes(
-      vec![1, 2, 3].into_boxed_slice(),
-    );
   }
 }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -837,7 +837,7 @@ fn array_buffer() {
     // From something that derefs to a slice
     #[derive(Default)]
     struct DerefsToSlice {
-      bytes: [u8; 16]
+      bytes: [u8; 16],
     }
 
     impl std::ops::Deref for DerefsToSlice {
@@ -858,7 +858,8 @@ fn array_buffer() {
     let unique_bs = v8::ArrayBuffer::new_backing_store_from_bytes(data);
     assert_eq!(unique_bs.get(0).unwrap().get(), 1);
 
-    let ab = v8::ArrayBuffer::with_backing_store(scope, &unique_bs.make_shared());
+    let ab =
+      v8::ArrayBuffer::with_backing_store(scope, &unique_bs.make_shared());
     assert_eq!(ab.byte_length(), 16);
     assert_eq!(ab.get_backing_store().get(0).unwrap().get(), 1);
   }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -853,15 +853,28 @@ fn array_buffer() {
       }
     }
 
+    impl AsMut<[u8]> for DerefsToSlice {
+      fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+      }
+    }
+
     let mut data = DerefsToSlice::default();
     data[0] = 1;
-    let unique_bs = v8::ArrayBuffer::new_backing_store_from_bytes(data);
+    let unique_bs =
+      v8::ArrayBuffer::new_backing_store_from_bytes(Box::new(data));
     assert_eq!(unique_bs.get(0).unwrap().get(), 1);
 
     let ab =
       v8::ArrayBuffer::with_backing_store(scope, &unique_bs.make_shared());
     assert_eq!(ab.byte_length(), 16);
     assert_eq!(ab.get_backing_store().get(0).unwrap().get(), 1);
+
+    // Ensure that these additional calls successfully compile (they are functionally tested above)
+    v8::ArrayBuffer::new_backing_store_from_bytes(vec![1, 2, 3]);
+    v8::ArrayBuffer::new_backing_store_from_bytes(
+      vec![1, 2, 3].into_boxed_slice(),
+    );
   }
 }
 


### PR DESCRIPTION
Allow creation of `v8::ArrayBuffer` and `v8::SharedArrayBuffer` from things that `DerefMut` to `&mut [u8]`. We stash the underlying object in a `Box` and then keep its slice around in the form of a buffer until we destroy the buffer. There's no way to take the object out of the buffer for now.

This is useful for when we want to return a `BytesMut` to v8.

We also expose an `empty` method for both buffers so we can avoid the overhead when creating empty buffers of any type.

