### PR TITLE
build: fix publishing step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,7 @@ jobs:
           startsWith(github.ref, 'refs/tags/') &&
           github.repository == 'denoland/rusty_v8' &&
           startsWith(matrix.config.target , 'x86_64') &&
+          !endsWith(matrix.config.target , 'android') &&
           matrix.config.variant == 'debug' &&
           runner.os == 'Linux'
         env:


### PR DESCRIPTION
After adding the Android support the CI fails on tags because `cargo publish` was being run
on linux GNU and linux Android.