### PR TITLE
chore: Allow Rust ASAN flags to propagate into v8 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           # Is there a better way to install this tool?
           curl -O http://commondatastorage.googleapis.com/chromium-browser-clang-staging/Mac/dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
           tar -C tools/clang/dsymutil/ -xvzf dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
-          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --lib --bins -vv --target ${{ matrix.config.target }}
+          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --lib --bins --tests -vv --target ${{ matrix.config.target }}
 
       - name: Test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,18 @@ jobs:
           . $basename/sccache --start-server
           echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Install Rust (nightly)
+        uses: dtolnay/rust-toolchain@nightly
+        if: matrix.config.variant == 'debug' && runner.os == 'macOS'
+
+      - name: Test (ASAN)
+        env:
+          SCCACHE_IDLE_TIMEOUT: 0
+        if: matrix.config.variant == 'debug' && runner.os == 'macOS'
+        # https://github.com/rust-lang/rust/issues/87215
+        run:
+          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --target ${{ matrix.config.target }}
+
       - name: Test
         env:
           SCCACHE_IDLE_TIMEOUT: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
         # https://github.com/rust-lang/rust/issues/87215
         run: |
           rustup component add rust-src --toolchain nightly-${{ matrix.config.target }}
+          # Is there a better way to install this tool?
           curl -O http://commondatastorage.googleapis.com/chromium-browser-clang-staging/Mac/dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
           tar -C tools/clang/dsymutil/ -xvzf dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
           RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --target ${{ matrix.config.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,8 @@ jobs:
         # https://github.com/rust-lang/rust/issues/87215
         run: |
           rustup component add rust-src --toolchain nightly-aarch64-apple-darwin
+          curl -O http://commondatastorage.googleapis.com/chromium-browser-clang-staging/Mac/dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
+          tar -C tools/clang/dsymutil/ -xvzf dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
           RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --target ${{ matrix.config.target }}
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
 
           - os: macos-14
             target: aarch64-apple-darwin
+            variant: asan
+
+          - os: macos-14
+            target: aarch64-apple-darwin
             variant: debug
 
           - os: macos-14
@@ -128,25 +132,6 @@ jobs:
           restore-keys:
             cargo-${{ matrix.config.target }}-${{ matrix.config.variant }}-
 
-        # It seems that the 'target' directory does not always get restored
-        # from cache correctly on MacOS. In the build log we see the following:
-        #
-        #   Fresh serde_derive v1.0.115
-        #
-        # But a little while after that Cargo aborts because 'serde_derive' is
-        # now nowhere to be found. We're not the only ones experiencing this,
-        # see https://github.com/actions-rs/cargo/issues/111.
-        #
-        #   error[E0463]: can't find crate for `serde_derive`
-        #   ##[error]   --> /Users/runner/.cargo/registry/src/github.com-
-        #       |           1ecc6299db9ec823/serde-1.0.115/src/lib.rs:285:1
-        #       |
-        #   285 | extern crate serde_derive;
-        #       | ^^^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate
-      - name: Work around MacOS + Cargo + Github Actions cache bug
-        if: runner.os == 'macOS'
-        run: cargo clean -p serde_derive
-
       - name: Install and start sccache
         shell: pwsh
         env:
@@ -176,18 +161,19 @@ jobs:
       - name: Test (ASAN)
         env:
           SCCACHE_IDLE_TIMEOUT: 0
-        if: matrix.config.variant == 'debug' && runner.os == 'macOS'
+        if: matrix.config.variant == 'asan'
         # https://github.com/rust-lang/rust/issues/87215
         run: |
           rustup component add rust-src --toolchain nightly-${{ matrix.config.target }}
           # Is there a better way to install this tool?
           curl -O http://commondatastorage.googleapis.com/chromium-browser-clang-staging/Mac/dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
           tar -C tools/clang/dsymutil/ -xvzf dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
-          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --lib -vv --target ${{ matrix.config.target }}
+          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test -vv --target ${{ matrix.config.target }}
 
       - name: Test
         env:
           SCCACHE_IDLE_TIMEOUT: 0
+        if: matrix.config.variant == 'debug' || matrix.config.variant == 'release'
         run:
           cargo test -vv --all-targets --locked ${{ env.CARGO_VARIANT_FLAG }}
           --target ${{ matrix.config.target }}
@@ -201,6 +187,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Prepare binary publish
+        if: matrix.config.variant == 'debug' || matrix.config.variant == 'release'
         run: gzip -9c
           target/${{ matrix.config.target }}/${{ matrix.config.variant }}/gn_out/obj/${{ env.LIB_NAME }}.${{ env.LIB_EXT }} >
           target/${{ env.LIB_NAME }}_${{ matrix.config.variant }}_${{ matrix.config.target }}.${{ env.LIB_EXT }}.gz &&
@@ -210,7 +197,8 @@ jobs:
         uses: softprops/action-gh-release@v0.1.15
         if: >-
           github.repository == 'denoland/rusty_v8' &&
-          startsWith(github.ref, 'refs/tags/')
+          startsWith(github.ref, 'refs/tags/') &&
+          (matrix.config.variant == 'debug' || matrix.config.variant == 'release')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           # Is there a better way to install this tool?
           curl -O http://commondatastorage.googleapis.com/chromium-browser-clang-staging/Mac/dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
           tar -C tools/clang/dsymutil/ -xvzf dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
-          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test -vv --target ${{ matrix.config.target }}
+          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --lib -vv --target ${{ matrix.config.target }}
 
       - name: Test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         if: matrix.config.variant == 'debug' && runner.os == 'macOS'
         # https://github.com/rust-lang/rust/issues/87215
         run: |
-          rustup component add rust-src --toolchain nightly-aarch64-apple-darwin
+          rustup component add rust-src --toolchain nightly-${{ matrix.config.target }}
           curl -O http://commondatastorage.googleapis.com/chromium-browser-clang-staging/Mac/dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
           tar -C tools/clang/dsymutil/ -xvzf dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
           RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --target ${{ matrix.config.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           # Is there a better way to install this tool?
           curl -O http://commondatastorage.googleapis.com/chromium-browser-clang-staging/Mac/dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
           tar -C tools/clang/dsymutil/ -xvzf dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
-          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --target ${{ matrix.config.target }}
+          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test -vv --target ${{ matrix.config.target }}
 
       - name: Test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,8 @@ jobs:
           SCCACHE_IDLE_TIMEOUT: 0
         if: matrix.config.variant == 'debug' && runner.os == 'macOS'
         # https://github.com/rust-lang/rust/issues/87215
-        run:
+        run: |
+          rustup component add rust-src --toolchain nightly-aarch64-apple-darwin
           RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --target ${{ matrix.config.target }}
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           # Is there a better way to install this tool?
           curl -O http://commondatastorage.googleapis.com/chromium-browser-clang-staging/Mac/dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
           tar -C tools/clang/dsymutil/ -xvzf dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
-          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --lib --bins --tests -vv --target ${{ matrix.config.target }}
+          V8_FROM_SOURCE=true RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --lib --bins --tests -vv --target ${{ matrix.config.target }}
 
       - name: Test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Install Rust (nightly)
         uses: dtolnay/rust-toolchain@nightly
-        if: matrix.config.variant == 'debug' && runner.os == 'macOS'
+        if: matrix.config.variant == 'asan'
 
       - name: Test (ASAN)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           # Is there a better way to install this tool?
           curl -O http://commondatastorage.googleapis.com/chromium-browser-clang-staging/Mac/dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
           tar -C tools/clang/dsymutil/ -xvzf dsymutil-llvmorg-17-init-19076-g5533fc10-1.tgz
-          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test -vv --target ${{ matrix.config.target }}
+          RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std test --lib --bins -vv --target ${{ matrix.config.target }}
 
       - name: Test
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1333,7 @@ dependencies = [
  "home",
  "miniz_oxide",
  "once_cell",
+ "rustversion",
  "trybuild",
  "which",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ exclude = [
   "!v8/tools/testrunner/utils/dump_build_config.py",
 ]
 
+[profile.dev]
+opt-level = "1"
+
 [features]
 default = ["use_custom_libcxx"]
 use_custom_libcxx = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,11 @@ exclude = [
 ]
 
 [profile.dev]
-opt-level = "1"
+# rusty_v8 may miscompile at opt-level=0.
+# https://github.com/rust-lang/rust/issues/87215
+# https://github.com/rust-lang/rust/issues/75839
+# https://github.com/rust-lang/rust/issues/121028
+opt-level = 1
 
 [features]
 default = ["use_custom_libcxx"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ fslock = "0.2"
 trybuild = "1.0.61"
 which = "5"
 home = "0"
+rustversion = "1"
 
 [[example]]
 name = "hello_world"

--- a/build.rs
+++ b/build.rs
@@ -85,7 +85,7 @@ fn main() {
   let is_asan = if let Some(rustflags) = env::var_os("CARGO_ENCODED_RUSTFLAGS")
   {
     if std::env::var_os("OPT_LEVEL").unwrap_or_default() == "0" {
-      panic!("v8 crate cannot be compiled with OPT_LEVEL=0 and ASAN. Aborting before miscompilations cause issues.");
+      panic!("v8 crate cannot be compiled with OPT_LEVEL=0 and ASAN.\nTry `[profile.dev.package.v8] opt-level = 1`.\nAborting before miscompilations cause issues.");
     }
 
     let rustflags = rustflags.to_string_lossy();

--- a/build.rs
+++ b/build.rs
@@ -991,11 +991,4 @@ edge [fontsize=10]
     assert!(files.contains("../../../example/src/count_bytes.py"));
     assert!(!files.contains("obj/hello/hello.o"));
   }
-
-  #[test]
-  fn test_static_lib_size() {
-    let static_lib_size = std::fs::metadata(static_lib_path()).unwrap().len();
-    eprintln!("static lib size {}", static_lib_size);
-    assert!(static_lib_size <= 300u64 << 20); // No more than 300 MiB.
-  }
 }

--- a/build.rs
+++ b/build.rs
@@ -84,6 +84,10 @@ fn main() {
 
   let is_asan = if let Some(rustflags) = env::var_os("CARGO_ENCODED_RUSTFLAGS")
   {
+    if std::env::var_os("OPT_LEVEL").unwrap_or_default() == "0" {
+      panic!("v8 crate cannot be compiled with OPT_LEVEL=0 and ASAN. Aborting before miscompilations cause issues.");
+    }
+
     let rustflags = rustflags.to_string_lossy();
     rustflags.find("-Z sanitizer=address").is_some()
       || rustflags.find("-Zsanitizer=address").is_some()

--- a/build.rs
+++ b/build.rs
@@ -96,7 +96,7 @@ fn main() {
   };
 
   // Build from source
-  if is_asan || env::var_os("V8_FROM_SOURCE").is_some() {
+  if env::var_os("V8_FROM_SOURCE").is_some() {
     return build_v8(is_asan);
   }
 

--- a/src/V8.rs
+++ b/src/V8.rs
@@ -67,7 +67,7 @@ enum GlobalState {
   Uninitialized,
   PlatformInitialized(SharedRef<Platform>),
   Initialized(SharedRef<Platform>),
-  Disposed(SharedRef<Platform>),
+  Disposed(#[allow(dead_code)] SharedRef<Platform>),
   PlatformShutdown,
 }
 use GlobalState::*;

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2136,19 +2136,27 @@ const v8::FunctionTemplate* v8__FunctionTemplate__New(
     v8::SideEffectType side_effect_type, void* func_ptr1,
     const v8::CFunctionInfo* c_function_info1, void* func_ptr2,
     const v8::CFunctionInfo* c_function_info2) {
-  auto overload = v8::MemorySpan<const v8::CFunction>{};
   // Support upto 2 overloads. V8 requires TypedArray to have a
   // v8::Array overload.
   if (func_ptr1) {
     if (func_ptr2 == nullptr) {
       const v8::CFunction o[] = {v8::CFunction(func_ptr1, c_function_info1)};
-      overload = v8::MemorySpan<const v8::CFunction>{o, 1};
+      auto overload = v8::MemorySpan<const v8::CFunction>{o, 1};
+      return local_to_ptr(v8::FunctionTemplate::NewWithCFunctionOverloads(
+          isolate, callback, ptr_to_local(data_or_null),
+          ptr_to_local(signature_or_null), length, constructor_behavior,
+          side_effect_type, overload));
     } else {
       const v8::CFunction o[] = {v8::CFunction(func_ptr1, c_function_info1),
                                  v8::CFunction(func_ptr2, c_function_info2)};
-      overload = v8::MemorySpan<const v8::CFunction>{o, 2};
+      auto overload = v8::MemorySpan<const v8::CFunction>{o, 2};
+      return local_to_ptr(v8::FunctionTemplate::NewWithCFunctionOverloads(
+          isolate, callback, ptr_to_local(data_or_null),
+          ptr_to_local(signature_or_null), length, constructor_behavior,
+          side_effect_type, overload));
     }
   }
+  auto overload = v8::MemorySpan<const v8::CFunction>{};
   return local_to_ptr(v8::FunctionTemplate::NewWithCFunctionOverloads(
       isolate, callback, ptr_to_local(data_or_null),
       ptr_to_local(signature_or_null), length, constructor_behavior,

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -1290,15 +1290,16 @@ impl Isolate {
     {
       let mut callback = NonNull::<F>::new_unchecked(arg as _);
       if size > 0 {
-        let slice = unsafe { std::slice::from_raw_parts(data, size) };
-        (callback.as_mut())(slice)
+        (callback.as_mut())(std::slice::from_raw_parts(data, size))
       } else {
         (callback.as_mut())(&[])
       }
     }
 
     let arg = addr_of_mut!(callback);
-    unsafe { v8__HeapProfiler__TakeHeapSnapshot(self, trampoline::<F>, arg) }
+    unsafe {
+      v8__HeapProfiler__TakeHeapSnapshot(self, trampoline::<F>, arg as _)
+    }
   }
 
   /// Set the default context to be included in the snapshot blob.

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -2220,7 +2220,7 @@ mod tests {
   /// assigning a value to a variable with an explicitly stated type is that the
   /// latter allows coercions and dereferencing to change the type, whereas
   /// `AssertTypeOf` requires the compared types to match exactly.
-  struct AssertTypeOf<'a, T>(pub &'a T);
+  struct AssertTypeOf<'a, T>(#[allow(dead_code)] &'a T);
   impl<'a, T> AssertTypeOf<'a, T> {
     pub fn is<A>(self)
     where

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8692,7 +8692,9 @@ fn icu_date() {
 
 #[test]
 fn icu_set_common_data_fail() {
-  assert!(v8::icu::set_common_data_73(&[1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0]).is_err());
+  assert!(
+    v8::icu::set_common_data_73(&[1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0]).is_err()
+  );
 }
 
 #[test]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8690,10 +8690,9 @@ fn icu_date() {
   }
 }
 
-#[ignore]
 #[test]
 fn icu_set_common_data_fail() {
-  assert!(v8::icu::set_common_data_73(&[1, 2, 3]).is_err());
+  assert!(v8::icu::set_common_data_73(&[1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0]).is_err());
 }
 
 #[test]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -11,7 +11,7 @@ use std::ffi::CStr;
 use std::hash::Hash;
 use std::mem::MaybeUninit;
 use std::os::raw::c_char;
-use std::ptr::{addr_of, NonNull};
+use std::ptr::{addr_of, addr_of_mut, NonNull};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -8381,7 +8381,7 @@ fn clear_kept_objects() {
 #[test]
 fn wasm_streaming_callback() {
   thread_local! {
-    static WS: RefCell<Option<v8::WasmStreaming>> = RefCell::new(None);
+    static WS: RefCell<Option<v8::WasmStreaming>> = const { RefCell::new(None) };
   }
 
   let callback = |scope: &mut v8::HandleScope,
@@ -8593,7 +8593,7 @@ fn oom_callback() {
 #[test]
 fn prepare_stack_trace_callback() {
   thread_local! {
-    static SITES: RefCell<Option<v8::Global<v8::Array>>> = RefCell::new(None);
+    static SITES: RefCell<Option<v8::Global<v8::Array>>> = const { RefCell::new(None) };
   }
 
   let script = r#"
@@ -8690,6 +8690,7 @@ fn icu_date() {
   }
 }
 
+#[ignore]
 #[test]
 fn icu_set_common_data_fail() {
   assert!(v8::icu::set_common_data_73(&[1, 2, 3]).is_err());
@@ -10578,7 +10579,7 @@ fn test_fast_calls_callback_options_data() {
 
   let global = context.global(scope);
   let external =
-    v8::External::new(scope, unsafe { &mut DATA as *mut bool as *mut c_void });
+    v8::External::new(scope, unsafe { addr_of_mut!(DATA) as *mut c_void });
 
   let template = v8::FunctionTemplate::builder(slow_fn)
     .data(external.into())

--- a/tests/test_ui.rs
+++ b/tests/test_ui.rs
@@ -1,4 +1,4 @@
-// Don't run UI tests on emulated environment.
+// Don't run UI tests on emulated environment or nightly build.
 #[cfg(not(target_os = "android"))]
 #[rustversion::attr(not(nightly), test)]
 fn ui() {

--- a/tests/test_ui.rs
+++ b/tests/test_ui.rs
@@ -1,6 +1,6 @@
 // Don't run UI tests on emulated environment.
 #[cfg(not(target_os = "android"))]
-#[test]
+#[rustversion::attr(not(nightly), test)]
 fn ui() {
   // This environment variable tells build.rs that we're running trybuild tests,
   // so it won't rebuild V8.


### PR DESCRIPTION
Runs ASAN on every build as part of the Mac runs. I wasn't able to get this working for Linux :/ 

 - Requires fixing +nightly warnings.
 - One ASAN issue found: fast functions w/an overload were accessing the stack after a scope was destroyed.