### PR TITLE
chore: revert V8 upgrade from 12.3 to 12.2.

### DIFF
--- a/.gn
+++ b/.gn
@@ -72,18 +72,6 @@ default_args = {
 
   # Enable V8 object print for debugging.
   # v8_enable_object_print = true
-  
-  # V8 12.3 added google/fuzztest as a third party dependency.
-  # https://chromium.googlesource.com/v8/v8.git/+/d5acece0c9b89b18716c177d1fcc8f734191e1e2%5E%21/#F4
-  #
-  # This flag disables it.
-  v8_enable_fuzztest = false
-
-  # Disable v8::HandleScope LIFO checks.
-  # https://chromium-review.googlesource.com/c/v8/v8/+/5110566
-  #
-  # rusty_v8 scopes are not on the stack.
-  v8_enable_v8_checks = false
 
   # Enable Deno-specific extra bindings
   deno_enable_extras = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rusty V8 Binding
 
-V8 Version: 12.3.219.1
+V8 Version: 12.1.285.27
 
 [![ci](https://github.com/denoland/rusty_v8/workflows/ci/badge.svg?branch=main)](https://github.com/denoland/rusty_v8/actions)
 [![crates](https://img.shields.io/crates/v/v8.svg)](https://crates.io/crates/v8)

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3073,9 +3073,9 @@ int v8__ModuleRequest__GetSourceOffset(const v8::ModuleRequest& self) {
   return self.GetSourceOffset();
 }
 
-const v8::FixedArray* v8__ModuleRequest__GetImportAttributes(
+const v8::FixedArray* v8__ModuleRequest__GetImportAssertions(
     const v8::ModuleRequest& self) {
-  return local_to_ptr(self.GetImportAttributes());
+  return local_to_ptr(self.GetImportAssertions());
 }
 
 struct WasmStreamingSharedPtr {

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -548,7 +548,7 @@ impl Isolate {
   // Byte offset inside `Isolate` where the isolate data slots are stored. This
   // should be the same as the value of `kIsolateEmbedderDataOffset` which is
   // defined in `v8-internal.h`.
-  const EMBEDDER_DATA_OFFSET: usize = size_of::<[*const (); 67]>();
+  const EMBEDDER_DATA_OFFSET: usize = size_of::<[*const (); 65]>();
 
   // Isolate data slots used internally by rusty_v8.
   const ANNEX_SLOT: u32 = 0;

--- a/src/module.rs
+++ b/src/module.rs
@@ -193,7 +193,7 @@ extern "C" {
     this: *const ModuleRequest,
   ) -> *const String;
   fn v8__ModuleRequest__GetSourceOffset(this: *const ModuleRequest) -> int;
-  fn v8__ModuleRequest__GetImportAttributes(
+  fn v8__ModuleRequest__GetImportAssertions(
     this: *const ModuleRequest,
   ) -> *const FixedArray;
   fn v8__Module__GetStalledTopLevelAwaitMessage(
@@ -480,7 +480,7 @@ impl ModuleRequest {
     unsafe { v8__ModuleRequest__GetSourceOffset(self) }
   }
 
-  /// Contains the import attributes for this request in the form:
+  /// Contains the import assertions for this request in the form:
   /// [key1, value1, source_offset1, key2, value2, source_offset2, ...].
   /// The keys and values are of type v8::String, and the source offsets are of
   /// type Int32. Use Module::source_offset_to_location to convert the source
@@ -493,14 +493,8 @@ impl ModuleRequest {
   /// opposed to, for example, triggering an error if an unsupported assertion is
   /// present).
   #[inline(always)]
-  pub fn get_import_attributes(&self) -> Local<FixedArray> {
-    unsafe { Local::from_raw(v8__ModuleRequest__GetImportAttributes(self)) }
-      .unwrap()
-  }
-
-  #[inline(always)]
-  #[deprecated(note = "Use get_import_attributes instead")]
   pub fn get_import_assertions(&self) -> Local<FixedArray> {
-    self.get_import_attributes()
+    unsafe { Local::from_raw(v8__ModuleRequest__GetImportAssertions(self)) }
+      .unwrap()
   }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4693,7 +4693,7 @@ fn module_instantiation_failures1() {
     let loc = module.source_offset_to_location(mr1.get_source_offset());
     assert_eq!(0, loc.get_line_number());
     assert_eq!(7, loc.get_column_number());
-    assert_eq!(0, mr1.get_import_attributes().length());
+    assert_eq!(0, mr1.get_import_assertions().length());
 
     let mr2 = v8::Local::<v8::ModuleRequest>::try_from(
       module_requests.get(scope, 1).unwrap(),
@@ -4703,7 +4703,7 @@ fn module_instantiation_failures1() {
     let loc = module.source_offset_to_location(mr2.get_source_offset());
     assert_eq!(1, loc.get_line_number());
     assert_eq!(15, loc.get_column_number());
-    assert_eq!(0, mr2.get_import_attributes().length());
+    assert_eq!(0, mr2.get_import_assertions().length());
 
     // Instantiation should fail.
     {

--- a/tools/auto_update_v8.ts
+++ b/tools/auto_update_v8.ts
@@ -1,4 +1,4 @@
-const V8_TRACKING_BRANCH = "12.3-lkgr-denoland";
+const V8_TRACKING_BRANCH = "12.2-lkgr-denoland";
 const AUTOROLL_BRANCH = "autoroll";
 
 function extractVersion() {


### PR DESCRIPTION
This commit reverts:
- f30c18c77084acc46f5f0fad6969009be9972423
- 07436bdb4c396874ccad39e5f346c4b6f2ab1a8a

We have difficulties updating `deno_core` and `deno` to use V8 12.3
because of potential bug in named property handler for `globalThis`
(see https://github.com/denoland/rusty_v8/pull/1412).

We're reverting to tracking `12.2` branch for the time being to unblock
other work needed.