### PR TITLE
`isolate->GetCppHeap()` can return nullptr if no heap is attached

### DIFF
--- a/examples/cppgc-object.rs
+++ b/examples/cppgc-object.rs
@@ -63,7 +63,7 @@ fn main() {
           let obj = templ.new_instance(scope).unwrap();
 
           let member = v8::cppgc::make_garbage_collected(
-            scope.get_cpp_heap(),
+            scope.get_cpp_heap().unwrap(),
             Box::new(Wrappable {
               trace_count: Cell::new(0),
               id,

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -1101,7 +1101,7 @@ impl Isolate {
   }
 
   pub fn get_cpp_heap(&mut self) -> Option<&Heap> {
-    unsafe { v8__Isolate__GetCppHeap(self).as_ref().map(|h| &*h) }
+    unsafe { v8__Isolate__GetCppHeap(self).as_ref() }
   }
 
   #[inline(always)]

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -1100,8 +1100,8 @@ impl Isolate {
     }
   }
 
-  pub fn get_cpp_heap(&mut self) -> &Heap {
-    unsafe { &*v8__Isolate__GetCppHeap(self) }
+  pub fn get_cpp_heap(&mut self) -> Option<&Heap> {
+    unsafe { v8__Isolate__GetCppHeap(self).as_ref().map(|h| &*h) }
   }
 
   #[inline(always)]

--- a/tests/test_cppgc.rs
+++ b/tests/test_cppgc.rs
@@ -60,7 +60,7 @@ fn cppgc_object_wrap() {
     let obj = templ.new_instance(scope).unwrap();
 
     let member =
-      v8::cppgc::make_garbage_collected(scope.get_cpp_heap(), Box::new(Wrap));
+      v8::cppgc::make_garbage_collected(scope.get_cpp_heap().unwrap(), Box::new(Wrap));
 
     obj.set_aligned_pointer_in_internal_field(
       0,

--- a/tests/test_cppgc.rs
+++ b/tests/test_cppgc.rs
@@ -59,8 +59,10 @@ fn cppgc_object_wrap() {
 
     let obj = templ.new_instance(scope).unwrap();
 
-    let member =
-      v8::cppgc::make_garbage_collected(scope.get_cpp_heap().unwrap(), Box::new(Wrap));
+    let member = v8::cppgc::make_garbage_collected(
+      scope.get_cpp_heap().unwrap(),
+      Box::new(Wrap),
+    );
 
     obj.set_aligned_pointer_in_internal_field(
       0,


### PR DESCRIPTION
Changes `v8::Isolate::get_cpp_heap` to return a `Option<&Heap>`.