### PR TITLE
feat: enable maglev

### DIFF
--- a/.gn
+++ b/.gn
@@ -59,11 +59,6 @@ default_args = {
   # compile.
   v8_enable_verify_heap = false
 
-  # Maglev *should* be supported when pointer compression is disabled as per
-  # https://chromium-review.googlesource.com/c/v8/v8/+/4753150, but it still
-  # fails to compile.
-  v8_enable_maglev = false
-
   # Enable V8 object print for debugging.
   # v8_enable_object_print = true
   
@@ -78,7 +73,4 @@ default_args = {
   #
   # rusty_v8 scopes are not on the stack.
   v8_enable_v8_checks = false
-
-  # Enable Deno-specific extra bindings
-  deno_enable_extras = true
 }


### PR DESCRIPTION
can still be disabled at runtime with `--no-maglev`

also remove unused `deno_enable_extras` param