### PR TITLE
Fix uninitialized context annex slot

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -322,6 +322,9 @@ impl Context {
     slot: i32,
     data: *mut c_void,
   ) {
+    // Initialize the annex when slot count > INTERNAL_SLOT_COUNT.
+    self.get_annex_mut(&mut *v8__Context__GetIsolate(self), true);
+
     v8__Context__SetAlignedPointerInEmbedderData(
       self,
       slot + Self::INTERNAL_SLOT_COUNT,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -11485,7 +11485,6 @@ fn clear_slots_annex_uninitialized() {
   let mut isolate = v8::Isolate::new(Default::default());
 
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let queue = v8::MicrotaskQueue::new(&mut scope, v8::MicrotasksPolicy::Auto);
 
   let context = v8::Context::new(&mut scope);
 


### PR DESCRIPTION
Attempts to `clear_all_slots` would crash when annex slot is not intialized but is also non-null garbage value. This patch makes sure we initialize a valid annex slot.