### PR TITLE
Fix misleading BigInt rustdoc

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -79,9 +79,9 @@ impl BigInt {
   }
 
   /// Returns the value of this BigInt as an unsigned 64-bit integer, and a
-  /// `bool` indicating whether the return value was truncated was truncated or
-  /// wrapped around. In particular, it will be `false` if this BigInt is
-  /// negative.
+  /// `bool` indicating whether the conversion was lossless or not.
+  /// The boolean value will be `false` if the return value was truncated or wrapped around,
+  /// in particular if the BigInt is negative.
   #[inline(always)]
   pub fn u64_value(&self) -> (u64, bool) {
     let mut lossless = MaybeUninit::uninit();
@@ -91,7 +91,8 @@ impl BigInt {
   }
 
   /// Returns the value of this BigInt as a signed 64-bit integer, and a `bool`
-  /// indicating whether this BigInt was truncated or not.
+  /// indicating whether the conversion was lossless or not.
+  /// The boolean value will be `false` if the return value was truncated or wrapped around.
   #[inline(always)]
   pub fn i64_value(&self) -> (i64, bool) {
     let mut lossless = MaybeUninit::uninit();

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -91,7 +91,7 @@ impl BigInt {
   }
 
   /// Returns the value of this BigInt as a signed 64-bit integer, and a `bool`
-  /// indicating whether the conversion was lossless or not.
+  /// indicating that the conversion was lossless when `true`.
   /// The boolean value will be `false` if the return value was truncated or wrapped around.
   #[inline(always)]
   pub fn i64_value(&self) -> (i64, bool) {

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -79,7 +79,7 @@ impl BigInt {
   }
 
   /// Returns the value of this BigInt as an unsigned 64-bit integer, and a
-  /// `bool` indicating whether the conversion was lossless or not.
+  /// `bool` indicating that the conversion was lossless when `true`.
   /// The boolean value will be `false` if the return value was truncated or wrapped around,
   /// in particular if the BigInt is negative.
   #[inline(always)]


### PR DESCRIPTION
The original documentation was unclear about the value of the bool. I interpreted it as being `true` if the value was truncated.