### PR TITLE
feat: upgrade ScriptOrigin

### DIFF
--- a/examples/shell.rs
+++ b/examples/shell.rs
@@ -119,7 +119,6 @@ fn execute_string(
   let mut scope = v8::TryCatch::new(scope);
 
   let filename = v8::String::new(&mut scope, filename).unwrap();
-  let undefined = v8::undefined(&mut scope);
   let script = v8::String::new(&mut scope, script).unwrap();
   let origin = v8::ScriptOrigin::new(
     &mut scope,
@@ -128,10 +127,11 @@ fn execute_string(
     0,
     false,
     0,
-    undefined.into(),
+    None,
     false,
     false,
     false,
+    None,
   );
 
   let script = if let Some(script) =

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2631,18 +2631,17 @@ const v8::Value* v8__Script__Run(const v8::Script& script,
   return maybe_local_to_ptr(ptr_to_local(&script)->Run(ptr_to_local(&context)));
 }
 
-void v8__ScriptOrigin__CONSTRUCT(uninit_t<v8::ScriptOrigin>* buf,
-                                 const v8::Value& resource_name,
-                                 int resource_line_offset,
-                                 int resource_column_offset,
-                                 bool resource_is_shared_cross_origin,
-                                 int script_id, const v8::Value& source_map_url,
-                                 bool resource_is_opaque, bool is_wasm,
-                                 bool is_module) {
+void v8__ScriptOrigin__CONSTRUCT(
+    uninit_t<v8::ScriptOrigin>* buf, const v8::Value& resource_name,
+    int resource_line_offset, int resource_column_offset,
+    bool resource_is_shared_cross_origin, int script_id,
+    const v8::Value* source_map_url, bool resource_is_opaque, bool is_wasm,
+    bool is_module, const v8::Data* host_defined_options) {
   construct_in_place<v8::ScriptOrigin>(
       buf, ptr_to_local(&resource_name), resource_line_offset,
       resource_column_offset, resource_is_shared_cross_origin, script_id,
-      ptr_to_local(&source_map_url), resource_is_opaque, is_wasm, is_module);
+      ptr_to_local(source_map_url), resource_is_opaque, is_wasm, is_module,
+      ptr_to_local(host_defined_options));
 }
 
 int v8__ScriptOrigin__ScriptId(const v8::ScriptOrigin& self) {

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -412,9 +412,6 @@ extern "C" {
   fn v8__Isolate__Enter(this: *mut Isolate);
   fn v8__Isolate__Exit(this: *mut Isolate);
   fn v8__Isolate__GetCurrent() -> *mut Isolate;
-  fn v8__Isolate__GetCurrentHostDefinedOptions(
-    this: *mut Isolate,
-  ) -> *const Data;
   fn v8__Isolate__MemoryPressureNotification(this: *mut Isolate, level: u8);
   fn v8__Isolate__ClearKeptObjects(isolate: *mut Isolate);
   fn v8__Isolate__LowMemoryNotification(isolate: *mut Isolate);
@@ -1427,18 +1424,6 @@ impl Isolate {
       .as_mut()
       .unwrap();
     snapshot_creator.add_context_data(context, data)
-  }
-
-  /// Returns the host defined options set for currently running script or
-  /// module, if available.
-  #[inline(always)]
-  pub fn get_current_host_defined_options<'s>(
-    &mut self,
-    scope: &mut HandleScope<'s, ()>,
-  ) -> Option<Local<'s, Data>> {
-    unsafe {
-      scope.cast_local(|_| v8__Isolate__GetCurrentHostDefinedOptions(self))
-    }
   }
 }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -208,6 +208,19 @@ impl<'s> HandleScope<'s> {
       unsafe { raw::v8__Isolate__GetEnteredOrMicrotaskContext(isolate_ptr) };
     unsafe { Local::from_raw(context_ptr) }.unwrap()
   }
+
+  /// Returns the host defined options set for currently running script or
+  /// module, if available.
+  #[inline(always)]
+  pub fn get_current_host_defined_options(&self) -> Option<Local<'s, Data>> {
+    let data = data::ScopeData::get(self);
+    let isolate_ptr = data.get_isolate_ptr();
+    unsafe {
+      Local::from_raw(raw::v8__Isolate__GetCurrentHostDefinedOptions(
+        isolate_ptr,
+      ))
+    }
+  }
 }
 
 impl<'s> HandleScope<'s, ()> {
@@ -2113,6 +2126,9 @@ mod raw {
     pub(super) fn v8__Isolate__GetDataFromSnapshotOnce(
       this: *mut Isolate,
       index: usize,
+    ) -> *const Data;
+    pub(super) fn v8__Isolate__GetCurrentHostDefinedOptions(
+      this: *mut Isolate,
     ) -> *const Data;
 
     pub(super) fn v8__Context__EQ(


### PR DESCRIPTION
I meant to get this into the 0.100.0 release but forgot. This allows setting `host_defined_options` which will be useful in deno for fixing global modes and and improving `node:vm` compat.