### PR TITLE
Upgrade to V8 12.1.285.6

### DIFF
--- a/examples/cppgc-object.rs
+++ b/examples/cppgc-object.rs
@@ -32,6 +32,8 @@ fn main() {
   v8::cppgc::initalize_process(platform.clone());
 
   {
+    let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
+
     // Create a managed heap.
     let heap = v8::cppgc::Heap::create(
       platform,
@@ -41,9 +43,7 @@ fn main() {
         DEFAULT_CPP_GC_EMBEDDER_ID,
       )),
     );
-
-    let isolate =
-      &mut v8::Isolate::new(v8::CreateParams::default().cppgc_heap(&heap));
+    isolate.attach_cpp_heap(&heap);
 
     let handle_scope = &mut v8::HandleScope::new(isolate);
     let context = v8::Context::new(handle_scope);

--- a/examples/cppgc-object.rs
+++ b/examples/cppgc-object.rs
@@ -32,8 +32,6 @@ fn main() {
   v8::cppgc::initalize_process(platform.clone());
 
   {
-    let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
-
     // Create a managed heap.
     let heap = v8::cppgc::Heap::create(
       platform,
@@ -44,7 +42,8 @@ fn main() {
       )),
     );
 
-    isolate.attach_cpp_heap(&heap);
+    let isolate =
+      &mut v8::Isolate::new(v8::CreateParams::default().cppgc_heap(&heap));
 
     let handle_scope = &mut v8::HandleScope::new(isolate);
     let context = v8::Context::new(handle_scope);

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3654,6 +3654,18 @@ v8::CppHeap* cppgc__heap__create(v8::Platform* platform,
   return heap.release();
 }
 
+void v8__Isolate__AttachCppHeap(v8::Isolate* isolate, v8::CppHeap* cpp_heap) { 
+// The AttachCppHeap method is deprecated but the alternative of passing
+// heap to the Isolate CreateParams is broken.
+//
+// TODO(@littledivy): Remove this when the above CL is merged.
+// https://chromium-review.googlesource.com/c/chromium/src/+/4992764
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  isolate->AttachCppHeap(cpp_heap);
+#pragma clang diagnostic pop
+}
+
 v8::CppHeap* v8__Isolate__GetCppHeap(v8::Isolate* isolate) {
   return isolate->GetCppHeap();
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2543,10 +2543,8 @@ bool v8__Proxy__IsRevoked(const v8::Proxy& self) {
 void v8__Proxy__Revoke(const v8::Proxy& self) { ptr_to_local(&self)->Revoke(); }
 
 void v8__SnapshotCreator__CONSTRUCT(uninit_t<v8::SnapshotCreator>* buf,
-                                    const intptr_t* external_references,
-                                    v8::StartupData* existing_blob) {
-  construct_in_place<v8::SnapshotCreator>(buf, external_references,
-                                          existing_blob);
+                                    const v8::Isolate::CreateParams& params) {
+  construct_in_place<v8::SnapshotCreator>(buf, params);
 }
 
 void v8__SnapshotCreator__DESTRUCT(v8::SnapshotCreator* self) {

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2367,13 +2367,13 @@ const v8::Value* v8__Script__Run(const v8::Script& script,
 }
 
 void v8__ScriptOrigin__CONSTRUCT(
-    v8::Isolate* isolate, uninit_t<v8::ScriptOrigin>* buf,
+    uninit_t<v8::ScriptOrigin>* buf,
     const v8::Value& resource_name, int resource_line_offset,
     int resource_column_offset, bool resource_is_shared_cross_origin,
     int script_id, const v8::Value& source_map_url, bool resource_is_opaque,
     bool is_wasm, bool is_module) {
   construct_in_place<v8::ScriptOrigin>(
-      buf, isolate, ptr_to_local(&resource_name), resource_line_offset,
+      buf, ptr_to_local(&resource_name), resource_line_offset,
       resource_column_offset, resource_is_shared_cross_origin, script_id,
       ptr_to_local(&source_map_url), resource_is_opaque, is_wasm, is_module);
 }

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -545,7 +545,7 @@ impl Isolate {
   // Byte offset inside `Isolate` where the isolate data slots are stored. This
   // should be the same as the value of `kIsolateEmbedderDataOffset` which is
   // defined in `v8-internal.h`.
-  const EMBEDDER_DATA_OFFSET: usize = size_of::<[*const (); 67]>();
+  const EMBEDDER_DATA_OFFSET: usize = size_of::<[*const (); 65]>();
 
   // Isolate data slots used internally by rusty_v8.
   const ANNEX_SLOT: u32 = 0;

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -422,6 +422,7 @@ extern "C" {
     change_in_bytes: i64,
   ) -> i64;
   fn v8__Isolate__GetCppHeap(isolate: *mut Isolate) -> *mut Heap;
+  fn v8__Isolate__AttachCppHeap(isolate: *mut Isolate, heap: *mut Heap);
   fn v8__Isolate__SetPrepareStackTraceCallback(
     isolate: *mut Isolate,
     callback: PrepareStackTraceCallback,
@@ -1083,6 +1084,17 @@ impl Isolate {
   ) -> i64 {
     unsafe {
       v8__Isolate__AdjustAmountOfExternalAllocatedMemory(self, change_in_bytes)
+    }
+  }
+
+  /// Attaches a managed C++ heap as an extension to the JavaScript heap.
+  ///
+  /// The embedder maintains ownership of the CppHeap. At most one C++ heap
+  /// can be attached to V8.
+  #[inline(always)]
+  pub fn attach_cpp_heap(&mut self, heap: &Heap) {
+    unsafe {
+      v8__Isolate__AttachCppHeap(self, heap as *const Heap as *mut _);
     }
   }
 

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -422,7 +422,6 @@ extern "C" {
     change_in_bytes: i64,
   ) -> i64;
   fn v8__Isolate__GetCppHeap(isolate: *mut Isolate) -> *mut Heap;
-  fn v8__Isolate__AttachCppHeap(isolate: *mut Isolate, heap: *mut Heap);
   fn v8__Isolate__SetPrepareStackTraceCallback(
     isolate: *mut Isolate,
     callback: PrepareStackTraceCallback,
@@ -1091,12 +1090,6 @@ impl Isolate {
   ///
   /// The embedder maintains ownership of the CppHeap. At most one C++ heap
   /// can be attached to V8.
-  #[inline(always)]
-  pub fn attach_cpp_heap(&mut self, heap: &Heap) {
-    unsafe {
-      v8__Isolate__AttachCppHeap(self, heap as *const Heap as *mut _);
-    }
-  }
 
   pub fn get_cpp_heap(&mut self) -> &Heap {
     unsafe { &*v8__Isolate__GetCppHeap(self) }

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -1086,11 +1086,6 @@ impl Isolate {
     }
   }
 
-  /// Attaches a managed C++ heap as an extension to the JavaScript heap.
-  ///
-  /// The embedder maintains ownership of the CppHeap. At most one C++ heap
-  /// can be attached to V8.
-
   pub fn get_cpp_heap(&mut self) -> &Heap {
     unsafe { &*v8__Isolate__GetCppHeap(self) }
   }

--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -165,15 +165,6 @@ impl CreateParams {
     self
   }
 
-  /// Attaches a managed C++ heap as an extension to the JavaScript heap.
-  ///
-  /// The embedder maintains ownership of the CppHeap. At most one C++ heap
-  /// can be attached to V8.
-  pub fn cppgc_heap(mut self, heap: &Heap) -> Self {
-    self.raw.cpp_heap = heap as *const Heap;
-    self
-  }
-
   pub(crate) fn finalize(mut self) -> (raw::CreateParams, Box<dyn Any>) {
     if self.raw.array_buffer_allocator_shared.is_null() {
       self = self.array_buffer_allocator(array_buffer::new_default_allocator());

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -327,7 +327,7 @@ impl<'s> HandleScope<'s> {
     unsafe {
       let sd = data::ScopeData::get_mut(self);
       raw::v8__Context__SetContinuationPreservedEmbedderData(
-        sd.get_current_context(),
+        sd.get_isolate_ptr(),
         &*data,
       );
     }
@@ -341,7 +341,7 @@ impl<'s> HandleScope<'s> {
       self
         .cast_local(|sd| {
           raw::v8__Context__GetContinuationPreservedEmbedderData(
-            sd.get_current_context(),
+            sd.get_isolate_ptr(),
           )
         })
         .unwrap()
@@ -2100,11 +2100,11 @@ mod raw {
       resolve_hook: *const Function,
     );
     pub(super) fn v8__Context__SetContinuationPreservedEmbedderData(
-      this: *const Context,
+      this: *mut Isolate,
       value: *const Value,
     );
     pub(super) fn v8__Context__GetContinuationPreservedEmbedderData(
-      this: *const Context,
+      this: *mut Isolate,
     ) -> *const Value;
 
     pub(super) fn v8__HandleScope__CONSTRUCT(

--- a/src/script.rs
+++ b/src/script.rs
@@ -31,7 +31,6 @@ extern "C" {
   ) -> *const Value;
 
   fn v8__ScriptOrigin__CONSTRUCT(
-    isolate: *mut Isolate,
     buf: *mut MaybeUninit<ScriptOrigin>,
     resource_name: *const Value,
     resource_line_offset: i32,
@@ -117,7 +116,6 @@ impl<'s> ScriptOrigin<'s> {
     unsafe {
       let mut buf = std::mem::MaybeUninit::<ScriptOrigin>::uninit();
       v8__ScriptOrigin__CONSTRUCT(
-        scope.get_isolate_ptr(),
         &mut buf,
         &*resource_name,
         resource_line_offset,

--- a/src/script.rs
+++ b/src/script.rs
@@ -4,7 +4,6 @@ use std::ptr::null;
 
 use crate::Context;
 use crate::HandleScope;
-use crate::Isolate;
 use crate::Local;
 use crate::Script;
 use crate::String;
@@ -102,7 +101,8 @@ impl<'s> ScriptOrigin<'s> {
   #[allow(clippy::too_many_arguments)]
   #[inline(always)]
   pub fn new(
-    scope: &mut HandleScope<'s, ()>,
+    // TODO(littledivy): remove
+    _scope: &mut HandleScope<'s, ()>,
     resource_name: Local<'s, Value>,
     resource_line_offset: i32,
     resource_column_offset: i32,

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -74,6 +74,7 @@ pub struct Source {
   _consume_cache_task: usize,
   _compile_hint_callback: usize,
   _compile_hint_callback_data: usize,
+  _compilation_details: [usize; 3],
 }
 
 /// Compilation data that the embedder can cache and pass back to speed up future

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -21,8 +21,7 @@ use std::ptr::null;
 extern "C" {
   fn v8__SnapshotCreator__CONSTRUCT(
     buf: *mut MaybeUninit<SnapshotCreator>,
-    external_references: *const intptr_t,
-    existing_blob: *const raw::StartupData,
+    params: *const raw::CreateParams,
   );
   fn v8__SnapshotCreator__DESTRUCT(this: *mut SnapshotCreator);
   fn v8__SnapshotCreator__GetIsolate(
@@ -131,30 +130,18 @@ impl SnapshotCreator {
     existing_snapshot_blob: Option<impl Allocated<[u8]>>,
   ) -> OwnedIsolate {
     let mut snapshot_creator: MaybeUninit<Self> = MaybeUninit::uninit();
-    let external_references_ptr = if let Some(er) = external_references {
-      er.as_ptr()
-    } else {
-      std::ptr::null()
-    };
 
-    let snapshot_blob_ptr;
-    let snapshot_allocations;
-    if let Some(snapshot_blob) = existing_snapshot_blob {
-      let data = Allocation::of(snapshot_blob);
-      let header = Allocation::of(raw::StartupData::boxed_header(&data));
-      snapshot_blob_ptr = &*header as *const _;
-      snapshot_allocations = Some((header, data));
-    } else {
-      snapshot_blob_ptr = null();
-      snapshot_allocations = None;
+    let mut params = crate::CreateParams::default();
+    if let Some(external_refs) = external_references {
+      params = params.external_references(&**external_refs);
     }
+    if let Some(snapshot_blob) = existing_snapshot_blob {
+      params = params.snapshot_blob(snapshot_blob);
+    }
+    let (raw_create_params, create_param_allocations) = params.finalize();
 
     let snapshot_creator = unsafe {
-      v8__SnapshotCreator__CONSTRUCT(
-        &mut snapshot_creator,
-        external_references_ptr,
-        snapshot_blob_ptr,
-      );
+      v8__SnapshotCreator__CONSTRUCT(&mut snapshot_creator, &raw_create_params);
       snapshot_creator.assume_init()
     };
 
@@ -162,7 +149,7 @@ impl SnapshotCreator {
       unsafe { v8__SnapshotCreator__GetIsolate(&snapshot_creator) };
     let mut owned_isolate = OwnedIsolate::new(isolate_ptr);
     ScopeData::new_root(&mut owned_isolate);
-    owned_isolate.create_annex(Box::new(snapshot_allocations));
+    owned_isolate.create_annex(create_param_allocations);
     owned_isolate.set_snapshot_creator(snapshot_creator);
     owned_isolate
   }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -3,9 +3,7 @@ use crate::isolate_create_params::raw;
 use crate::scope::data::ScopeData;
 use crate::support::char;
 use crate::support::int;
-use crate::support::intptr_t;
 use crate::support::Allocated;
-use crate::support::Allocation;
 use crate::Context;
 use crate::Data;
 use crate::Isolate;
@@ -16,7 +14,6 @@ use std::borrow::Borrow;
 use std::convert::TryFrom;
 use std::mem::MaybeUninit;
 use std::ops::Deref;
-use std::ptr::null;
 
 extern "C" {
   fn v8__SnapshotCreator__CONSTRUCT(

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -270,16 +270,9 @@ pub trait ValueSerializerImpl {
 
   fn get_shared_array_buffer_id<'s>(
     &mut self,
-    scope: &mut HandleScope<'s>,
+    _scope: &mut HandleScope<'s>,
     _shared_array_buffer: Local<'s, SharedArrayBuffer>,
   ) -> Option<u32> {
-    let msg = String::new(
-      scope,
-      "Deno serializer: get_shared_array_buffer_id not implemented",
-    )
-    .unwrap();
-    let exc = Exception::error(scope, msg);
-    scope.throw_exception(exc);
     None
   }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2117,7 +2117,6 @@ fn object_template_set_named_property_handler() {
       assert!(!args.should_throw_on_error());
 
       let expected_key = v8::String::new(scope, "key").unwrap();
-      println!("key: {:?}", key.to_rust_string_lossy(scope));
       assert!(key.strict_equals(expected_key.into()));
 
       let internal_field = this

--- a/tests/test_cppgc.rs
+++ b/tests/test_cppgc.rs
@@ -72,7 +72,6 @@ fn cppgc_object_wrap() {
   }
 
   {
-    let isolate = &mut v8::Isolate::new(Default::default());
     // Create a managed heap.
     let heap = v8::cppgc::Heap::create(
       guard.platform.clone(),
@@ -83,7 +82,8 @@ fn cppgc_object_wrap() {
       )),
     );
 
-    isolate.attach_cpp_heap(&heap);
+    let isolate =
+      &mut v8::Isolate::new(v8::CreateParams::default().cppgc_heap(&heap));
 
     let handle_scope = &mut v8::HandleScope::new(isolate);
     let context = v8::Context::new(handle_scope);

--- a/tests/test_cppgc.rs
+++ b/tests/test_cppgc.rs
@@ -72,6 +72,7 @@ fn cppgc_object_wrap() {
   }
 
   {
+    let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
     // Create a managed heap.
     let heap = v8::cppgc::Heap::create(
       guard.platform.clone(),
@@ -81,9 +82,7 @@ fn cppgc_object_wrap() {
         DEFAULT_CPP_GC_EMBEDDER_ID,
       )),
     );
-
-    let isolate =
-      &mut v8::Isolate::new(v8::CreateParams::default().cppgc_heap(&heap));
+    isolate.attach_cpp_heap(&heap);
 
     let handle_scope = &mut v8::HandleScope::new(isolate);
     let context = v8::Context::new(handle_scope);


### PR DESCRIPTION
Changes:

- [x] `v8::ScriptCompiler` size increased by 3 words with `v8::ScriptCompiler::CompilationDetails`. @littledivy
- [x] `v8::ObjectTemplate::SetAccessor` & `v8::ObjectTemplate::SetAccessorProperty` signature changed and also deprecated.  @littledivy
- [x] `v8::Context::SetContinuationPreservedEmbedderData` deprecated. Use `v8::Isolate::GetContinuationPreservedEmbedderData` instead.  @littledivy
- [x] `GetStalledTopLevelAwaitMessage` deprecated. Use `GetStalledTopLevelAwaitMessages` instead.  @littledivy
- [x] `v8::Isolate::AttachCppHeap` deprecated. Set the heap on Isolate creation using CreateParams instead.  @littledivy
- [x] `v8::ScriptOrigin` deprecated. Use constructor without the isolate. @bartlomieju
- [x] `v8::SnapshotCreator` is deprecated. Use the version that passes CreateParams instead. @bartlomieju
- [x] `v8::Isolate` assertion failures. @littledivy

#1373 but without denobot force pushing over our changes :)