### PR TITLE
Fix busted doc comment

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -63,7 +63,7 @@ extern "C" {
 ///
 /// It is safe to extract the object stored in the handle by
 /// dereferencing the handle (for instance, to extract the `*Object` from
-/// a Local`<Object>`); the value will still be governed by a handle
+/// a `Local<Object>`); the value will still be governed by a handle
 /// behind the scenes and the same rules apply to these values as to
 /// their handles.
 ///


### PR DESCRIPTION
This doc comment contains raw HTML, when it's supposed to contain generics. Fix this by wrapping them as code.