### PR TITLE
Fixed the broken link of releases in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ We default to release builds of `v8` due to performance & CI reasons in `deno`.
 
 Tells the build script where to get binary builds from. Understands `http://`
 and `https://` URLs, and file paths. The default is
-https://github.com/denoland/rusty_v8/releases/download.
+https://github.com/denoland/rusty_v8/releases.
 
 File-based mirrors are good for using cached downloads. First, point the
 environment variable to a suitable location:


### PR DESCRIPTION
In this PR, I have fixed the broken link of releases in README.md file which previously used to redirect to a 404 page.
Fixes #1356 