### PR TITLE
chore: Update use of deprecated APIs

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1218,25 +1218,26 @@ void v8__ObjectTemplate__SetInternalFieldCount(const v8::ObjectTemplate& self,
   ptr_to_local(&self)->SetInternalFieldCount(value);
 }
 
-void v8__ObjectTemplate__SetAccessor(const v8::ObjectTemplate& self,
-                                     const v8::Name& key,
-                                     v8::AccessorNameGetterCallback getter,
-                                     v8::AccessorNameSetterCallback setter,
-                                     const v8::Value* data_or_null,
-                                     v8::PropertyAttribute attr) {
-  ptr_to_local(&self)->SetAccessor(ptr_to_local(&key), getter, setter,
-                                   ptr_to_local(data_or_null), attr);
+void v8__ObjectTemplate__SetNativeDataProperty(
+  const v8::ObjectTemplate& self,
+  const v8::Name& key,
+  v8::AccessorNameGetterCallback getter,
+  v8::AccessorNameSetterCallback setter,
+  const v8::Value* data_or_null,
+  v8::PropertyAttribute attr) {
+    ptr_to_local(&self)->SetNativeDataProperty(ptr_to_local(&key),
+      getter, setter, ptr_to_local(data_or_null), attr);
 }
 
 void v8__ObjectTemplate__SetNamedPropertyHandler(
     const v8::ObjectTemplate& self,
-    v8::GenericNamedPropertyGetterCallback getter,
-    v8::GenericNamedPropertySetterCallback setter,
-    v8::GenericNamedPropertyQueryCallback query,
-    v8::GenericNamedPropertyDeleterCallback deleter,
-    v8::GenericNamedPropertyEnumeratorCallback enumerator,
-    v8::GenericNamedPropertyDefinerCallback definer,
-    v8::GenericNamedPropertyDescriptorCallback descriptor,
+    v8::NamedPropertyGetterCallback getter,
+    v8::NamedPropertySetterCallback setter,
+    v8::NamedPropertyQueryCallback query,
+    v8::NamedPropertyDeleterCallback deleter,
+    v8::NamedPropertyEnumeratorCallback enumerator,
+    v8::NamedPropertyDefinerCallback definer,
+    v8::NamedPropertyDescriptorCallback descriptor,
     const v8::Value* data_or_null, v8::PropertyHandlerFlags flags) {
   ptr_to_local(&self)->SetHandler(v8::NamedPropertyHandlerConfiguration(
       getter, setter, query, deleter, enumerator, definer, descriptor,

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1245,13 +1245,13 @@ void v8__ObjectTemplate__SetNamedPropertyHandler(
 }
 
 void v8__ObjectTemplate__SetIndexedPropertyHandler(
-    const v8::ObjectTemplate& self, v8::IndexedPropertyGetterCallback getter,
-    v8::IndexedPropertySetterCallback setter,
-    v8::IndexedPropertyQueryCallback query,
-    v8::IndexedPropertyDeleterCallback deleter,
+    const v8::ObjectTemplate& self, v8::IndexedPropertyGetterCallbackV2 getter,
+    v8::IndexedPropertySetterCallbackV2 setter,
+    v8::IndexedPropertyQueryCallbackV2 query,
+    v8::IndexedPropertyDeleterCallbackV2 deleter,
     v8::IndexedPropertyEnumeratorCallback enumerator,
-    v8::IndexedPropertyDefinerCallback definer,
-    v8::IndexedPropertyDescriptorCallback descriptor,
+    v8::IndexedPropertyDefinerCallbackV2 definer,
+    v8::IndexedPropertyDescriptorCallbackV2 descriptor,
     const v8::Value* data_or_null, v8::PropertyHandlerFlags flags) {
   ptr_to_local(&self)->SetHandler(v8::IndexedPropertyHandlerConfiguration(
       getter, setter, query, deleter, enumerator, definer, descriptor,

--- a/src/external_references.rs
+++ b/src/external_references.rs
@@ -6,9 +6,9 @@ use crate::IndexedDefinerCallback;
 use crate::IndexedGetterCallback;
 use crate::IndexedSetterCallback;
 use crate::MessageCallback;
-use crate::NamedDefinerCallback;
-use crate::NamedGetterCallback;
-use crate::NamedSetterCallback;
+use crate::NamedDefinerCallbackNew;
+use crate::NamedGetterCallbackNew;
+use crate::NamedSetterCallbackNew;
 use crate::PropertyEnumeratorCallback;
 use std::ffi::c_void;
 use std::fmt::Debug;
@@ -16,9 +16,9 @@ use std::fmt::Debug;
 #[derive(Clone, Copy)]
 pub union ExternalReference<'s> {
   pub function: FunctionCallback,
-  pub named_getter: NamedGetterCallback<'s>,
-  pub named_setter: NamedSetterCallback<'s>,
-  pub named_definer: NamedDefinerCallback<'s>,
+  pub named_getter: NamedGetterCallbackNew<'s>,
+  pub named_setter: NamedSetterCallbackNew<'s>,
+  pub named_definer: NamedDefinerCallbackNew<'s>,
   pub indexed_getter: IndexedGetterCallback<'s>,
   pub indexed_setter: IndexedSetterCallback<'s>,
   pub indexed_definer: IndexedDefinerCallback<'s>,

--- a/src/external_references.rs
+++ b/src/external_references.rs
@@ -6,9 +6,9 @@ use crate::IndexedDefinerCallback;
 use crate::IndexedGetterCallback;
 use crate::IndexedSetterCallback;
 use crate::MessageCallback;
-use crate::NamedDefinerCallbackNew;
-use crate::NamedGetterCallbackNew;
-use crate::NamedSetterCallbackNew;
+use crate::NamedDefinerCallback;
+use crate::NamedGetterCallback;
+use crate::NamedSetterCallback;
 use crate::PropertyEnumeratorCallback;
 use std::ffi::c_void;
 use std::fmt::Debug;
@@ -16,9 +16,9 @@ use std::fmt::Debug;
 #[derive(Clone, Copy)]
 pub union ExternalReference<'s> {
   pub function: FunctionCallback,
-  pub named_getter: NamedGetterCallbackNew<'s>,
-  pub named_setter: NamedSetterCallbackNew<'s>,
-  pub named_definer: NamedDefinerCallbackNew<'s>,
+  pub named_getter: NamedGetterCallback<'s>,
+  pub named_setter: NamedSetterCallback<'s>,
+  pub named_definer: NamedDefinerCallback<'s>,
   pub indexed_getter: IndexedGetterCallback<'s>,
   pub indexed_setter: IndexedSetterCallback<'s>,
   pub indexed_definer: IndexedDefinerCallback<'s>,

--- a/src/function.rs
+++ b/src/function.rs
@@ -3,7 +3,6 @@ use std::marker::PhantomData;
 use std::ptr::null;
 use std::ptr::NonNull;
 
-use crate::template::Intercepted;
 use crate::scope::CallbackScope;
 use crate::script_compiler::CachedData;
 use crate::support::MapFnFrom;
@@ -11,6 +10,7 @@ use crate::support::MapFnTo;
 use crate::support::ToCFn;
 use crate::support::UnitType;
 use crate::support::{int, Opaque};
+use crate::template::Intercepted;
 use crate::Context;
 use crate::Function;
 use crate::HandleScope;
@@ -569,10 +569,10 @@ where
   }
 }
 
-pub(crate) type NamedGetterCallbackNew<'s> =
+pub(crate) type NamedGetterCallback<'s> =
   extern "C" fn(Local<'s, Name>, *const PropertyCallbackInfo) -> Intercepted;
 
-impl<F> MapFnFrom<F> for NamedGetterCallbackNew<'_>
+impl<F> MapFnFrom<F> for NamedGetterCallback<'_>
 where
   F: UnitType
     + for<'s> Fn(
@@ -622,13 +622,13 @@ where
   }
 }
 
-pub(crate) type NamedSetterCallbackNew<'s> = extern "C" fn(
+pub(crate) type NamedSetterCallback<'s> = extern "C" fn(
   Local<'s, Name>,
   Local<'s, Value>,
   *const PropertyCallbackInfo,
 ) -> Intercepted;
 
-impl<F> MapFnFrom<F> for NamedSetterCallbackNew<'_>
+impl<F> MapFnFrom<F> for NamedSetterCallback<'_>
 where
   F: UnitType
     + for<'s> Fn(
@@ -674,13 +674,13 @@ where
   }
 }
 
-pub(crate) type NamedDefinerCallbackNew<'s> = extern "C" fn(
+pub(crate) type NamedDefinerCallback<'s> = extern "C" fn(
   Local<'s, Name>,
   *const PropertyDescriptor,
   *const PropertyCallbackInfo,
 ) -> Intercepted;
 
-impl<F> MapFnFrom<F> for NamedDefinerCallbackNew<'_>
+impl<F> MapFnFrom<F> for NamedDefinerCallback<'_>
 where
   F: UnitType
     + for<'s> Fn(

--- a/src/function.rs
+++ b/src/function.rs
@@ -707,7 +707,7 @@ where
 }
 
 pub(crate) type IndexedGetterCallback<'s> =
-  extern "C" fn(u32, *const PropertyCallbackInfo);
+  extern "C" fn(u32, *const PropertyCallbackInfo) -> Intercepted;
 
 impl<F> MapFnFrom<F> for IndexedGetterCallback<'_>
 where
@@ -717,7 +717,7 @@ where
       u32,
       PropertyCallbackArguments<'s>,
       ReturnValue,
-    ),
+    ) -> Intercepted,
 {
   fn mapping() -> Self {
     let f = |index: u32, info: *const PropertyCallbackInfo| {
@@ -725,14 +725,17 @@ where
       let scope = &mut unsafe { CallbackScope::new(info) };
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
-      (F::get())(scope, index, args, rv);
+      (F::get())(scope, index, args, rv)
     };
     f.to_c_fn()
   }
 }
 
-pub(crate) type IndexedSetterCallback<'s> =
-  extern "C" fn(u32, Local<'s, Value>, *const PropertyCallbackInfo);
+pub(crate) type IndexedSetterCallback<'s> = extern "C" fn(
+  u32,
+  Local<'s, Value>,
+  *const PropertyCallbackInfo,
+) -> Intercepted;
 
 impl<F> MapFnFrom<F> for IndexedSetterCallback<'_>
 where
@@ -743,7 +746,7 @@ where
       Local<'s, Value>,
       PropertyCallbackArguments<'s>,
       ReturnValue,
-    ),
+    ) -> Intercepted,
 {
   fn mapping() -> Self {
     let f =
@@ -752,14 +755,17 @@ where
         let scope = &mut unsafe { CallbackScope::new(info) };
         let args = PropertyCallbackArguments::from_property_callback_info(info);
         let rv = ReturnValue::from_property_callback_info(info);
-        (F::get())(scope, index, value, args, rv);
+        (F::get())(scope, index, value, args, rv)
       };
     f.to_c_fn()
   }
 }
 
-pub(crate) type IndexedDefinerCallback<'s> =
-  extern "C" fn(u32, *const PropertyDescriptor, *const PropertyCallbackInfo);
+pub(crate) type IndexedDefinerCallback<'s> = extern "C" fn(
+  u32,
+  *const PropertyDescriptor,
+  *const PropertyCallbackInfo,
+) -> Intercepted;
 
 impl<F> MapFnFrom<F> for IndexedDefinerCallback<'_>
 where
@@ -770,7 +776,7 @@ where
       &PropertyDescriptor,
       PropertyCallbackArguments<'s>,
       ReturnValue,
-    ),
+    ) -> Intercepted,
 {
   fn mapping() -> Self {
     let f = |index: u32,
@@ -781,7 +787,7 @@ where
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
       let desc = unsafe { &*desc };
-      (F::get())(scope, index, desc, args, rv);
+      (F::get())(scope, index, desc, args, rv)
     };
     f.to_c_fn()
   }

--- a/src/function.rs
+++ b/src/function.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use std::ptr::null;
 use std::ptr::NonNull;
 
+use crate::template::Intercepted;
 use crate::scope::CallbackScope;
 use crate::script_compiler::CachedData;
 use crate::support::MapFnFrom;
@@ -543,10 +544,10 @@ where
   }
 }
 
-pub(crate) type NamedGetterCallback<'s> =
+pub(crate) type NamedGetterCallbackForAccessor<'s> =
   extern "C" fn(Local<'s, Name>, *const PropertyCallbackInfo);
 
-impl<F> MapFnFrom<F> for NamedGetterCallback<'_>
+impl<F> MapFnFrom<F> for NamedGetterCallbackForAccessor<'_>
 where
   F: UnitType
     + for<'s> Fn(
@@ -568,10 +569,35 @@ where
   }
 }
 
-pub(crate) type NamedSetterCallback<'s> =
+pub(crate) type NamedGetterCallbackNew<'s> =
+  extern "C" fn(Local<'s, Name>, *const PropertyCallbackInfo) -> Intercepted;
+
+impl<F> MapFnFrom<F> for NamedGetterCallbackNew<'_>
+where
+  F: UnitType
+    + for<'s> Fn(
+      &mut HandleScope<'s>,
+      Local<'s, Name>,
+      PropertyCallbackArguments<'s>,
+      ReturnValue,
+    ) -> Intercepted,
+{
+  fn mapping() -> Self {
+    let f = |key: Local<Name>, info: *const PropertyCallbackInfo| {
+      let info = unsafe { &*info };
+      let scope = &mut unsafe { CallbackScope::new(info) };
+      let args = PropertyCallbackArguments::from_property_callback_info(info);
+      let rv = ReturnValue::from_property_callback_info(info);
+      (F::get())(scope, key, args, rv)
+    };
+    f.to_c_fn()
+  }
+}
+
+pub(crate) type NamedSetterCallbackForAccessor<'s> =
   extern "C" fn(Local<'s, Name>, Local<'s, Value>, *const PropertyCallbackInfo);
 
-impl<F> MapFnFrom<F> for NamedSetterCallback<'_>
+impl<F> MapFnFrom<F> for NamedSetterCallbackForAccessor<'_>
 where
   F: UnitType
     + for<'s> Fn(
@@ -591,6 +617,37 @@ where
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
       (F::get())(scope, key, value, args, rv);
+    };
+    f.to_c_fn()
+  }
+}
+
+pub(crate) type NamedSetterCallbackNew<'s> = extern "C" fn(
+  Local<'s, Name>,
+  Local<'s, Value>,
+  *const PropertyCallbackInfo,
+) -> Intercepted;
+
+impl<F> MapFnFrom<F> for NamedSetterCallbackNew<'_>
+where
+  F: UnitType
+    + for<'s> Fn(
+      &mut HandleScope<'s>,
+      Local<'s, Name>,
+      Local<'s, Value>,
+      PropertyCallbackArguments<'s>,
+      ReturnValue,
+    ) -> Intercepted,
+{
+  fn mapping() -> Self {
+    let f = |key: Local<Name>,
+             value: Local<Value>,
+             info: *const PropertyCallbackInfo| {
+      let info = unsafe { &*info };
+      let scope = &mut unsafe { CallbackScope::new(info) };
+      let args = PropertyCallbackArguments::from_property_callback_info(info);
+      let rv = ReturnValue::from_property_callback_info(info);
+      (F::get())(scope, key, value, args, rv)
     };
     f.to_c_fn()
   }
@@ -617,13 +674,13 @@ where
   }
 }
 
-pub(crate) type NamedDefinerCallback<'s> = extern "C" fn(
+pub(crate) type NamedDefinerCallbackNew<'s> = extern "C" fn(
   Local<'s, Name>,
   *const PropertyDescriptor,
   *const PropertyCallbackInfo,
-);
+) -> Intercepted;
 
-impl<F> MapFnFrom<F> for NamedDefinerCallback<'_>
+impl<F> MapFnFrom<F> for NamedDefinerCallbackNew<'_>
 where
   F: UnitType
     + for<'s> Fn(
@@ -632,7 +689,7 @@ where
       &PropertyDescriptor,
       PropertyCallbackArguments<'s>,
       ReturnValue,
-    ),
+    ) -> Intercepted,
 {
   fn mapping() -> Self {
     let f = |key: Local<Name>,
@@ -643,7 +700,7 @@ where
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let desc = unsafe { &*desc };
       let rv = ReturnValue::from_property_callback_info(info);
-      (F::get())(scope, key, desc, args, rv);
+      (F::get())(scope, key, desc, args, rv)
     };
     f.to_c_fn()
   }

--- a/src/template.rs
+++ b/src/template.rs
@@ -19,9 +19,11 @@ use crate::IndexedDefinerCallback;
 use crate::IndexedGetterCallback;
 use crate::IndexedSetterCallback;
 use crate::Local;
-use crate::NamedDefinerCallback;
-use crate::NamedGetterCallback;
-use crate::NamedSetterCallback;
+use crate::NamedDefinerCallbackNew;
+use crate::NamedGetterCallbackForAccessor;
+use crate::NamedGetterCallbackNew;
+use crate::NamedSetterCallbackForAccessor;
+use crate::NamedSetterCallbackNew;
 use crate::Object;
 use crate::PropertyAttribute;
 use crate::PropertyEnumeratorCallback;
@@ -94,7 +96,7 @@ extern "C" {
     value: int,
   );
 
-  fn v8__ObjectTemplate__SetAccessor(
+  fn v8__ObjectTemplate__SetNativeDataProperty(
     this: *const ObjectTemplate,
     key: *const Name,
     getter: AccessorNameGetterCallback,
@@ -112,13 +114,13 @@ extern "C" {
 
   fn v8__ObjectTemplate__SetNamedPropertyHandler(
     this: *const ObjectTemplate,
-    getter: Option<GenericNamedPropertyGetterCallback>,
-    setter: Option<GenericNamedPropertySetterCallback>,
-    query: Option<GenericNamedPropertyQueryCallback>,
-    deleter: Option<GenericNamedPropertyDeleterCallback>,
-    enumerator: Option<GenericNamedPropertyEnumeratorCallback>,
-    definer: Option<GenericNamedPropertyDefinerCallback>,
-    descriptor: Option<GenericNamedPropertyDescriptorCallback>,
+    getter: Option<NamedPropertyGetterCallback>,
+    setter: Option<NamedPropertySetterCallback>,
+    query: Option<NamedPropertyQueryCallback>,
+    deleter: Option<NamedPropertyDeleterCallback>,
+    enumerator: Option<NamedPropertyEnumeratorCallback>,
+    definer: Option<NamedPropertyDefinerCallback>,
+    descriptor: Option<NamedPropertyDescriptorCallback>,
     data_or_null: *const Value,
     flags: PropertyHandlerFlags,
   );
@@ -138,10 +140,18 @@ extern "C" {
   fn v8__ObjectTemplate__SetImmutableProto(this: *const ObjectTemplate);
 }
 
-pub type AccessorNameGetterCallback<'s> = NamedGetterCallback<'s>;
+/// Interceptor callbacks use this value to indicate whether the request was
+/// intercepted or not.
+#[repr(u8)]
+pub enum Intercepted {
+  No,
+  Yes,
+}
+
+pub type AccessorNameGetterCallback<'s> = NamedGetterCallbackForAccessor<'s>;
 
 /// Note: [ReturnValue] is ignored for accessors.
-pub type AccessorNameSetterCallback<'s> = NamedSetterCallback<'s>;
+pub type AccessorNameSetterCallback<'s> = NamedSetterCallbackForAccessor<'s>;
 
 /// Interceptor for get requests on an object.
 ///
@@ -150,7 +160,7 @@ pub type AccessorNameSetterCallback<'s> = NamedSetterCallback<'s>;
 /// not produce side effects.
 ///
 /// See also [ObjectTemplate::set_handler].
-pub type GenericNamedPropertyGetterCallback<'s> = NamedGetterCallback<'s>;
+pub type NamedPropertyGetterCallback<'s> = NamedGetterCallbackNew<'s>;
 
 /// Interceptor for set requests on an object.
 ///
@@ -162,7 +172,7 @@ pub type GenericNamedPropertyGetterCallback<'s> = NamedGetterCallback<'s>;
 /// effects.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type GenericNamedPropertySetterCallback<'s> = NamedSetterCallback<'s>;
+pub type NamedPropertySetterCallback<'s> = NamedSetterCallbackNew<'s>;
 
 /// Intercepts all requests that query the attributes of the property, e.g.,
 /// getOwnPropertyDescriptor(), propertyIsEnumerable(), and defineProperty().
@@ -176,7 +186,7 @@ pub type GenericNamedPropertySetterCallback<'s> = NamedSetterCallback<'s>;
 /// this interceptor depending on the state of the object.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type GenericNamedPropertyQueryCallback<'s> = NamedGetterCallback<'s>;
+pub type NamedPropertyQueryCallback<'s> = NamedGetterCallbackNew<'s>;
 
 /// Interceptor for delete requests on an object.
 ///
@@ -193,15 +203,14 @@ pub type GenericNamedPropertyQueryCallback<'s> = NamedGetterCallback<'s>;
 /// in strict mode.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type GenericNamedPropertyDeleterCallback<'s> = NamedGetterCallback<'s>;
+pub type NamedPropertyDeleterCallback<'s> = NamedGetterCallbackNew<'s>;
 
 /// Returns an array containing the names of the properties the named property getter intercepts.
 ///
 /// Note: The values in the array must be of type v8::Name.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type GenericNamedPropertyEnumeratorCallback<'s> =
-  PropertyEnumeratorCallback<'s>;
+pub type NamedPropertyEnumeratorCallback<'s> = PropertyEnumeratorCallback<'s>;
 
 /// Interceptor for defineProperty requests on an object.
 ///
@@ -213,7 +222,7 @@ pub type GenericNamedPropertyEnumeratorCallback<'s> =
 /// effects.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type GenericNamedPropertyDefinerCallback<'s> = NamedDefinerCallback<'s>;
+pub type NamedPropertyDefinerCallback<'s> = NamedDefinerCallbackNew<'s>;
 
 /// Interceptor for getOwnPropertyDescriptor requests on an object.
 ///
@@ -226,7 +235,7 @@ pub type GenericNamedPropertyDefinerCallback<'s> = NamedDefinerCallback<'s>;
 /// true, i.e., indicate that the property was found.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type GenericNamedPropertyDescriptorCallback<'s> = NamedGetterCallback<'s>;
+pub type NamedPropertyDescriptorCallback<'s> = NamedGetterCallbackNew<'s>;
 
 /// See [GenericNamedPropertyGetterCallback].
 pub type IndexedPropertyGetterCallback<'s> = IndexedGetterCallback<'s>;
@@ -291,13 +300,13 @@ impl<'s> AccessorConfiguration<'s> {
 
 #[derive(Default)]
 pub struct NamedPropertyHandlerConfiguration<'s> {
-  pub(crate) getter: Option<GenericNamedPropertyGetterCallback<'s>>,
-  pub(crate) setter: Option<GenericNamedPropertySetterCallback<'s>>,
-  pub(crate) query: Option<GenericNamedPropertyQueryCallback<'s>>,
-  pub(crate) deleter: Option<GenericNamedPropertyDeleterCallback<'s>>,
-  pub(crate) enumerator: Option<GenericNamedPropertyEnumeratorCallback<'s>>,
-  pub(crate) definer: Option<GenericNamedPropertyDefinerCallback<'s>>,
-  pub(crate) descriptor: Option<GenericNamedPropertyDescriptorCallback<'s>>,
+  pub(crate) getter: Option<NamedPropertyGetterCallback<'s>>,
+  pub(crate) setter: Option<NamedPropertySetterCallback<'s>>,
+  pub(crate) query: Option<NamedPropertyQueryCallback<'s>>,
+  pub(crate) deleter: Option<NamedPropertyDeleterCallback<'s>>,
+  pub(crate) enumerator: Option<NamedPropertyEnumeratorCallback<'s>>,
+  pub(crate) definer: Option<NamedPropertyDefinerCallback<'s>>,
+  pub(crate) descriptor: Option<NamedPropertyDescriptorCallback<'s>>,
   pub(crate) data: Option<Local<'s, Value>>,
   pub(crate) flags: PropertyHandlerFlags,
 }
@@ -330,55 +339,46 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn getter(
     mut self,
-    getter: impl MapFnTo<GenericNamedPropertyGetterCallback<'s>>,
+    getter: impl MapFnTo<NamedPropertyGetterCallback<'s>>,
   ) -> Self {
     self.getter = Some(getter.map_fn_to());
     self
   }
 
-  pub fn getter_raw(
-    mut self,
-    getter: GenericNamedPropertyGetterCallback<'s>,
-  ) -> Self {
+  pub fn getter_raw(mut self, getter: NamedPropertyGetterCallback<'s>) -> Self {
     self.getter = Some(getter);
     self
   }
 
   pub fn setter(
     mut self,
-    setter: impl MapFnTo<GenericNamedPropertySetterCallback<'s>>,
+    setter: impl MapFnTo<NamedPropertySetterCallback<'s>>,
   ) -> Self {
     self.setter = Some(setter.map_fn_to());
     self
   }
 
-  pub fn setter_raw(
-    mut self,
-    setter: GenericNamedPropertySetterCallback<'s>,
-  ) -> Self {
+  pub fn setter_raw(mut self, setter: NamedPropertySetterCallback<'s>) -> Self {
     self.setter = Some(setter);
     self
   }
 
   pub fn query(
     mut self,
-    query: impl MapFnTo<GenericNamedPropertyQueryCallback<'s>>,
+    query: impl MapFnTo<NamedPropertyQueryCallback<'s>>,
   ) -> Self {
     self.query = Some(query.map_fn_to());
     self
   }
 
-  pub fn query_raw(
-    mut self,
-    query: GenericNamedPropertyQueryCallback<'s>,
-  ) -> Self {
+  pub fn query_raw(mut self, query: NamedPropertyQueryCallback<'s>) -> Self {
     self.query = Some(query);
     self
   }
 
   pub fn deleter(
     mut self,
-    deleter: impl MapFnTo<GenericNamedPropertyDeleterCallback<'s>>,
+    deleter: impl MapFnTo<NamedPropertyDeleterCallback<'s>>,
   ) -> Self {
     self.deleter = Some(deleter.map_fn_to());
     self
@@ -386,7 +386,7 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn deleter_raw(
     mut self,
-    deleter: GenericNamedPropertyDeleterCallback<'s>,
+    deleter: NamedPropertyDeleterCallback<'s>,
   ) -> Self {
     self.deleter = Some(deleter);
     self
@@ -394,7 +394,7 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn enumerator(
     mut self,
-    enumerator: impl MapFnTo<GenericNamedPropertyEnumeratorCallback<'s>>,
+    enumerator: impl MapFnTo<NamedPropertyEnumeratorCallback<'s>>,
   ) -> Self {
     self.enumerator = Some(enumerator.map_fn_to());
     self
@@ -402,7 +402,7 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn enumerator_raw(
     mut self,
-    enumerator: GenericNamedPropertyEnumeratorCallback<'s>,
+    enumerator: NamedPropertyEnumeratorCallback<'s>,
   ) -> Self {
     self.enumerator = Some(enumerator);
     self
@@ -410,7 +410,7 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn definer(
     mut self,
-    definer: impl MapFnTo<GenericNamedPropertyDefinerCallback<'s>>,
+    definer: impl MapFnTo<NamedPropertyDefinerCallback<'s>>,
   ) -> Self {
     self.definer = Some(definer.map_fn_to());
     self
@@ -418,7 +418,7 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn definer_raw(
     mut self,
-    definer: GenericNamedPropertyDefinerCallback<'s>,
+    definer: NamedPropertyDefinerCallback<'s>,
   ) -> Self {
     self.definer = Some(definer);
     self
@@ -426,7 +426,7 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn descriptor(
     mut self,
-    descriptor: impl MapFnTo<GenericNamedPropertyDescriptorCallback<'s>>,
+    descriptor: impl MapFnTo<NamedPropertyDescriptorCallback<'s>>,
   ) -> Self {
     self.descriptor = Some(descriptor.map_fn_to());
     self
@@ -434,7 +434,7 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn descriptor_raw(
     mut self,
-    descriptor: GenericNamedPropertyDescriptorCallback<'s>,
+    descriptor: NamedPropertyDescriptorCallback<'s>,
   ) -> Self {
     self.descriptor = Some(descriptor);
     self
@@ -950,7 +950,7 @@ impl ObjectTemplate {
     configuration: AccessorConfiguration,
   ) {
     unsafe {
-      v8__ObjectTemplate__SetAccessor(
+      v8__ObjectTemplate__SetNativeDataProperty(
         self,
         &*key,
         configuration.getter,

--- a/src/template.rs
+++ b/src/template.rs
@@ -19,11 +19,11 @@ use crate::IndexedDefinerCallback;
 use crate::IndexedGetterCallback;
 use crate::IndexedSetterCallback;
 use crate::Local;
-use crate::NamedDefinerCallbackNew;
+use crate::NamedDefinerCallback;
+use crate::NamedGetterCallback;
 use crate::NamedGetterCallbackForAccessor;
-use crate::NamedGetterCallbackNew;
+use crate::NamedSetterCallback;
 use crate::NamedSetterCallbackForAccessor;
-use crate::NamedSetterCallbackNew;
 use crate::Object;
 use crate::PropertyAttribute;
 use crate::PropertyEnumeratorCallback;
@@ -160,7 +160,7 @@ pub type AccessorNameSetterCallback<'s> = NamedSetterCallbackForAccessor<'s>;
 /// not produce side effects.
 ///
 /// See also [ObjectTemplate::set_handler].
-pub type NamedPropertyGetterCallback<'s> = NamedGetterCallbackNew<'s>;
+pub type NamedPropertyGetterCallback<'s> = NamedGetterCallback<'s>;
 
 /// Interceptor for set requests on an object.
 ///
@@ -172,7 +172,7 @@ pub type NamedPropertyGetterCallback<'s> = NamedGetterCallbackNew<'s>;
 /// effects.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type NamedPropertySetterCallback<'s> = NamedSetterCallbackNew<'s>;
+pub type NamedPropertySetterCallback<'s> = NamedSetterCallback<'s>;
 
 /// Intercepts all requests that query the attributes of the property, e.g.,
 /// getOwnPropertyDescriptor(), propertyIsEnumerable(), and defineProperty().
@@ -186,7 +186,7 @@ pub type NamedPropertySetterCallback<'s> = NamedSetterCallbackNew<'s>;
 /// this interceptor depending on the state of the object.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type NamedPropertyQueryCallback<'s> = NamedGetterCallbackNew<'s>;
+pub type NamedPropertyQueryCallback<'s> = NamedGetterCallback<'s>;
 
 /// Interceptor for delete requests on an object.
 ///
@@ -203,7 +203,7 @@ pub type NamedPropertyQueryCallback<'s> = NamedGetterCallbackNew<'s>;
 /// in strict mode.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type NamedPropertyDeleterCallback<'s> = NamedGetterCallbackNew<'s>;
+pub type NamedPropertyDeleterCallback<'s> = NamedGetterCallback<'s>;
 
 /// Returns an array containing the names of the properties the named property getter intercepts.
 ///
@@ -222,7 +222,7 @@ pub type NamedPropertyEnumeratorCallback<'s> = PropertyEnumeratorCallback<'s>;
 /// effects.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type NamedPropertyDefinerCallback<'s> = NamedDefinerCallbackNew<'s>;
+pub type NamedPropertyDefinerCallback<'s> = NamedDefinerCallback<'s>;
 
 /// Interceptor for getOwnPropertyDescriptor requests on an object.
 ///
@@ -235,7 +235,7 @@ pub type NamedPropertyDefinerCallback<'s> = NamedDefinerCallbackNew<'s>;
 /// true, i.e., indicate that the property was found.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type NamedPropertyDescriptorCallback<'s> = NamedGetterCallbackNew<'s>;
+pub type NamedPropertyDescriptorCallback<'s> = NamedGetterCallback<'s>;
 
 /// See [GenericNamedPropertyGetterCallback].
 pub type IndexedPropertyGetterCallback<'s> = IndexedGetterCallback<'s>;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2604,6 +2604,7 @@ fn object_template_set_indexed_property_handler() {
       .try_into()
       .unwrap();
     rv.set(internal_field);
+    v8::Intercepted::Yes
   };
 
   let setter = |_scope: &mut v8::HandleScope,
@@ -2623,6 +2624,7 @@ fn object_template_set_indexed_property_handler() {
     assert!(this.set_internal_field(0, value.into()));
 
     rv.set_undefined();
+    v8::Intercepted::Yes
   };
 
   let query = |_scope: &mut v8::HandleScope,
@@ -2630,13 +2632,14 @@ fn object_template_set_indexed_property_handler() {
                _args: v8::PropertyCallbackArguments,
                mut rv: v8::ReturnValue| {
     if index == 12 {
-      return;
+      return v8::Intercepted::No;
     }
 
     assert_eq!(index, 37);
 
     // PropertyAttribute::READ_ONLY
     rv.set_int32(1);
+    v8::Intercepted::Yes
   };
 
   let deleter = |_scope: &mut v8::HandleScope,
@@ -2646,6 +2649,7 @@ fn object_template_set_indexed_property_handler() {
     assert_eq!(index, 37);
 
     rv.set_bool(false);
+    v8::Intercepted::Yes
   };
 
   let enumerator = |scope: &mut v8::HandleScope,
@@ -2691,6 +2695,7 @@ fn object_template_set_indexed_property_handler() {
     this.set_internal_field(0, value.into());
 
     rv.set_undefined();
+    v8::Intercepted::Yes
   };
 
   let descriptor = |scope: &mut v8::HandleScope,
@@ -2717,6 +2722,7 @@ fn object_template_set_indexed_property_handler() {
     descriptor.set(scope, writable_key.into(), writable.into());
 
     rv.set(descriptor.into());
+    v8::Intercepted::Yes
   };
 
   let name = v8::String::new(scope, "obj").unwrap();

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2117,7 +2117,7 @@ fn object_template_set_named_property_handler() {
                   mut rv: v8::ReturnValue| {
       let fallthrough_key = v8::String::new(scope, "fallthrough").unwrap();
       if key.strict_equals(fallthrough_key.into()) {
-        return;
+        return v8::Intercepted::No;
       }
 
       let this = args.this();
@@ -2135,6 +2135,7 @@ fn object_template_set_named_property_handler() {
         .try_into()
         .unwrap();
       rv.set(internal_field);
+      v8::Intercepted::Yes
     };
 
     let setter = |scope: &mut v8::HandleScope,
@@ -2144,12 +2145,12 @@ fn object_template_set_named_property_handler() {
                   mut rv: v8::ReturnValue| {
       let fallthrough_key = v8::String::new(scope, "fallthrough").unwrap();
       if key.strict_equals(fallthrough_key.into()) {
-        return;
+        return v8::Intercepted::No;
       }
 
       let panic_on_get = v8::String::new(scope, "panicOnGet").unwrap();
       if key.strict_equals(panic_on_get.into()) {
-        return;
+        return v8::Intercepted::No;
       }
 
       let this = args.this();
@@ -2165,6 +2166,7 @@ fn object_template_set_named_property_handler() {
       assert!(this.set_internal_field(0, value.into()));
 
       rv.set_undefined();
+      v8::Intercepted::Yes
     };
 
     let query = |scope: &mut v8::HandleScope,
@@ -2173,12 +2175,12 @@ fn object_template_set_named_property_handler() {
                  mut rv: v8::ReturnValue| {
       let fallthrough_key = v8::String::new(scope, "fallthrough").unwrap();
       if key.strict_equals(fallthrough_key.into()) {
-        return;
+        return v8::Intercepted::No;
       }
 
       let panic_on_get = v8::String::new(scope, "panicOnGet").unwrap();
       if key.strict_equals(panic_on_get.into()) {
-        return;
+        return v8::Intercepted::No;
       }
 
       let this = args.this();
@@ -2198,6 +2200,7 @@ fn object_template_set_named_property_handler() {
         .try_into()
         .unwrap();
       assert!(internal_field.strict_equals(expected_value.into()));
+      v8::Intercepted::Yes
     };
 
     let deleter = |scope: &mut v8::HandleScope,
@@ -2206,7 +2209,7 @@ fn object_template_set_named_property_handler() {
                    mut rv: v8::ReturnValue| {
       let fallthrough_key = v8::String::new(scope, "fallthrough").unwrap();
       if key.strict_equals(fallthrough_key.into()) {
-        return;
+        return v8::Intercepted::No;
       }
 
       let this = args.this();
@@ -2217,6 +2220,7 @@ fn object_template_set_named_property_handler() {
       assert!(this.set_internal_field(0, v8::undefined(scope).into()));
 
       rv.set_bool(true);
+      v8::Intercepted::Yes
     };
 
     let enumerator = |scope: &mut v8::HandleScope,
@@ -2250,7 +2254,7 @@ fn object_template_set_named_property_handler() {
                    mut rv: v8::ReturnValue| {
       let fallthrough_key = v8::String::new(scope, "fallthrough").unwrap();
       if key.strict_equals(fallthrough_key.into()) {
-        return;
+        return v8::Intercepted::No;
       }
 
       let this = args.this();
@@ -2275,6 +2279,7 @@ fn object_template_set_named_property_handler() {
       assert!(this.set_internal_field(0, value.into()));
 
       rv.set_undefined();
+      v8::Intercepted::Yes
     };
 
     let descriptor = |scope: &mut v8::HandleScope,
@@ -2283,7 +2288,7 @@ fn object_template_set_named_property_handler() {
                       mut rv: v8::ReturnValue| {
       let fallthrough_key = v8::String::new(scope, "fallthrough").unwrap();
       if key.strict_equals(fallthrough_key.into()) {
-        return;
+        return v8::Intercepted::No;
       }
 
       let this = args.this();
@@ -2307,6 +2312,7 @@ fn object_template_set_named_property_handler() {
       descriptor.set(scope, writable_key.into(), writable.into());
 
       rv.set(descriptor.into());
+      v8::Intercepted::Yes
     };
 
     let name = v8::String::new(scope, "obj").unwrap();
@@ -4493,6 +4499,9 @@ fn security_token() {
             let obj = v8::Local::<v8::Object>::try_from(args.data()).unwrap();
             if let Some(val) = obj.get(scope, key.into()) {
               rv.set(val);
+              v8::Intercepted::Yes
+            } else {
+              v8::Intercepted::No
             }
           },
         )
@@ -4541,10 +4550,11 @@ fn context_with_object_template() {
     _descriptor: &v8::PropertyDescriptor,
     _args: v8::PropertyCallbackArguments<'s>,
     _rv: v8::ReturnValue,
-  ) {
+  ) -> v8::Intercepted {
     unsafe {
       CALLS.push("definer".to_string());
     }
+    v8::Intercepted::No
   }
 
   pub fn setter<'s>(
@@ -4553,10 +4563,11 @@ fn context_with_object_template() {
     _value: v8::Local<'s, v8::Value>,
     _args: v8::PropertyCallbackArguments<'s>,
     _rv: v8::ReturnValue,
-  ) {
+  ) -> v8::Intercepted {
     unsafe {
       CALLS.push("setter".to_string());
     }
+    v8::Intercepted::No
   }
 
   {


### PR DESCRIPTION
This commit updates APIs related to named and indexed property
handlers to not use deprecated V8 APIs. Main change is the change
of return value in callbacks that now requires to return `v8::Intercepted` enum.

Towards https://github.com/denoland/rusty_v8/issues/1478