### PR TITLE
feat: add get_backing_store to ArrayBufferView

### DIFF
--- a/src/array_buffer_view.rs
+++ b/src/array_buffer_view.rs
@@ -4,8 +4,10 @@ use std::ffi::c_void;
 use crate::support::int;
 use crate::ArrayBuffer;
 use crate::ArrayBufferView;
+use crate::BackingStore;
 use crate::HandleScope;
 use crate::Local;
+use crate::SharedRef;
 
 extern "C" {
   fn v8__ArrayBufferView__Buffer(
@@ -31,6 +33,17 @@ impl ArrayBufferView {
     scope: &mut HandleScope<'s>,
   ) -> Option<Local<'s, ArrayBuffer>> {
     unsafe { scope.cast_local(|_| v8__ArrayBufferView__Buffer(self)) }
+  }
+
+  /// Get a shared pointer to the backing store of this array buffer. This
+  /// pointer coordinates the lifetime management of the internal storage
+  /// with any live ArrayBuffers on the heap, even across isolates. The embedder
+  /// should not attempt to manage lifetime of the storage through other means.
+  #[inline(always)]
+  pub fn get_backing_store(&self) -> Option<SharedRef<BackingStore>> {
+    let buffer =
+      unsafe { v8__ArrayBufferView__Buffer(self) as *mut ArrayBuffer };
+    unsafe { buffer.as_mut().map(|buffer| buffer.get_backing_store()) }
   }
 
   /// Returns the underlying storage for this `ArrayBufferView`, including the built-in `byte_offset`.

--- a/src/array_buffer_view.rs
+++ b/src/array_buffer_view.rs
@@ -41,9 +41,8 @@ impl ArrayBufferView {
   /// should not attempt to manage lifetime of the storage through other means.
   #[inline(always)]
   pub fn get_backing_store(&self) -> Option<SharedRef<BackingStore>> {
-    let buffer =
-      unsafe { v8__ArrayBufferView__Buffer(self) as *mut ArrayBuffer };
-    unsafe { buffer.as_mut().map(|buffer| buffer.get_backing_store()) }
+    let buffer = unsafe { v8__ArrayBufferView__Buffer(self) };
+    unsafe { buffer.as_ref().map(|buffer| buffer.get_backing_store()) }
   }
 
   /// Returns the underlying storage for this `ArrayBufferView`, including the built-in `byte_offset`.

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -5066,6 +5066,10 @@ fn array_buffer_view() {
     assert!(maybe_ab.is_some());
     let ab = maybe_ab.unwrap();
     assert_eq!(ab.byte_length(), 6);
+    assert_eq!(
+      result.get_backing_store().unwrap().data(),
+      ab.get_backing_store().data()
+    );
   }
 }
 


### PR DESCRIPTION
Allows for scope-free access to ArrayBufferView's backing store