### PR TITLE
Explicit panic instead of silent memory corruption

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -161,6 +161,8 @@ void v8__Isolate__Enter(v8::Isolate* isolate) { isolate->Enter(); }
 
 void v8__Isolate__Exit(v8::Isolate* isolate) { isolate->Exit(); }
 
+v8::Isolate* v8__Isolate__GetCurrent() { return v8::Isolate::GetCurrent(); }
+
 void v8__Isolate__MemoryPressureNotification(v8::Isolate* isolate,
                                              v8::MemoryPressureLevel level) {
   isolate->MemoryPressureNotification(level);

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -637,6 +637,17 @@ fn microtasks() {
 }
 
 #[test]
+#[should_panic(
+  expected = "v8::OwnedIsolate instances must be dropped in the reverse order of creation. They are entered upon creation and exited upon being dropped."
+)]
+fn isolate_drop_order() {
+  let isolate1 = v8::Isolate::new(Default::default());
+  let isolate2 = v8::Isolate::new(Default::default());
+  drop(isolate1);
+  drop(isolate2);
+}
+
+#[test]
 fn get_isolate_from_handle() {
   extern "C" {
     fn v8__internal__GetIsolateFromHeapObject(


### PR DESCRIPTION
Due to the automatic entry and exit behavior of Isolate upon creation and drop, it is crucial to ensure that v8::OwnedIsolate instances are dropped in the reverse order of their creation. Dropping them in the incorrect order can result in the corruption of the thread-local stack managed by v8, leading to memory corruption and potential segfaults. 

This introduces a check to verify the `this == Isolate::GetCurrent()` requirement before invoking the exit function. If the requirement is not met, a clean panic is triggered to provide explicit error handling instead of allowing silent memory corruption.

The following program demonstrates how a segfault can be currently triggered using only the safe Rust API:

```rust
fn main() {
    let platform = v8::new_default_platform(0, false).make_shared();
    v8::V8::initialize_platform(platform);
    v8::V8::initialize();

    let mut isolates = vec![];

    loop {
        isolates.push(v8::Isolate::new(Default::default()));

        // maybe drop a random isolate
        if rand::random() {
            drop(isolates.remove(rand::random::<usize>() % isolates.len()));
        }
    }
}
```

An alternative approach would be to strictly disallow the creation of multiple v8::OwnedIsolate instances on the same thread to ensure immediate failure. However, some tests (and probably some applications) currently rely on this behavior.

Another option is to remove the automatic enter/exit functionality and instead introduce a safe API that explicitly requires entering and exiting the Isolate. However, implementing this change would result in a significant break in the API.