### PR TITLE
feat: cppgc NameProvider

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -157,6 +157,7 @@ fn build_binding() {
     .rustified_enum(".*UseCounterFeature")
     .allowlist_item("v8__.*")
     .allowlist_item("cppgc__.*")
+    .allowlist_item("RustObj")
     .generate()
     .expect("Unable to generate bindings");
 

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -11,8 +11,6 @@
  * and made available in `crate::binding` in rust.
  */
 
-class RustObj;
-
 static size_t v8__ScriptOrigin_SIZE = sizeof(v8::ScriptOrigin);
 
 static size_t cppgc__Member_SIZE = sizeof(cppgc::Member<RustObj>);

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,7 +1,7 @@
+use crate::binding::RustObj;
 use crate::cppgc::GarbageCollected;
 use crate::cppgc::GetRustObj;
 use crate::cppgc::Ptr;
-use crate::cppgc::RustObj;
 use crate::isolate::Isolate;
 use crate::support::int;
 use crate::support::MapFnTo;

--- a/src/support.h
+++ b/src/support.h
@@ -9,6 +9,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "v8/include/cppgc/name-provider.h"
+#include "v8/include/v8-cppgc.h"
 #include "v8/include/v8.h"
 
 // Work around a bug in the V8 headers.
@@ -190,3 +192,12 @@ struct three_pointers_t {
   V(BigInt64Array)
 
 #endif  // SUPPORT_H_
+
+class RustObj final : public cppgc::GarbageCollected<RustObj>,
+                      public cppgc::NameProvider {
+ public:
+  ~RustObj();
+  void Trace(cppgc::Visitor* visitor) const;
+  const char* GetHumanReadableName() const final;
+  uintptr_t data[2];
+};


### PR DESCRIPTION
implements NameProvider, but I didn't want RustObj to grow beyond 2 pointers, so replace it with a dyn pointer and use that to dispatch.