### PR TITLE
fix: ExternalOneByteStringResource is not guaranteed to be valid UTF-8

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -158,8 +158,12 @@ impl ExternalOneByteStringResource {
   /// The data is guaranteed to be Latin-1.
   pub fn as_bytes(&self) -> &[u8] {
     let len = self.length();
-    // SAFETY: We know this is Latin-1
-    unsafe { std::slice::from_raw_parts(self.data().cast(), len) }
+    if len == 0 {
+      &[]
+    } else {
+      // SAFETY: We know this is Latin-1
+      unsafe { std::slice::from_raw_parts(self.data().cast(), len) }
+    }
   }
 }
 


### PR DESCRIPTION
A subtle unsoundness / undefined behaviour made its way into the fairly recently added `ExternalOneByteStringResource` object: The `as_str` API is not sound as the data inside may be be Latin-1, not ASCII.

As the API was not used anywhere in deno or deno_core, I opted to simply remove it and replace it with an `as_bytes` API. I also modified the test to showcase the Latin-1 string case and added copious notes and explanations around the code to make sure this doesn't accidentally happen again. The likely reason why the API originally slipped in is because the `OneByteConst` has this API where it _is_ safe because the `OneByteConst` creation checks the data for ASCII-ness.

I also tried to add an API to extract an `Option<&'static OneByteConst>` from an `&ExternalOneByteStringResource` but run into https://github.com/rust-lang/rust/issues/119618 ie. OneByteConst is actually duplicating the vtables... which is not great.

Closes #1531 