### PR TITLE
fix: arraybuffer init from vec was broken if vec reallocated to box

### DIFF
--- a/src/shared_array_buffer.rs
+++ b/src/shared_array_buffer.rs
@@ -176,8 +176,13 @@ impl SharedArrayBuffer {
     T: crate::array_buffer::sealed::Rawable<U>,
   {
     let len = bytes.as_mut().as_mut().len();
-    let slice = bytes.as_mut().as_mut().as_mut_ptr();
-    let ptr = T::into_raw(bytes);
+    if len == 0 {
+      return unsafe {
+        UniqueRef::from_raw(v8__BackingStore__EmptyBackingStore(false))
+      };
+    }
+
+    let (ptr, slice) = T::into_raw(bytes);
 
     extern "C" fn drop_rawable<
       T: crate::array_buffer::sealed::Rawable<U>,


### PR DESCRIPTION
If a vector tried to shrink during the `into_boxed_slice` operation, the slice we took before would become invalid.