### PR TITLE
Add `cppgc` bindings

### DIFF
--- a/examples/cppgc-object.rs
+++ b/examples/cppgc-object.rs
@@ -19,6 +19,8 @@ impl Drop for Wrappable {
   }
 }
 
+// Set a custom embedder ID for the garbage collector. cppgc will use this ID to
+// identify the object that it manages.
 const DEFAULT_CPP_GC_EMBEDDER_ID: u16 = 0xde90;
 
 fn main() {

--- a/examples/cppgc-object.rs
+++ b/examples/cppgc-object.rs
@@ -1,0 +1,127 @@
+// Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
+use std::cell::Cell;
+
+struct Wrappable {
+  id: String,
+  trace_count: Cell<u16>,
+}
+
+impl v8::cppgc::GarbageCollected for Wrappable {
+  fn trace(&self, _visitor: &v8::cppgc::Visitor) {
+    println!("Wrappable::trace() {}", self.id);
+    self.trace_count.set(self.trace_count.get() + 1);
+  }
+}
+
+impl Drop for Wrappable {
+  fn drop(&mut self) {
+    println!("Wrappable::drop() {}", self.id);
+  }
+}
+
+const DEFAULT_CPP_GC_EMBEDDER_ID: u16 = 0xde90;
+
+fn main() {
+  let platform = v8::new_default_platform(0, false).make_shared();
+  v8::V8::set_flags_from_string("--no_freeze_flags_after_init --expose-gc");
+  v8::V8::initialize_platform(platform.clone());
+  v8::V8::initialize();
+
+  v8::cppgc::initalize_process(platform.clone());
+
+  {
+    let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
+
+    // Create a managed heap.
+    let heap = v8::cppgc::Heap::create(
+      platform,
+      v8::cppgc::HeapCreateParams::new(v8::cppgc::WrapperDescriptor::new(
+        0,
+        1,
+        DEFAULT_CPP_GC_EMBEDDER_ID,
+      )),
+    );
+
+    isolate.attach_cpp_heap(&heap);
+
+    let handle_scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(handle_scope);
+    let scope = &mut v8::ContextScope::new(handle_scope, context);
+    let global = context.global(scope);
+    {
+      let func = v8::Function::new(
+        scope,
+        |scope: &mut v8::HandleScope,
+         args: v8::FunctionCallbackArguments,
+         mut rv: v8::ReturnValue| {
+          let id = args.get(0).to_rust_string_lossy(scope);
+
+          let templ = v8::ObjectTemplate::new(scope);
+          templ.set_internal_field_count(2);
+
+          let obj = templ.new_instance(scope).unwrap();
+
+          let member = v8::cppgc::make_garbage_collected(
+            scope.get_cpp_heap(),
+            Box::new(Wrappable {
+              trace_count: Cell::new(0),
+              id,
+            }),
+          );
+
+          obj.set_aligned_pointer_in_internal_field(
+            0,
+            &DEFAULT_CPP_GC_EMBEDDER_ID as *const u16 as _,
+          );
+          obj.set_aligned_pointer_in_internal_field(1, member.handle as _);
+
+          rv.set(obj.into());
+        },
+      )
+      .unwrap();
+      let name = v8::String::new(scope, "make_wrap").unwrap();
+      global.set(scope, name.into(), func.into()).unwrap();
+    }
+
+    let source = v8::String::new(
+      scope,
+      r#"
+      make_wrap('gc me pls'); // Inaccessible after scope.
+      globalThis.wrap = make_wrap('dont gc me'); // Accessible after scope.
+    "#,
+    )
+    .unwrap();
+    execute_script(scope, source);
+
+    scope
+      .request_garbage_collection_for_testing(v8::GarbageCollectionType::Full);
+  }
+
+  // Gracefully shutdown the process.
+  unsafe {
+    v8::cppgc::shutdown_process();
+    v8::V8::dispose();
+  }
+  v8::V8::dispose_platform();
+}
+
+fn execute_script(
+  context_scope: &mut v8::ContextScope<v8::HandleScope>,
+  script: v8::Local<v8::String>,
+) {
+  let scope = &mut v8::HandleScope::new(context_scope);
+  let try_catch = &mut v8::TryCatch::new(scope);
+
+  let script = v8::Script::compile(try_catch, script, None)
+    .expect("failed to compile script");
+
+  if script.run(try_catch).is_none() {
+    let exception_string = try_catch
+      .stack_trace()
+      .or_else(|| try_catch.exception())
+      .map(|value| value.to_rust_string_lossy(try_catch))
+      .unwrap_or_else(|| "no stack trace".into());
+
+    panic!("{}", exception_string);
+  }
+}

--- a/examples/cppgc.rs
+++ b/examples/cppgc.rs
@@ -1,0 +1,45 @@
+struct Resource {
+  name: String,
+}
+
+impl Drop for Resource {
+  fn drop(&mut self) {
+    println!("Dropping {}", self.name);
+  }
+}
+
+fn main() {
+  let platform = v8::new_default_platform(0, false).make_shared();
+  v8::V8::initialize_platform(platform.clone());
+  v8::V8::initialize();
+
+  v8::cppgc::initalize_process(platform.clone());
+  {
+    let heap = v8::cppgc::Heap::create(platform);
+
+    let obj = make_object(&*heap, "hello");
+
+    heap.enable_detached_garbage_collections_for_testing();
+
+    heap.force_garbage_collection_slow(
+      v8::cppgc::EmbedderStackState::MayContainHeapPointers,
+    );
+    heap.force_garbage_collection_slow(
+      v8::cppgc::EmbedderStackState::NoHeapPointers,
+    );
+  }
+  unsafe { v8::cppgc::shutdown_process() };
+}
+
+fn make_object(heap: &v8::cppgc::Heap, name: &str) -> *mut Resource {
+  extern "C" fn trace(visitor: *mut v8::cppgc::Visitor, obj: *mut ()) {
+    let obj = unsafe { &*(obj as *const Resource) };
+    println!("Trace {}", obj.name);
+  }
+
+  let val = Box::new(Resource {
+    name: name.to_string(),
+  });
+  let obj = v8::cppgc::make_garbage_collected(heap, val, trace);
+  return obj;
+}

--- a/examples/cppgc.rs
+++ b/examples/cppgc.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 struct Resource {
   name: String,
 }
@@ -18,7 +19,6 @@ fn main() {
   let platform = v8::new_default_platform(0, false).make_shared();
   v8::V8::initialize_platform(platform.clone());
   v8::V8::initialize();
-
   v8::cppgc::initalize_process(platform.clone());
   {
     let heap = v8::cppgc::Heap::create(platform);
@@ -39,7 +39,10 @@ fn main() {
   unsafe { v8::cppgc::shutdown_process() };
 }
 
-fn make_object(heap: &v8::cppgc::Heap, name: &str) -> *mut Resource {
+fn make_object(
+  heap: &v8::cppgc::Heap,
+  name: &str,
+) -> v8::cppgc::Member<Resource> {
   let val = Box::new(Resource {
     name: name.to_string(),
   });

--- a/examples/cppgc.rs
+++ b/examples/cppgc.rs
@@ -40,7 +40,7 @@ impl Drop for Rope {
   }
 }
 
-const DEFAULT_CPP_GC_EMBEDDER_ID: u16 = 0x90de;
+const DEFAULT_CPP_GC_EMBEDDER_ID: u16 = 0xde90;
 
 fn main() {
   let platform = v8::new_default_platform(0, false).make_shared();

--- a/examples/cppgc.rs
+++ b/examples/cppgc.rs
@@ -65,10 +65,10 @@ fn main() {
     println!("{}", &*rope);
     // Manually trigger garbage collection.
     heap.enable_detached_garbage_collections_for_testing();
-    heap.force_garbage_collection_slow(
+    heap.collect_garbage_for_testing(
       v8::cppgc::EmbedderStackState::MayContainHeapPointers,
     );
-    heap.force_garbage_collection_slow(
+    heap.collect_garbage_for_testing(
       v8::cppgc::EmbedderStackState::NoHeapPointers,
     );
   }

--- a/examples/cppgc.rs
+++ b/examples/cppgc.rs
@@ -40,6 +40,8 @@ impl Drop for Rope {
   }
 }
 
+const DEFAULT_CPP_GC_EMBEDDER_ID: u16 = 0x90de;
+
 fn main() {
   let platform = v8::new_default_platform(0, false).make_shared();
   v8::V8::initialize_platform(platform.clone());
@@ -48,7 +50,14 @@ fn main() {
 
   {
     // Create a managed heap.
-    let heap = v8::cppgc::Heap::create(platform);
+    let heap = v8::cppgc::Heap::create(
+      platform,
+      v8::cppgc::HeapCreateParams::new(v8::cppgc::WrapperDescriptor::new(
+        0,
+        1,
+        DEFAULT_CPP_GC_EMBEDDER_ID,
+      )),
+    );
 
     // Allocate a string rope on the managed heap.
     let rope = v8::cppgc::make_garbage_collected(

--- a/examples/cppgc.rs
+++ b/examples/cppgc.rs
@@ -4,7 +4,7 @@ struct Resource {
 }
 
 impl v8::cppgc::GarbageCollected for Resource {
-  fn trace(&self, _visitor: *mut v8::cppgc::Visitor) {
+  fn trace(&self, _visitor: &v8::cppgc::Visitor) {
     println!("Trace {}", self.name);
   }
 }

--- a/examples/cppgc.rs
+++ b/examples/cppgc.rs
@@ -71,7 +71,7 @@ fn main() {
       ),
     );
 
-    println!("{}", &*rope);
+    println!("{}", unsafe { rope.get() });
     // Manually trigger garbage collection.
     heap.enable_detached_garbage_collections_for_testing();
     heap.collect_garbage_for_testing(

--- a/examples/cppgc.rs
+++ b/examples/cppgc.rs
@@ -29,7 +29,7 @@ impl Rope {
 impl v8::cppgc::GarbageCollected for Rope {
   fn trace(&self, visitor: &v8::cppgc::Visitor) {
     if let Some(member) = &self.next {
-      visitor.trace(&member);
+      visitor.trace(member);
     }
   }
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3620,6 +3620,8 @@ v8::CppHeap* cppgc__heap__create(v8::Platform* platform) {
   return heap.release();
 }
 
+void cppgc__heap__DELETE(v8::CppHeap* self) { delete self; }
+
 void cppgc__heap__enable_detached_garbage_collections_for_testing(v8::CppHeap* heap) {
   heap->EnableDetachedGarbageCollectionsForTesting();
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3621,6 +3621,10 @@ void v8__Isolate__AttachCppHeap(v8::Isolate* isolate, v8::CppHeap* cpp_heap) {
   isolate->AttachCppHeap(cpp_heap);
 }
 
+v8::CppHeap* v8__Isolate__GetCppHeap(v8::Isolate* isolate) {
+  return isolate->GetCppHeap();
+}
+
 void cppgc__heap__DELETE(v8::CppHeap* self) { delete self; }
 
 void cppgc__heap__enable_detached_garbage_collections_for_testing(v8::CppHeap* heap) {

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3626,7 +3626,7 @@ void cppgc__heap__enable_detached_garbage_collections_for_testing(v8::CppHeap* h
   heap->EnableDetachedGarbageCollectionsForTesting();
 }
 
-void cppgc__heap__force_garbage_collection_slow(v8::CppHeap* heap, cppgc::EmbedderStackState stack_state) {  
+void cppgc__heap__collect_garbage_for_testing(v8::CppHeap* heap, cppgc::EmbedderStackState stack_state) {  
   heap->CollectGarbageForTesting(stack_state);
 }
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3600,10 +3600,6 @@ class RustObj final: public cppgc::GarbageCollected<RustObj> {
     void* obj_;
 };
 
-enum InternalFields { kEmbedderType, kSlot, kInternalFieldCount };
-
-constexpr uint16_t kDefaultCppGCEmebdderID = 0x90de;
-
 void cppgc__initialize_process(v8::Platform* platform) {
   cppgc::InitializeProcess(platform->GetPageAllocator());
 }
@@ -3612,10 +3608,11 @@ void cppgc__shutdown_process() {
   cppgc::ShutdownProcess();
 }
 
-v8::CppHeap* cppgc__heap__create(v8::Platform* platform) {
+v8::CppHeap* cppgc__heap__create(v8::Platform* platform, int wrappable_type_index,
+                                 int wrappable_instance_index, uint16_t embedder_id) {
   std::unique_ptr<v8::CppHeap> heap = v8::CppHeap::Create(platform, v8::CppHeapCreateParams {
     {},
-    v8::WrapperDescriptor(InternalFields::kEmbedderType, InternalFields::kSlot, kDefaultCppGCEmebdderID),
+    v8::WrapperDescriptor(wrappable_type_index, wrappable_instance_index, embedder_id),
   });
   return heap.release();
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3579,7 +3579,7 @@ void v8__PropertyDescriptor__set_configurable(v8::PropertyDescriptor* self,
 
 extern "C" {
 
-using RustTraceFn = void (*)(cppgc::Visitor*, void* obj);
+using RustTraceFn = void (*)(void* obj, cppgc::Visitor*);
 using RustDestroyFn = void (*)(void* obj);
 
 class RustObj final: public cppgc::GarbageCollected<RustObj> {
@@ -3591,7 +3591,7 @@ class RustObj final: public cppgc::GarbageCollected<RustObj> {
     }
 
     void Trace(cppgc::Visitor* visitor) const {
-      trace_(visitor, obj_);
+      trace_(obj_, visitor);
     }
 
   private:

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3634,4 +3634,8 @@ RustObj* cppgc__make_garbage_collectable(v8::CppHeap* heap, void* obj, RustTrace
   return cppgc::MakeGarbageCollected<RustObj>(heap->GetAllocationHandle(), obj, trace, destroy);
 }
 
+void cppgc__visitor__trace(cppgc::Visitor* visitor, RustObj* member) {
+  visitor->Trace(*member);
+}
+
 }  // extern "C"

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3617,6 +3617,10 @@ v8::CppHeap* cppgc__heap__create(v8::Platform* platform, int wrappable_type_inde
   return heap.release();
 }
 
+void v8__Isolate__AttachCppHeap(v8::Isolate* isolate, v8::CppHeap* cpp_heap) { 
+  isolate->AttachCppHeap(cpp_heap);
+}
+
 void cppgc__heap__DELETE(v8::CppHeap* self) { delete self; }
 
 void cppgc__heap__enable_detached_garbage_collections_for_testing(v8::CppHeap* heap) {

--- a/src/cppgc.rs
+++ b/src/cppgc.rs
@@ -1,0 +1,110 @@
+// Copyright 2019-2021 the Deno authors. All rights reserved. MIT license
+
+use crate::platform::Platform;
+use crate::support::Opaque;
+use crate::support::SharedRef;
+use crate::support::UniqueRef;
+
+extern "C" {
+  fn cppgc__initialize_process(platform: *mut Platform);
+  fn cppgc__shutdown_process();
+
+  fn cppgc__heap__create(platform: *mut Platform) -> *mut Heap;
+  fn cppgc__make_garbage_collectable(
+    heap: *mut Heap,
+    obj: *mut (),
+    trace: TraceFn,
+    destroy: DestroyFn,
+  ) -> *mut ();
+
+  fn cppgc__heap__enable_detached_garbage_collections_for_testing(
+    heap: *mut Heap,
+  );
+  fn cppgc__heap__force_garbage_collection_slow(
+    heap: *mut Heap,
+    stack_state: EmbedderStackState,
+  );
+}
+
+pub fn initalize_process(platform: SharedRef<Platform>) {
+  unsafe {
+    cppgc__initialize_process(&*platform as *const Platform as *mut _);
+  }
+}
+
+pub unsafe fn shutdown_process() {
+  cppgc__shutdown_process();
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct RustObj(Opaque);
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct Visitor(Opaque);
+
+#[repr(C)]
+pub enum EmbedderStackState {
+  /// Stack may contain interesting heap pointers.
+  MayContainHeapPointers,
+  /// Stack does not contain any interesting heap pointers.
+  NoHeapPointers,
+}
+
+type TraceFn = extern "C" fn(*mut Visitor, *mut ());
+type DestroyFn = extern "C" fn(*mut ());
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct Heap(Opaque);
+
+impl Drop for Heap {
+  fn drop(&mut self) {}
+}
+
+impl Heap {
+  pub fn create(platform: SharedRef<Platform>) -> UniqueRef<Heap> {
+    unsafe {
+      UniqueRef::from_raw(cppgc__heap__create(
+        &*platform as *const Platform as *mut _,
+      ))
+    }
+  }
+
+  pub fn force_garbage_collection_slow(&self, stack_state: EmbedderStackState) {
+    unsafe {
+      cppgc__heap__force_garbage_collection_slow(
+        self as *const Heap as *mut _,
+        stack_state,
+      );
+    }
+  }
+
+  pub fn enable_detached_garbage_collections_for_testing(&self) {
+    unsafe {
+      cppgc__heap__enable_detached_garbage_collections_for_testing(
+        self as *const Heap as *mut _,
+      );
+    }
+  }
+}
+
+pub fn make_garbage_collected<T>(
+  heap: &Heap,
+  obj: Box<T>,
+  trace: TraceFn,
+) -> *mut T {
+  extern "C" fn destroy<T>(obj: *mut ()) {
+    let _ = unsafe { Box::from_raw(obj as *mut T) };
+  }
+
+  unsafe {
+    cppgc__make_garbage_collectable(
+      heap as *const Heap as *mut _,
+      Box::into_raw(obj) as _,
+      trace,
+      destroy::<T>,
+    ) as *mut T
+  }
+}

--- a/src/cppgc.rs
+++ b/src/cppgc.rs
@@ -224,6 +224,17 @@ pub struct Member<T: GarbageCollected> {
   ptr: *mut T,
 }
 
+impl<T: GarbageCollected> Member<T> {
+  /// Returns a raw pointer to the object.
+  ///
+  /// # Safety
+  ///
+  /// There are no guarantees that the object is alive and not garbage collected.
+  pub unsafe fn get(&self) -> &T {
+    unsafe { &*self.ptr }
+  }
+}
+
 impl<T: GarbageCollected> std::ops::Deref for Member<T> {
   type Target = T;
 

--- a/src/cppgc.rs
+++ b/src/cppgc.rs
@@ -57,7 +57,9 @@ pub unsafe fn shutdown_process() {
 /// Visitor passed to trace methods. All managed pointers must have called the
 /// Visitor's trace method on them.
 ///
-/// ```no_run
+/// ```
+/// use v8::cppgc::{Member, Visitor, GarbageCollected};
+///
 /// struct Foo { foo: Member<Foo> }
 ///
 /// impl GarbageCollected for Foo {

--- a/src/cppgc.rs
+++ b/src/cppgc.rs
@@ -231,6 +231,12 @@ impl<T: GarbageCollected> std::ops::Deref for Member<T> {
 }
 
 /// Constructs an instance of T, which is a garbage collected type.
+///
+/// The object will be allocated on the heap and managed by cppgc. During
+/// marking, the object will be traced by calling the `trace` method on it.
+///
+/// During sweeping, the destructor will be called and the memory will be
+/// freed using `Box::from_raw`.
 pub fn make_garbage_collected<T: GarbageCollected>(
   heap: &Heap,
   obj: Box<T>,
@@ -243,6 +249,9 @@ pub fn make_garbage_collected<T: GarbageCollected>(
 }
 
 /// # Safety
+///
+/// By calling this function, you are giving up ownership of `T` to the
+/// garbage collector.
 ///
 /// `obj` must be a pointer to a valid instance of T allocated on the heap.
 ///

--- a/src/cppgc.rs
+++ b/src/cppgc.rs
@@ -153,7 +153,7 @@ impl HeapCreateParams {
   }
 }
 
-type TraceFn = extern "C" fn(*mut Visitor, *mut ());
+type TraceFn = extern "C" fn(*mut (), *mut Visitor);
 type DestroyFn = extern "C" fn(*mut ());
 
 /// A heap for allocating managed C++ objects.
@@ -240,8 +240,8 @@ pub fn make_garbage_collected<T: GarbageCollected>(
   }
 
   extern "C" fn trace<T: GarbageCollected>(
-    visitor: *mut Visitor,
     obj: *mut (),
+    visitor: *mut Visitor,
   ) {
     let obj = unsafe { &*(obj as *const T) };
     obj.trace(unsafe { &*visitor });

--- a/src/cppgc.rs
+++ b/src/cppgc.rs
@@ -218,7 +218,7 @@ pub trait GarbageCollected {
 /// collected objects. All members fields on garbage collected objects
 /// must be trace in the `trace` method.
 pub struct Member<T: GarbageCollected> {
-  handle: *mut (),
+  pub handle: *mut (),
   ptr: *mut T,
 }
 

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -1,5 +1,6 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
 use crate::function::FunctionCallbackInfo;
+use crate::cppgc::Heap;
 use crate::gc::GCCallbackFlags;
 use crate::gc::GCType;
 use crate::handle::FinalizerCallback;
@@ -420,6 +421,10 @@ extern "C" {
     isolate: *mut Isolate,
     change_in_bytes: i64,
   ) -> i64;
+  fn v8__Isolate__AttachCppHeap(
+    isolate: *mut Isolate,
+    heap: *mut Heap,
+  );
   fn v8__Isolate__SetPrepareStackTraceCallback(
     isolate: *mut Isolate,
     callback: PrepareStackTraceCallback,
@@ -1081,6 +1086,20 @@ impl Isolate {
   ) -> i64 {
     unsafe {
       v8__Isolate__AdjustAmountOfExternalAllocatedMemory(self, change_in_bytes)
+    }
+  }
+
+  /// Attaches a managed C++ heap as an extension to the JavaScript heap.
+  /// 
+  /// The embedder maintains ownership of the CppHeap. At most one C++ heap
+  /// can be attached to V8.
+  #[inline(always)]
+  pub fn attach_cpp_heap(
+    &mut self,
+    heap: &Heap,
+  ) {
+    unsafe {
+      v8__Isolate__AttachCppHeap(self, heap as *const Heap as *mut _);
     }
   }
 

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
-use crate::function::FunctionCallbackInfo;
 use crate::cppgc::Heap;
+use crate::function::FunctionCallbackInfo;
 use crate::gc::GCCallbackFlags;
 use crate::gc::GCType;
 use crate::handle::FinalizerCallback;
@@ -421,10 +421,8 @@ extern "C" {
     isolate: *mut Isolate,
     change_in_bytes: i64,
   ) -> i64;
-  fn v8__Isolate__AttachCppHeap(
-    isolate: *mut Isolate,
-    heap: *mut Heap,
-  );
+  fn v8__Isolate__GetCppHeap(isolate: *mut Isolate) -> *mut Heap;
+  fn v8__Isolate__AttachCppHeap(isolate: *mut Isolate, heap: *mut Heap);
   fn v8__Isolate__SetPrepareStackTraceCallback(
     isolate: *mut Isolate,
     callback: PrepareStackTraceCallback,
@@ -1090,17 +1088,18 @@ impl Isolate {
   }
 
   /// Attaches a managed C++ heap as an extension to the JavaScript heap.
-  /// 
+  ///
   /// The embedder maintains ownership of the CppHeap. At most one C++ heap
   /// can be attached to V8.
   #[inline(always)]
-  pub fn attach_cpp_heap(
-    &mut self,
-    heap: &Heap,
-  ) {
+  pub fn attach_cpp_heap(&mut self, heap: &Heap) {
     unsafe {
       v8__Isolate__AttachCppHeap(self, heap as *const Heap as *mut _);
     }
+  }
+
+  pub fn get_cpp_heap(&mut self) -> &Heap {
+    unsafe { &*v8__Isolate__GetCppHeap(self) }
   }
 
   #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod array_buffer;
 mod array_buffer_view;
 mod bigint;
 mod context;
+pub mod cppgc;
 mod data;
 mod date;
 mod exception;

--- a/tests/test_cppgc.rs
+++ b/tests/test_cppgc.rs
@@ -1,0 +1,137 @@
+// Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
+use std::sync::atomic::{AtomicUsize, Ordering};
+use v8::cppgc::{GarbageCollected, Visitor};
+
+struct CppGCGuard {
+  pub platform: v8::SharedRef<v8::Platform>,
+}
+
+fn initalize_test() -> CppGCGuard {
+  v8::V8::set_flags_from_string("--no_freeze_flags_after_init --expose-gc");
+  let platform = v8::new_unprotected_default_platform(0, false).make_shared();
+  v8::V8::initialize_platform(platform.clone());
+  v8::V8::initialize();
+  v8::cppgc::initalize_process(platform.clone());
+
+  CppGCGuard { platform }
+}
+
+impl Drop for CppGCGuard {
+  fn drop(&mut self) {
+    unsafe {
+      v8::cppgc::shutdown_process();
+      v8::V8::dispose();
+    }
+    v8::V8::dispose_platform();
+  }
+}
+
+const DEFAULT_CPP_GC_EMBEDDER_ID: u16 = 0xde90;
+
+#[test]
+fn cppgc_object_wrap() {
+  let guard = initalize_test();
+
+  static TRACE_COUNT: AtomicUsize = AtomicUsize::new(0);
+  static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+  struct Wrap;
+
+  impl GarbageCollected for Wrap {
+    fn trace(&self, _: &Visitor) {
+      TRACE_COUNT.fetch_add(1, Ordering::SeqCst);
+    }
+  }
+
+  impl Drop for Wrap {
+    fn drop(&mut self) {
+      DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+    }
+  }
+
+  fn op_make_wrap(
+    scope: &mut v8::HandleScope,
+    _: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue,
+  ) {
+    let templ = v8::ObjectTemplate::new(scope);
+    templ.set_internal_field_count(2);
+
+    let obj = templ.new_instance(scope).unwrap();
+
+    let member =
+      v8::cppgc::make_garbage_collected(scope.get_cpp_heap(), Box::new(Wrap));
+
+    obj.set_aligned_pointer_in_internal_field(
+      0,
+      &DEFAULT_CPP_GC_EMBEDDER_ID as *const u16 as _,
+    );
+    obj.set_aligned_pointer_in_internal_field(1, member.handle as _);
+
+    rv.set(obj.into());
+  }
+
+  {
+    let isolate = &mut v8::Isolate::new(Default::default());
+    // Create a managed heap.
+    let heap = v8::cppgc::Heap::create(
+      guard.platform.clone(),
+      v8::cppgc::HeapCreateParams::new(v8::cppgc::WrapperDescriptor::new(
+        0,
+        1,
+        DEFAULT_CPP_GC_EMBEDDER_ID,
+      )),
+    );
+
+    isolate.attach_cpp_heap(&heap);
+
+    let handle_scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(handle_scope);
+    let scope = &mut v8::ContextScope::new(handle_scope, context);
+    let global = context.global(scope);
+    {
+      let func = v8::Function::new(scope, op_make_wrap).unwrap();
+      let name = v8::String::new(scope, "make_wrap").unwrap();
+      global.set(scope, name.into(), func.into()).unwrap();
+    }
+
+    let source = v8::String::new(
+      scope,
+      r#"
+      make_wrap(); // Inaccessible after scope.
+      globalThis.wrap = make_wrap(); // Accessible after scope.
+    "#,
+    )
+    .unwrap();
+    execute_script(scope, source);
+
+    assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 0);
+
+    scope
+      .request_garbage_collection_for_testing(v8::GarbageCollectionType::Full);
+
+    assert!(TRACE_COUNT.load(Ordering::SeqCst) > 0);
+    assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 1);
+  }
+}
+
+fn execute_script(
+  context_scope: &mut v8::ContextScope<v8::HandleScope>,
+  script: v8::Local<v8::String>,
+) {
+  let scope = &mut v8::HandleScope::new(context_scope);
+  let try_catch = &mut v8::TryCatch::new(scope);
+
+  let script = v8::Script::compile(try_catch, script, None)
+    .expect("failed to compile script");
+
+  if script.run(try_catch).is_none() {
+    let exception_string = try_catch
+      .stack_trace()
+      .or_else(|| try_catch.exception())
+      .map(|value| value.to_rust_string_lossy(try_catch))
+      .unwrap_or_else(|| "no stack trace".into());
+
+    panic!("{}", exception_string);
+  }
+}


### PR DESCRIPTION
https://v8.dev/blog/high-performance-cpp-gc

Oilpan in Deno design doc: https://www.notion.so/denolandinc/Oilpan-cppgc-in-Deno-e194f4268e9f4135ba97610ff7d3a949?pvs=4

Oilpan can be used to implement GC'able resources in Deno

Closes https://github.com/denoland/rusty_v8/issues/933