### PR TITLE
chore: Fixed incorrect use of cfg! macro and update build.rs to support arm target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
         !contains(github.event.pull_request.labels.*.name, 'no-fail-fast') }}
       matrix:
         config:
-          - os: macOS-latest
+          - os: macos-12
             target: x86_64-apple-darwin
             variant: debug
             cargo: cargo
 
-          - os: macOS-latest
+          - os: macos-12
             target: x86_64-apple-darwin
             variant: release
             cargo: cargo

--- a/build.rs
+++ b/build.rs
@@ -200,7 +200,7 @@ fn build_v8(is_asan: bool) {
     maybe_install_sysroot("arm64");
     maybe_install_sysroot("amd64");
   }
-  if target_arch == "arm"{
+  if target_arch == "arm" {
     gn_args.push(r#"target_cpu="arm""#.to_string());
     gn_args.push(r#"v8_target_cpu="arm""#.to_string());
     gn_args.push("use_sysroot=true".to_string());
@@ -290,9 +290,26 @@ fn maybe_install_sysroot(arch: &str) {
   }
 }
 
-fn platform() -> String {
-  let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-  let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+fn host_platform() -> String {
+  let os = if cfg!(target_os = "linux") {
+    "linux"
+  } else if cfg!(target_os = "macos") {
+    "mac"
+  } else if cfg!(target_os = "windows") {
+    "windows"
+  } else {
+    "unknown"
+  };
+
+  let arch = if cfg!(target_arch = "x86_64") {
+    "amd64"
+  } else if cfg!(target_arch = "aarch64") {
+    "arm64"
+  } else if cfg!(target_arch = "arm") {
+    "arm"
+  } else {
+    "unknown"
+  };
   format!("{os}-{arch}")
 }
 
@@ -300,7 +317,7 @@ fn download_ninja_gn_binaries() {
   let target_dir = build_dir();
   let bin_dir = target_dir
     .join("ninja_gn_binaries-20221218")
-    .join(platform());
+    .join(host_platform());
   let gn = bin_dir.join("gn");
   let ninja = bin_dir.join("ninja");
   #[cfg(windows)]

--- a/build.rs
+++ b/build.rs
@@ -137,6 +137,10 @@ fn build_v8(is_asan: bool) {
   if need_gn_ninja_download() {
     download_ninja_gn_binaries();
   }
+  // `#[cfg(...)]` attributes don't work as expected from build.rs -- they refer to the configuration
+  // of the host system which the build.rs script will be running on. In short, `cfg!(target_<os/arch>)`
+  // is actually the host os/arch instead of target os/arch while cross compiling. Instead, Environment variables
+  // are the officially approach to get the target os/arch in build.rs.
   let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
   let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
   // On windows, rustc cannot link with a V8 debug build.

--- a/build.rs
+++ b/build.rs
@@ -149,7 +149,7 @@ fn build_v8(is_asan: bool) {
   if is_asan {
     gn_args.push("is_asan=true".to_string());
   }
-  if let Err(_) = env::var("CARGO_FEATURE_USE_CUSTOM_LIBCXX") {
+  if env::var("CARGO_FEATURE_USE_CUSTOM_LIBCXX").is_err() {
     gn_args.push("use_custom_libcxx=false".to_string());
   }
 
@@ -210,29 +210,26 @@ fn build_v8(is_asan: bool) {
 
   let target_triple = env::var("TARGET").unwrap();
   // check if the target triple describes a non-native environment
-  if target_triple != env::var("HOST").unwrap() {
-    if target_os == "android" {
-      let arch = if target_arch == "x86_64" {
-        "x64"
-      } else if target_arch == "aarch64" {
-        "arm64"
-      } else {
-        "unknown"
-      };
+  if target_triple != env::var("HOST").unwrap() && target_os == "android" {
+    let arch = if target_arch == "x86_64" {
+      "x64"
+    } else if target_arch == "aarch64" {
+      "arm64"
+    } else {
+      "unknown"
+    };
+    if target_arch == "x86_64" {
+      maybe_install_sysroot("amd64");
+    }
+    gn_args.push(format!(r#"v8_target_cpu="{}""#, arch).to_string());
+    gn_args.push(format!(r#"target_cpu="{}""#, arch).to_string());
+    gn_args.push(r#"target_os="android""#.to_string());
+    gn_args.push("treat_warnings_as_errors=false".to_string());
+    gn_args.push("use_sysroot=true".to_string());
 
-      if target_arch == "x86_64" {
-        maybe_install_sysroot("amd64");
-      }
-
-      gn_args.push(format!(r#"v8_target_cpu="{}""#, arch).to_string());
-      gn_args.push(format!(r#"target_cpu="{}""#, arch).to_string());
-      gn_args.push(r#"target_os="android""#.to_string());
-      gn_args.push("treat_warnings_as_errors=false".to_string());
-      gn_args.push("use_sysroot=true".to_string());
-
-      // NDK 23 and above removes libgcc entirely.
-      // https://github.com/rust-lang/rust/pull/85806
-      if !Path::new("./third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang++").exists() {
+    // NDK 23 and above removes libgcc entirely.
+    // https://github.com/rust-lang/rust/pull/85806
+    if !Path::new("./third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang++").exists() {
         assert!(Command::new("curl")
         .arg("-L")
         .arg("-o").arg("./third_party/android-ndk-r26c-linux.zip")
@@ -253,21 +250,18 @@ fn build_v8(is_asan: bool) {
         fs::rename("./third_party/android-ndk-r26c", "./third_party/android_ndk").unwrap();
         fs::remove_file("./third_party/android-ndk-r26c-linux.zip").unwrap();
       }
-
-      static CHROMIUM_URI: &str = "https://chromium.googlesource.com";
-
-      maybe_clone_repo(
-        "./third_party/android_platform",
-        &format!(
-          "{}/chromium/src/third_party/android_platform.git",
-          CHROMIUM_URI
-        ),
-      );
-      maybe_clone_repo(
-        "./third_party/catapult",
-        &format!("{}/catapult.git", CHROMIUM_URI),
-      );
-    };
+    static CHROMIUM_URI: &str = "https://chromium.googlesource.com";
+    maybe_clone_repo(
+      "./third_party/android_platform",
+      &format!(
+        "{}/chromium/src/third_party/android_platform.git",
+        CHROMIUM_URI
+      ),
+    );
+    maybe_clone_repo(
+      "./third_party/catapult",
+      &format!("{}/catapult.git", CHROMIUM_URI),
+    );
   }
 
   if target_triple.starts_with("i686-") {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,12 @@
 [toolchain]
 channel = "1.76.0"
 components = ["rustfmt", "clippy"]
+targets = [
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "aarch64-linux-android",
+    "x86_64-linux-android",
+]


### PR DESCRIPTION
## What I've done
1. [Fixed incorrect use of cfg! macro](https://github.com/denoland/rusty_v8/commit/328f31f5a197476b3475bbcd5383cdc08364c863) use the `CARGO_CFG_TARGET_<OS/ARCH>` macro instead of the original `cfg! (target_<os/arch>)` This is because The build script is compiled for the host architecture as a separate build phase, as that's where it runs. Since the cfg macro runs at compile time it'll always report the host configuration there.When cargo runs the build script it passes the configuration through [environment variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts), one of which is `CARGO_CFG_TARGET_ARCH`. Some dicussions can be found [here](https://users.rust-lang.org/t/failed-to-detect-target-arch-in-build-rs-file/109938/3)

2. [update build.rs to support arm target](https://github.com/denoland/rusty_v8/commit/3342536158c2886eaccc82e037bbb35d5c0d718e) support arm target. Like the Aarch64 target, we need to additionally install the cross-compilation toolchain and specify the linker in Cargo/config.toml. I can add this part of the work in next pull request if necessary.