### PR TITLE
build: remove symlink on Windows before creating it

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -848,6 +848,7 @@ fn maybe_symlink_root_dir(dirs: &mut Dirs) {
         Ok(existing) if existing == target => break,
         Ok(_) => remove_dir(symlink).expect("remove_dir failed"),
         Err(_) => {
+          remove_dir(symlink).expect("remove_dir failed");
           break symlink_dir(target, symlink).expect("symlink_dir failed")
         }
       }

--- a/build.rs
+++ b/build.rs
@@ -849,7 +849,7 @@ fn maybe_symlink_root_dir(dirs: &mut Dirs) {
         Ok(_) => remove_dir(symlink).expect("remove_dir failed"),
         Err(_) => {
           remove_dir(symlink).expect("remove_dir failed");
-          break symlink_dir(target, symlink).expect("symlink_dir failed")
+          break symlink_dir(target, symlink).expect("symlink_dir failed");
         }
       }
     }

--- a/build.rs
+++ b/build.rs
@@ -848,7 +848,7 @@ fn maybe_symlink_root_dir(dirs: &mut Dirs) {
         Ok(existing) if existing == target => break,
         Ok(_) => remove_dir(symlink).expect("remove_dir failed"),
         Err(_) => {
-          remove_dir(symlink).expect("remove_dir failed");
+          let _ = remove_dir(symlink);
           break symlink_dir(target, symlink).expect("symlink_dir failed");
         }
       }


### PR DESCRIPTION
Fixes failures like this:
```
 --- stderr
  thread 'main' panicked at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\v8-0.95.0\build.rs:851:46:
  symlink_dir failed: Os { code: 183, kind: AlreadyExists, message: "Cannot create a file when that file already exists." }
  stack backtrace:
     0:     0x7ff65a7eb788 - std::backtrace_rs::backtrace::dbghelp64::trace
                                 at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library\std\src\..\..\backtrace\src\backtrace\dbghelp64.rs:91
     1:     0x7ff65a7eb788 - std::backtrace_rs::backtrace::trace_unsynchronized
                                 at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library\std\src\..\..\backtrace\src\backtrace\mod.rs:66
     2:     0x7ff65a7eb788 - std::sys_common::backtrace::_print_fmt
                                 at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library\std\src\sys_common\backtrace.rs:68
     3:     0x7ff65a7eb788 - std::sys_common::backtrace::_print::impl$0::fmt
                                 at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library\std\src\sys_common\backtrace.rs:44
     4:     0x7ff65a80c049 - core::fmt::rt::Argument::fmt
                                 at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library\core\src\fmt\rt.rs:165
     5:     0x7ff65a80c049 - core::fmt::write
                                 at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library\core\src\fmt\mod.rs:1157
     6:     0x7ff65a7e7211 - std::io::Write::write_fmt<std::sys::pal::windows::stdio::Stderr>
                                 at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library\std\src\io\mod.rs:1832
     7:     0x7ff65a7eb566 - std::sys_common::backtrace::print
                                 at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library\std\src\sys_common\backtrace.rs:34

```
