### PR TITLE
Add Drop impl for CFunctionInfo

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2129,6 +2129,8 @@ v8::CFunctionInfo* v8__CFunctionInfo__New(
   return info.release();
 }
 
+void v8__CFunctionInfo__DELETE(v8::CFunctionInfo* self) { delete self; }
+
 const v8::FunctionTemplate* v8__FunctionTemplate__New(
     v8::Isolate* isolate, v8::FunctionCallback callback,
     const v8::Value* data_or_null, const v8::Signature* signature_or_null,

--- a/src/fast_api.rs
+++ b/src/fast_api.rs
@@ -19,6 +19,7 @@ extern "C" {
     args_info: *const CTypeInfo,
     repr: Int64Representation,
   ) -> *mut CFunctionInfo;
+  fn v8__CFunctionInfo__DELETE(this: &mut CFunctionInfo);
 }
 
 #[repr(C)]
@@ -43,6 +44,12 @@ impl CFunctionInfo {
       args,
       repr,
     ))
+  }
+}
+
+impl Drop for CFunctionInfo {
+  fn drop(&mut self) {
+    unsafe { v8__CFunctionInfo__DELETE(self) };
   }
 }
 


### PR DESCRIPTION
This deallocates the C++ allocation, preventing a memory leak