### PR TITLE
fix: Re-enable pointer compression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
         !contains(github.event.pull_request.labels.*.name, 'no-fail-fast') }}
       matrix:
         config:
-          - os: macOS-latest
+          - os: macOS-13
             target: x86_64-apple-darwin
             variant: debug
             cargo: cargo
 
-          - os: macOS-latest
+          - os: macOS-13
             target: x86_64-apple-darwin
             variant: release
             cargo: cargo

--- a/.gn
+++ b/.gn
@@ -59,12 +59,6 @@ default_args = {
   # compile.
   v8_enable_verify_heap = false
 
-  # V8 introduced a bug in 11.1 that causes the External Pointer Table to never
-  # be cleaned which causes resource exhaustion. Disabling pointer compression
-  # makes sure that the EPT is not used.
-  # https://bugs.chromium.org/p/v8/issues/detail?id=13640&q=garbage%20collection&can=2
-  v8_enable_pointer_compression = false
-
   # Maglev *should* be supported when pointer compression is disabled as per
   # https://chromium-review.googlesource.com/c/v8/v8/+/4753150, but it still
   # fails to compile.

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3229,6 +3229,14 @@ void v8__HeapProfiler__TakeHeapSnapshot(v8::Isolate* isolate,
   const_cast<v8::HeapSnapshot*>(snapshot)->Delete();
 }
 
+// This is necessary for v8__internal__GetIsolateFromHeapObject() to be
+// reliable enough for our purposes.
+#if UINTPTR_MAX == 0xffffffffffffffff && \
+    !(defined V8_SHARED_RO_HEAP or defined V8_COMPRESS_POINTERS)
+#error V8 must be built with either the 'v8_enable_pointer_compression' or \
+'v8_enable_shared_ro_heap' feature enabled.
+#endif
+
 v8::Isolate* v8__internal__GetIsolateFromHeapObject(const v8::Data& data) {
   namespace i = v8::internal;
   i::Tagged<i::Object> object(reinterpret_cast<const i::Address&>(data));

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8514,7 +8514,7 @@ fn ept_torture_test() {
     let source = v8::String::new(
       scope,
       r#"
-        for(let i = 0; i < 1_000_000; i++) new ArrayBuffer(1024 * 1024);
+        for(let i = 0; i < 100_000; i++) new ArrayBuffer(1024 * 1024);
         "OK";
       "#,
     )

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8502,6 +8502,30 @@ fn unbound_script_conversion() {
 }
 
 #[test]
+fn ept_torture_test() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  // This should not OOM or crash when we run in a tight loop as the EPT should be subject
+  // to GC.
+  {
+    let scope = &mut v8::HandleScope::new(isolate);
+    let context = v8::Context::new(scope);
+    let scope = &mut v8::ContextScope::new(scope, context);
+    let source = v8::String::new(
+      scope,
+      r#"
+        for(let i = 0; i < 1_000_000; i++) new ArrayBuffer(1024 * 1024);
+        "OK";
+      "#,
+    )
+    .unwrap();
+    let script = v8::Script::compile(scope, source, None).unwrap();
+    let result = script.run(scope).unwrap();
+    assert_eq!(result.to_rust_string_lossy(scope), "OK");
+  }
+}
+
+#[test]
 fn run_with_rust_allocator() {
   use std::sync::Arc;
 


### PR DESCRIPTION
Re-land pointer compression now that @wingo's external pointer table GC changeset has landed.

Reverts https://github.com/denoland/rusty_v8/pull/1302 / https://github.com/denoland/rusty_v8/pull/1214

