### PR TITLE
Fixed a typo in the parameter `capture` in `v8__Isolate__SetCaptureStackTraceForUncaughtExceptions`

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -386,7 +386,7 @@ extern "C" {
   fn v8__Isolate__GetHeapStatistics(this: *mut Isolate, s: *mut HeapStatistics);
   fn v8__Isolate__SetCaptureStackTraceForUncaughtExceptions(
     this: *mut Isolate,
-    caputre: bool,
+    capture: bool,
     frame_limit: i32,
   );
   fn v8__Isolate__AddMessageListener(


### PR DESCRIPTION
Tis was a drive-by fix, callers spelled it correctly and the C++ side was also spelled correctly.