### PR TITLE
fix: mispelling in C binding

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -203,7 +203,7 @@ extern "C" {
     context: *const Context,
     key: *const Name,
   ) -> *const Value;
-  fn v8__Object__GetRealNamedPropertyAttribute(
+  fn v8__Object__GetRealNamedPropertyAttributes(
     this: *const Object,
     context: *const Context,
     key: *const Name,
@@ -870,7 +870,7 @@ impl Object {
   ) -> Option<PropertyAttribute> {
     let mut out = Maybe::<PropertyAttribute>::default();
     unsafe {
-      v8__Object__GetRealNamedPropertyAttribute(
+      v8__Object__GetRealNamedPropertyAttributes(
         self,
         &*scope.get_current_context(),
         &*key,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -6968,7 +6968,9 @@ fn get_property_attributes() {
   assert!(attrs.is_none());
   let real_prop = obj.get_real_named_property(scope, key.into()).unwrap();
   assert!(real_prop.is_number());
-  let real_prop_attrs = obj.get_real_named_property_attributes(scope, key.into()).unwrap();
+  let real_prop_attrs = obj
+    .get_real_named_property_attributes(scope, key.into())
+    .unwrap();
   assert!(!real_prop_attrs.is_read_only());
   assert!(!real_prop_attrs.is_dont_enum());
   assert!(!real_prop_attrs.is_dont_delete());

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -6966,6 +6966,13 @@ fn get_property_attributes() {
   assert!(!attrs.is_dont_enum());
   assert!(!attrs.is_dont_delete());
   assert!(attrs.is_none());
+  let real_prop = obj.get_real_named_property(scope, key.into()).unwrap();
+  assert!(real_prop.is_number());
+  let real_prop_attrs = obj.get_real_named_property_attributes(scope, key.into()).unwrap();
+  assert!(!real_prop_attrs.is_read_only());
+  assert!(!real_prop_attrs.is_dont_enum());
+  assert!(!real_prop_attrs.is_dont_delete());
+  assert!(real_prop_attrs.is_none());
 
   // doesn't exist
   let key = v8::String::new(scope, "b").unwrap();


### PR DESCRIPTION
I made a mistake in https://github.com/denoland/rusty_v8/pull/1428.

Added some tests.