### PR TITLE
Impl Drop for CTypeInfo

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2107,6 +2107,8 @@ v8::CTypeInfo* v8__CTypeInfo__New(v8::CTypeInfo::Type ty) {
   return u.release();
 }
 
+void v8__CTypeInfo__DELETE(v8::CTypeInfo* self) { delete self; }
+
 struct CTypeSequenceType {
   v8::CTypeInfo::Type c_type;
   v8::CTypeInfo::SequenceType sequence_type;

--- a/src/fast_api.rs
+++ b/src/fast_api.rs
@@ -13,6 +13,7 @@ extern "C" {
     len: usize,
     tys: *const CTypeSequenceInfo,
   ) -> *mut CTypeInfo;
+  fn v8__CTypeInfo__DELETE(this: &mut CTypeInfo);
   fn v8__CFunctionInfo__New(
     return_info: *const CTypeInfo,
     args_len: usize,
@@ -69,6 +70,12 @@ impl CTypeInfo {
         structs.as_ptr(),
       ))
     }
+  }
+}
+
+impl Drop for CTypeInfo {
+  fn drop(&mut self) {
+    unsafe { v8__CTypeInfo__DELETE(self) };
   }
 }
 


### PR DESCRIPTION
This deallocates the C++ allocation, preventing a memory leak