### PR TITLE
feat: cppgc::Ptr

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3936,8 +3936,8 @@ void cppgc__WeakMember__Assign(cppgc::WeakMember<RustObj>* member,
   member->operator=(other);
 }
 
-cppgc::Persistent<RustObj>* cppgc__Persistent__CONSTRUCT() {
-  return new cppgc::Persistent<RustObj>(nullptr);
+cppgc::Persistent<RustObj>* cppgc__Persistent__CONSTRUCT(RustObj* obj) {
+  return new cppgc::Persistent<RustObj>(obj);
 }
 
 void cppgc__Persistent__DESTRUCT(cppgc::Persistent<RustObj>* self) {
@@ -3952,8 +3952,8 @@ RustObj* cppgc__Persistent__Get(cppgc::Persistent<RustObj>* self) {
   return self->Get();
 }
 
-cppgc::WeakPersistent<RustObj>* cppgc__WeakPersistent__CONSTRUCT() {
-  return new cppgc::WeakPersistent<RustObj>(nullptr);
+cppgc::WeakPersistent<RustObj>* cppgc__WeakPersistent__CONSTRUCT(RustObj* obj) {
+  return new cppgc::WeakPersistent<RustObj>(obj);
 }
 
 void cppgc__WeakPersistent__DESTRUCT(cppgc::WeakPersistent<RustObj>* self) {

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,6 +1,6 @@
 use crate::cppgc::GarbageCollected;
 use crate::cppgc::GetRustObj;
-use crate::cppgc::Member;
+use crate::cppgc::Ptr;
 use crate::cppgc::RustObj;
 use crate::isolate::Isolate;
 use crate::support::int;
@@ -721,16 +721,16 @@ impl Object {
   /// # Safety
   ///
   /// The caller must ensure that the returned pointer is always stored on
-  /// the stack, or moved into one of the Persistent types.
+  /// the stack, or is safely moved into one of the other cppgc pointer types.
   #[inline(always)]
   pub unsafe fn unwrap<const TAG: u16, T: GarbageCollected>(
     isolate: &mut Isolate,
     wrapper: Local<Object>,
-  ) -> Member<T> {
+  ) -> Option<Ptr<T>> {
     // TODO: use a const assert once const expressions are stable
     assert!(TAG < LAST_TAG);
     let ptr = unsafe { v8__Object__Unwrap(isolate as *mut _, &*wrapper, TAG) };
-    Member::new(ptr)
+    Ptr::new(&ptr)
   }
 
   /// Returns true if this object can be generally used to wrap object objects.

--- a/tests/test_cppgc.rs
+++ b/tests/test_cppgc.rs
@@ -89,7 +89,7 @@ fn cppgc_object_wrap() {
   ) {
     let obj = args.get(0).try_into().unwrap();
     let member = unsafe { v8::Object::unwrap::<TAG, Wrap>(scope, obj) };
-    rv.set(member.borrow().unwrap().value.get(scope).unwrap());
+    rv.set(member.unwrap().value.get(scope).unwrap());
   }
 
   {


### PR DESCRIPTION
I avoided this before because there's no way to make this type as safe as it should be, and Member<T> was convenient enough, but Member<T> is slower to construct and read/write from due to its internals, and it is also difficult to work with due to being nullable. This also enables some very useful API improvements in deno_core to unlock cppgc `Resource` types.