### PR TITLE
fix: remove use of deprecated apis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1463,7 @@ dependencies = [
  "home",
  "miniz_oxide",
  "once_cell",
+ "paste",
  "rustversion",
  "trybuild",
  "which 6.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ use_custom_libcxx = []
 [dependencies]
 bitflags = "2.5"
 once_cell = "1.19"
+paste = "1.0"
 
 [build-dependencies]
 miniz_oxide = "0.7.2"

--- a/examples/cppgc-object.rs
+++ b/examples/cppgc-object.rs
@@ -19,9 +19,7 @@ impl Drop for Wrappable {
   }
 }
 
-// Set a custom embedder ID for the garbage collector. cppgc will use this ID to
-// identify the object that it manages.
-const DEFAULT_CPP_GC_EMBEDDER_ID: u16 = 0xde90;
+const TAG: u16 = 1;
 
 fn main() {
   let platform = v8::new_default_platform(0, false).make_shared();
@@ -32,18 +30,10 @@ fn main() {
   v8::cppgc::initalize_process(platform.clone());
 
   {
-    let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
-
-    // Create a managed heap.
-    let heap = v8::cppgc::Heap::create(
-      platform,
-      v8::cppgc::HeapCreateParams::new(v8::cppgc::WrapperDescriptor::new(
-        0,
-        1,
-        DEFAULT_CPP_GC_EMBEDDER_ID,
-      )),
-    );
-    isolate.attach_cpp_heap(&heap);
+    let heap =
+      v8::cppgc::Heap::create(platform, v8::cppgc::HeapCreateParams::default());
+    let isolate =
+      &mut v8::Isolate::new(v8::CreateParams::default().cpp_heap(heap));
 
     let handle_scope = &mut v8::HandleScope::new(isolate);
     let context = v8::Context::new(handle_scope);
@@ -57,24 +47,31 @@ fn main() {
          mut rv: v8::ReturnValue| {
           let id = args.get(0).to_rust_string_lossy(scope);
 
-          let templ = v8::ObjectTemplate::new(scope);
-          templ.set_internal_field_count(2);
+          fn empty(
+            _scope: &mut v8::HandleScope,
+            _args: v8::FunctionCallbackArguments,
+            _rv: v8::ReturnValue,
+          ) {
+          }
+          let templ = v8::FunctionTemplate::new(scope, empty);
+          let func = templ.get_function(scope).unwrap();
+          let obj = func.new_instance(scope, &[]).unwrap();
 
-          let obj = templ.new_instance(scope).unwrap();
+          assert!(obj.is_api_wrapper());
 
-          let member = v8::cppgc::make_garbage_collected(
-            scope.get_cpp_heap().unwrap(),
-            Box::new(Wrappable {
-              trace_count: Cell::new(0),
-              id,
-            }),
-          );
+          let member = unsafe {
+            v8::cppgc::make_garbage_collected(
+              scope.get_cpp_heap().unwrap(),
+              Wrappable {
+                trace_count: Cell::new(0),
+                id,
+              },
+            )
+          };
 
-          obj.set_aligned_pointer_in_internal_field(
-            0,
-            &DEFAULT_CPP_GC_EMBEDDER_ID as *const u16 as _,
-          );
-          obj.set_aligned_pointer_in_internal_field(1, member.handle as _);
+          unsafe {
+            v8::Object::wrap::<TAG, Wrappable>(scope, obj, &member);
+          }
 
           rv.set(obj.into());
         },

--- a/examples/cppgc.rs
+++ b/examples/cppgc.rs
@@ -1,46 +1,42 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
 //
 // This sample program shows how to set up a stand-alone cppgc heap.
-use std::ops::Deref;
 
 // Simple string rope to illustrate allocation and garbage collection below.
 // The rope keeps the next parts alive via regular managed reference.
+
 struct Rope {
   part: String,
-  next: Option<v8::cppgc::Member<Rope>>,
+  next: v8::cppgc::Member<Rope>,
 }
 
 impl std::fmt::Display for Rope {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     write!(f, "{}", self.part)?;
-    if let Some(next) = &self.next {
-      write!(f, "{}", next.deref())?;
+    if let Some(next) = self.next.borrow() {
+      write!(f, "{}", next)?;
     }
     Ok(())
   }
 }
 
 impl Rope {
-  pub fn new(part: String, next: Option<v8::cppgc::Member<Rope>>) -> Box<Rope> {
-    Box::new(Self { part, next })
+  pub fn new(part: String, next: v8::cppgc::Member<Rope>) -> Rope {
+    Self { part, next }
   }
 }
 
 impl v8::cppgc::GarbageCollected for Rope {
   fn trace(&self, visitor: &v8::cppgc::Visitor) {
-    if let Some(member) = &self.next {
-      visitor.trace(member);
-    }
+    visitor.trace(&self.next);
   }
 }
 
 impl Drop for Rope {
   fn drop(&mut self) {
-    println!("Dropping {}", self.part);
+    println!("Dropping: {}", self.part);
   }
 }
-
-const DEFAULT_CPP_GC_EMBEDDER_ID: u16 = 0xde90;
 
 fn main() {
   let platform = v8::new_default_platform(0, false).make_shared();
@@ -50,36 +46,46 @@ fn main() {
 
   {
     // Create a managed heap.
-    let heap = v8::cppgc::Heap::create(
-      platform,
-      v8::cppgc::HeapCreateParams::new(v8::cppgc::WrapperDescriptor::new(
-        0,
-        1,
-        DEFAULT_CPP_GC_EMBEDDER_ID,
-      )),
-    );
+    let heap =
+      v8::cppgc::Heap::create(platform, v8::cppgc::HeapCreateParams::default());
 
     // Allocate a string rope on the managed heap.
-    let rope = v8::cppgc::make_garbage_collected(
-      &heap,
-      Rope::new(
-        String::from("Hello "),
-        Some(v8::cppgc::make_garbage_collected(
-          &heap,
-          Rope::new(String::from("World!"), None),
-        )),
-      ),
-    );
+    let rope = unsafe {
+      v8::cppgc::make_garbage_collected(
+        &heap,
+        Rope::new(
+          String::from("Hello "),
+          v8::cppgc::make_garbage_collected(
+            &heap,
+            Rope::new(String::from("World!"), v8::cppgc::Member::empty()),
+          ),
+        ),
+      )
+    };
 
-    println!("{}", unsafe { rope.get() });
+    println!("{}", rope.borrow().unwrap());
+
     // Manually trigger garbage collection.
     heap.enable_detached_garbage_collections_for_testing();
-    heap.collect_garbage_for_testing(
-      v8::cppgc::EmbedderStackState::MayContainHeapPointers,
-    );
-    heap.collect_garbage_for_testing(
-      v8::cppgc::EmbedderStackState::NoHeapPointers,
-    );
+
+    println!("Collect: MayContainHeapPointers");
+    unsafe {
+      heap.collect_garbage_for_testing(
+        v8::cppgc::EmbedderStackState::MayContainHeapPointers,
+      );
+    }
+
+    // Should still be live here:
+    println!("{}", rope.borrow().unwrap());
+
+    println!("Collect: NoHeapPointers");
+    unsafe {
+      heap.collect_garbage_for_testing(
+        v8::cppgc::EmbedderStackState::NoHeapPointers,
+      );
+    }
+
+    // Should be dead now.
   }
 
   // Gracefully shutdown the process.

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -1,3 +1,4 @@
+#include <v8-cppgc.h>
 #include <v8-message.h>
 
 /**
@@ -5,8 +6,16 @@
  * and made available in `crate::binding` in rust.
  */
 
-// TODO: In the immediate term, cppgc definitions will go here.
-// In the future we should migrate over the rest of our SIZE definitions,
-// and eventually entire structs and functions.
+namespace {
+
+class RustObj;
+
+}
 
 static size_t RUST_v8__ScriptOrigin_SIZE = sizeof(v8::ScriptOrigin);
+
+static size_t RUST_cppgc__Member_SIZE = sizeof(cppgc::Member<RustObj>);
+static size_t RUST_cppgc__WeakMember_SIZE = sizeof(cppgc::WeakMember<RustObj>);
+
+static size_t RUST_v8__TracedReference_SIZE =
+    sizeof(v8::TracedReference<v8::Data>);

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -460,7 +460,6 @@ extern "C" {
     change_in_bytes: i64,
   ) -> i64;
   fn v8__Isolate__GetCppHeap(isolate: *mut Isolate) -> *mut Heap;
-  fn v8__Isolate__AttachCppHeap(isolate: *mut Isolate, heap: *mut Heap);
   fn v8__Isolate__SetPrepareStackTraceCallback(
     isolate: *mut Isolate,
     callback: PrepareStackTraceCallback,
@@ -637,18 +636,21 @@ impl Isolate {
   #[allow(clippy::new_ret_no_self)]
   pub fn snapshot_creator(
     external_references: Option<&'static ExternalReferences>,
+    params: Option<CreateParams>,
   ) -> OwnedIsolate {
-    SnapshotCreator::new(external_references)
+    SnapshotCreator::new(external_references, params)
   }
 
   #[allow(clippy::new_ret_no_self)]
   pub fn snapshot_creator_from_existing_snapshot(
     existing_snapshot_blob: impl Allocated<[u8]>,
     external_references: Option<&'static ExternalReferences>,
+    params: Option<CreateParams>,
   ) -> OwnedIsolate {
     SnapshotCreator::from_existing_snapshot(
       existing_snapshot_blob,
       external_references,
+      params,
     )
   }
 
@@ -1181,17 +1183,6 @@ impl Isolate {
   ) -> i64 {
     unsafe {
       v8__Isolate__AdjustAmountOfExternalAllocatedMemory(self, change_in_bytes)
-    }
-  }
-
-  /// Attaches a managed C++ heap as an extension to the JavaScript heap.
-  ///
-  /// The embedder maintains ownership of the CppHeap. At most one C++ heap
-  /// can be attached to V8.
-  #[inline(always)]
-  pub fn attach_cpp_heap(&mut self, heap: &Heap) {
-    unsafe {
-      v8__Isolate__AttachCppHeap(self, heap as *const Heap as *mut _);
     }
   }
 

--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -8,6 +8,7 @@ use crate::support::Allocated;
 use crate::support::Allocation;
 use crate::support::Opaque;
 use crate::support::SharedPtr;
+use crate::support::UniqueRef;
 
 use std::any::Any;
 use std::convert::TryFrom;
@@ -156,6 +157,13 @@ impl CreateParams {
       .raw
       .constraints
       .configure_defaults_from_heap_size(initial, max);
+    self
+  }
+
+  /// A CppHeap used to construct the Isolate. V8 takes ownership of the
+  /// CppHeap passed this way.
+  pub fn cpp_heap(mut self, heap: UniqueRef<Heap>) -> Self {
+    self.raw.cpp_heap = heap.into_raw();
     self
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub use get_property_names_args_builder::*;
 pub use handle::Global;
 pub use handle::Handle;
 pub use handle::Local;
+pub use handle::TracedReference;
 pub use handle::Weak;
 pub use isolate::GarbageCollectionType;
 pub use isolate::HeapStatistics;

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -102,8 +102,9 @@ impl SnapshotCreator {
   #[allow(clippy::new_ret_no_self)]
   pub(crate) fn new(
     external_references: Option<&'static ExternalReferences>,
+    params: Option<crate::CreateParams>,
   ) -> OwnedIsolate {
-    Self::new_impl(external_references, None::<&[u8]>)
+    Self::new_impl(external_references, None::<&[u8]>, params)
   }
 
   /// Create an isolate, and set it up for serialization.
@@ -113,8 +114,9 @@ impl SnapshotCreator {
   pub(crate) fn from_existing_snapshot(
     existing_snapshot_blob: impl Allocated<[u8]>,
     external_references: Option<&'static ExternalReferences>,
+    params: Option<crate::CreateParams>,
   ) -> OwnedIsolate {
-    Self::new_impl(external_references, Some(existing_snapshot_blob))
+    Self::new_impl(external_references, Some(existing_snapshot_blob), params)
   }
 
   /// Create and enter an isolate, and set it up for serialization.
@@ -124,10 +126,11 @@ impl SnapshotCreator {
   fn new_impl(
     external_references: Option<&'static ExternalReferences>,
     existing_snapshot_blob: Option<impl Allocated<[u8]>>,
+    params: Option<crate::CreateParams>,
   ) -> OwnedIsolate {
     let mut snapshot_creator: MaybeUninit<Self> = MaybeUninit::uninit();
 
-    let mut params = crate::CreateParams::default();
+    let mut params = params.unwrap_or_default();
     if let Some(external_refs) = external_references {
       params = params.external_references(&**external_refs);
     }

--- a/tests/slots.rs
+++ b/tests/slots.rs
@@ -326,7 +326,7 @@ fn dropped_context_slots_on_kept_context() {
 fn clear_all_context_slots() {
   setup();
 
-  let mut snapshot_creator = v8::Isolate::snapshot_creator(None);
+  let mut snapshot_creator = v8::Isolate::snapshot_creator(None, None);
 
   {
     let scope = &mut v8::HandleScope::new(&mut snapshot_creator);

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -5395,7 +5395,7 @@ fn snapshot_creator() {
   let context_data_index;
   let context_data_index_2;
   let startup_data = {
-    let mut snapshot_creator = v8::Isolate::snapshot_creator(None);
+    let mut snapshot_creator = v8::Isolate::snapshot_creator(None, None);
     {
       let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
       let context = v8::Context::new(scope);
@@ -5411,7 +5411,11 @@ fn snapshot_creator() {
 
   let startup_data = {
     let mut snapshot_creator =
-      v8::Isolate::snapshot_creator_from_existing_snapshot(startup_data, None);
+      v8::Isolate::snapshot_creator_from_existing_snapshot(
+        startup_data,
+        None,
+        None,
+      );
     {
       // Check that the SnapshotCreator isolate has been set up correctly.
       let _ = snapshot_creator.thread_safe_handle();
@@ -5482,7 +5486,7 @@ fn snapshot_creator() {
 fn snapshot_creator_multiple_contexts() {
   let _setup_guard = setup::sequential_test();
   let startup_data = {
-    let mut snapshot_creator = v8::Isolate::snapshot_creator(None);
+    let mut snapshot_creator = v8::Isolate::snapshot_creator(None, None);
     {
       let mut scope = v8::HandleScope::new(&mut snapshot_creator);
       let context = v8::Context::new(&mut scope);
@@ -5517,7 +5521,11 @@ fn snapshot_creator_multiple_contexts() {
 
   let startup_data = {
     let mut snapshot_creator =
-      v8::Isolate::snapshot_creator_from_existing_snapshot(startup_data, None);
+      v8::Isolate::snapshot_creator_from_existing_snapshot(
+        startup_data,
+        None,
+        None,
+      );
     {
       let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
       let context = v8::Context::new(scope);
@@ -5655,7 +5663,7 @@ fn external_references() {
   // First we create the snapshot, there is a single global variable 'a' set to
   // the value 3.
   let startup_data = {
-    let mut snapshot_creator = v8::Isolate::snapshot_creator(Some(refs));
+    let mut snapshot_creator = v8::Isolate::snapshot_creator(Some(refs), None);
     {
       let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
       let context = v8::Context::new(scope);
@@ -7477,7 +7485,7 @@ fn module_snapshot() {
   let _setup_guard = setup::sequential_test();
 
   let startup_data = {
-    let mut snapshot_creator = v8::Isolate::snapshot_creator(None);
+    let mut snapshot_creator = v8::Isolate::snapshot_creator(None, None);
     {
       let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
       let context = v8::Context::new(scope);


### PR DESCRIPTION
Fixes: https://github.com/denoland/rusty_v8/issues/1478

https://docs.google.com/document/d/1FWnrKxjl0P-jY0CMPlzbXkH8xkKoX6nM4e2OXq1EGHU

tldr some* v8 objects now directly store a "wrapped pointer" field which is traced by cppgc. cppgc no longer requires embedder field information when being set up, and this field is set using `Object::wrap`/`Object::unwrap`.

\* objects must use the JSObjectWithEmbedderSlots map