### PR TITLE
add embedder suffix to v8 version

### DIFF
--- a/.gn
+++ b/.gn
@@ -30,6 +30,8 @@ default_args = {
   symbol_level = 1
   use_debug_fission = false
 
+  v8_embedder_string = "-rusty"
+
   v8_enable_sandbox = false
   v8_enable_javascript_promise_hooks = true
   v8_promise_internal_field_count = 1


### PR DESCRIPTION
`-rusty` seemed like the best option since this library is used by more than just deno.