### PR TITLE
chore: binding cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
         if: startsWith(matrix.config.os, 'ubuntu')
         run: |
           sudo apt-get install -y clang-format
-          clang-format --verbose --Werror --dry-run src/*.cc src/*.hpp
+          clang-format --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h
 
       - name: Test (ASAN)
         env:

--- a/build.rs
+++ b/build.rs
@@ -151,9 +151,10 @@ fn build_binding() {
   let bindings = bindgen::Builder::default()
     .header("src/binding.hpp")
     .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-    .clang_args(["-x", "c++", "-std=c++20", "-Iv8/include"])
+    .clang_args(["-x", "c++", "-std=c++20", "-Iv8/include", "-I."])
     .clang_args(args)
-    .allowlist_item("RUST_.*")
+    .allowlist_item("v8__.*")
+    .allowlist_item("cppgc__.*")
     .generate()
     .expect("Unable to generate bindings");
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -406,6 +406,10 @@ void v8__TracedReference__CONSTRUCT(
   construct_in_place<v8::TracedReference<v8::Data>>(buf);
 }
 
+void v8__TracedReference__DESTRUCT(v8::TracedReference<v8::Data>* self) {
+  self->~TracedReference();
+}
+
 void v8__TracedReference__Reset(v8::TracedReference<v8::Data>* self,
                                 v8::Isolate* isolate, const v8::Data* other) {
   self->Reset(isolate, ptr_to_local(other));
@@ -513,9 +517,6 @@ uint32_t v8__ScriptCompiler__CachedDataVersionTag() {
 
 size_t v8__TypedArray__Length(const v8::TypedArray* self) {
   return ptr_to_local(self)->Length();
-}
-size_t v8__TypedArray__kMaxByteLength() {
-  return v8::TypedArray::kMaxByteLength;
 }
 
 bool v8__Data__EQ(const v8::Data& self, const v8::Data& other) {
@@ -1003,8 +1004,6 @@ long std__shared_ptr__v8__ArrayBuffer__Allocator__use_count(
 int v8__Name__GetIdentityHash(const v8::Name& self) {
   return ptr_to_local(&self)->GetIdentityHash();
 }
-
-size_t v8__String__kMaxLength() { return v8::String::kMaxLength; }
 
 const v8::String* v8__String__Empty(v8::Isolate* isolate) {
   return local_to_ptr(v8::String::Empty(isolate));
@@ -2550,20 +2549,8 @@ void v8__AllowJavascriptExecutionScope__DESTRUCT(
                                     size_t byte_offset, size_t length) { \
     return local_to_ptr(                                                 \
         v8::NAME::New(ptr_to_local(&buf_ptr), byte_offset, length));     \
-  }                                                                      \
-  size_t v8__##NAME##__kMaxLength() { return v8::NAME::kMaxLength; }
-
-V(Uint8Array)
-V(Uint8ClampedArray)
-V(Int8Array)
-V(Uint16Array)
-V(Int16Array)
-V(Uint32Array)
-V(Int32Array)
-V(Float32Array)
-V(Float64Array)
-V(BigUint64Array)
-V(BigInt64Array)
+  }
+EACH_TYPED_ARRAY(V)
 #undef V
 
 const v8::Script* v8__Script__Compile(const v8::Context& context,

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -1,23 +1,30 @@
 #include <v8-cppgc.h>
 #include <v8-message.h>
+#include <v8-typed-array.h>
+
+#include "support.h"
 
 /**
  * Types defined here will be compiled with bindgen
  * and made available in `crate::binding` in rust.
  */
 
-namespace {
-
 class RustObj;
 
-}
+static size_t v8__ScriptOrigin_SIZE = sizeof(v8::ScriptOrigin);
 
-static size_t RUST_v8__ScriptOrigin_SIZE = sizeof(v8::ScriptOrigin);
+static size_t cppgc__Member_SIZE = sizeof(cppgc::Member<RustObj>);
+static size_t cppgc__WeakMember_SIZE = sizeof(cppgc::WeakMember<RustObj>);
 
-static size_t RUST_cppgc__Member_SIZE = sizeof(cppgc::Member<RustObj>);
-static size_t RUST_cppgc__WeakMember_SIZE = sizeof(cppgc::WeakMember<RustObj>);
+static size_t v8__TracedReference_SIZE = sizeof(v8::TracedReference<v8::Data>);
 
-static size_t RUST_v8__TracedReference_SIZE =
-    sizeof(v8::TracedReference<v8::Data>);
+static size_t v8__String__ValueView_SIZE = sizeof(v8::String::ValueView);
 
-static size_t RUST_v8__String__ValueView_SIZE = sizeof(v8::String::ValueView);
+static int v8__String__kMaxLength = v8::String::kMaxLength;
+
+static size_t v8__TypedArray__kMaxByteLength = v8::TypedArray::kMaxByteLength;
+
+#define TYPED_ARRAY_MAX_LENGTH(name) \
+  static size_t v8__##name##__kMaxLength = v8::name::kMaxLength;
+EACH_TYPED_ARRAY(TYPED_ARRAY_MAX_LENGTH)
+#undef TYPED_ARRAY_MAX_LENGTH

--- a/src/cppgc.rs
+++ b/src/cppgc.rs
@@ -337,7 +337,7 @@ macro_rules! member {
   ($( # $attr:tt )* $name:ident) => {
     paste::paste! {
       #[repr(transparent)]
-      struct [< $name Inner >]([u8; crate::binding:: [< RUST_cppgc__ $name _SIZE >]]);
+      struct [< $name Inner >]([u8; crate::binding:: [< cppgc__ $name _SIZE >]]);
 
       impl [< $name Inner >] {
         fn new(ptr: *mut RustObj) -> Self {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -37,6 +37,7 @@ extern "C" {
   );
 
   fn v8__TracedReference__CONSTRUCT(this: *mut TracedReference<Data>);
+  fn v8__TracedReference__DESTRUCT(this: *mut TracedReference<Data>);
   fn v8__TracedReference__Reset(
     this: *mut TracedReference<Data>,
     isolate: *mut Isolate,
@@ -1037,7 +1038,7 @@ impl FinalizerMap {
 /// reclaimed. For more details see BasicTracedReference.
 #[repr(C)]
 pub struct TracedReference<T> {
-  data: [u8; crate::binding::RUST_v8__TracedReference_SIZE],
+  data: [u8; crate::binding::v8__TracedReference_SIZE],
   _phantom: PhantomData<T>,
 }
 
@@ -1085,6 +1086,16 @@ impl<T> TracedReference<T> {
           .map(|h| h.as_non_null().as_ptr())
           .unwrap_or(std::ptr::null_mut())
           .cast(),
+      );
+    }
+  }
+}
+
+impl<T> Drop for TracedReference<T> {
+  fn drop(&mut self) {
+    unsafe {
+      v8__TracedReference__DESTRUCT(
+        self as *mut Self as *mut TracedReference<Data>,
       );
     }
   }

--- a/src/script.rs
+++ b/src/script.rs
@@ -14,7 +14,7 @@ use crate::Value;
 #[repr(C)]
 #[derive(Debug)]
 pub struct ScriptOrigin<'s>(
-  [u8; crate::binding::RUST_v8__ScriptOrigin_SIZE],
+  [u8; crate::binding::v8__ScriptOrigin_SIZE],
   PhantomData<&'s ()>,
 );
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,3 +1,4 @@
+use crate::binding::v8__String__kMaxLength;
 use crate::support::char;
 use crate::support::int;
 use crate::support::size_t;
@@ -16,8 +17,6 @@ use std::ptr::NonNull;
 use std::slice;
 
 extern "C" {
-  fn v8__String__kMaxLength() -> size_t;
-
   fn v8__String__Empty(isolate: *mut Isolate) -> *const String;
 
   fn v8__String__NewFromUtf8(
@@ -329,10 +328,7 @@ impl String {
   /// The maximum length (in bytes) of a buffer that a v8::String can be built
   /// from. Attempting to create a v8::String from a larger buffer will result
   /// in None being returned.
-  #[inline(always)]
-  pub fn max_length() -> usize {
-    unsafe { v8__String__kMaxLength() }
-  }
+  pub const MAX_LENGTH: usize = v8__String__kMaxLength as _;
 
   #[inline(always)]
   pub fn empty<'s>(scope: &mut HandleScope<'s, ()>) -> Local<'s, String> {
@@ -967,7 +963,7 @@ pub enum ValueViewData<'s> {
 /// V8 strings are either encoded as one-byte or two-bytes per character.
 #[repr(C)]
 pub struct ValueView<'s>(
-  [u8; crate::binding::RUST_v8__String__ValueView_SIZE],
+  [u8; crate::binding::v8__String__ValueView_SIZE],
   PhantomData<&'s ()>,
 );
 

--- a/src/support.h
+++ b/src/support.h
@@ -176,4 +176,17 @@ struct three_pointers_t {
 
 }  // namespace support
 
+#define EACH_TYPED_ARRAY(V) \
+  V(Uint8Array)             \
+  V(Uint8ClampedArray)      \
+  V(Int8Array)              \
+  V(Uint16Array)            \
+  V(Int16Array)             \
+  V(Uint32Array)            \
+  V(Int32Array)             \
+  V(Float32Array)           \
+  V(Float64Array)           \
+  V(BigUint64Array)         \
+  V(BigInt64Array)
+
 #endif  // SUPPORT_H_

--- a/src/typed_array.rs
+++ b/src/typed_array.rs
@@ -1,22 +1,20 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
+use crate::binding::v8__TypedArray__kMaxByteLength;
 use crate::support::size_t;
 use crate::ArrayBuffer;
 use crate::HandleScope;
 use crate::Local;
 use crate::TypedArray;
+use paste::paste;
 
 extern "C" {
-  fn v8__TypedArray__kMaxByteLength() -> size_t;
   fn v8__TypedArray__Length(this: *const TypedArray) -> size_t;
 }
 
 impl TypedArray {
   /// The largest supported typed array byte size. Each subclass defines a
   /// type-specific max_length for the maximum length that can be passed to new.
-  #[inline(always)]
-  pub fn max_byte_length() -> usize {
-    unsafe { v8__TypedArray__kMaxByteLength() }
-  }
+  pub const MAX_BYTE_LENGTH: usize = v8__TypedArray__kMaxByteLength;
 
   /// Number of elements in this typed array
   /// (e.g. for Int16Array, |ByteLength|/2).
@@ -27,75 +25,42 @@ impl TypedArray {
 }
 
 macro_rules! typed_array {
-  ($name:ident, $new_func:ident, $max_length_func:ident) => {
-    use crate::$name;
-    impl $name {
-      #[inline(always)]
-      pub fn new<'s>(
-        scope: &mut HandleScope<'s>,
-        buf: Local<ArrayBuffer>,
-        byte_offset: usize,
-        length: usize,
-      ) -> Option<Local<'s, $name>> {
-        extern "C" {
-          fn $new_func(
-            buf_ptr: *const ArrayBuffer,
-            byte_offset: usize,
-            length: usize,
-          ) -> *const $name;
+  ($name:ident) => {
+    paste! {
+      use crate::$name;
+      impl $name {
+        #[inline(always)]
+        pub fn new<'s>(
+          scope: &mut HandleScope<'s>,
+          buf: Local<ArrayBuffer>,
+          byte_offset: usize,
+          length: usize,
+        ) -> Option<Local<'s, $name>> {
+          extern "C" {
+            fn [< v8__ $name __New >](
+              buf_ptr: *const ArrayBuffer,
+              byte_offset: usize,
+              length: usize,
+            ) -> *const $name;
+          }
+          unsafe { scope.cast_local(|_| [< v8__ $name __New >](&*buf, byte_offset, length)) }
         }
-        unsafe { scope.cast_local(|_| $new_func(&*buf, byte_offset, length)) }
-      }
 
-      #[doc = concat!("The largest ", stringify!($name), " size that can be constructed using `new`.")]
-      #[inline(always)]
-      pub fn max_length() -> usize {
-        extern "C" {
-          fn $max_length_func() -> usize;
-        }
-        unsafe { $max_length_func() }
+        #[doc = concat!("The largest ", stringify!($name), " size that can be constructed using `new`.")]
+        pub const MAX_LENGTH: usize = crate::binding::[< v8__ $name __kMaxLength >];
       }
-
     }
   };
 }
 
-typed_array!(Uint8Array, v8__Uint8Array__New, v8__Uint8Array__kMaxLength);
-typed_array!(
-  Uint8ClampedArray,
-  v8__Uint8ClampedArray__New,
-  v8__Uint8ClampedArray__kMaxLength
-);
-typed_array!(Int8Array, v8__Int8Array__New, v8__Int8Array__kMaxLength);
-typed_array!(
-  Uint16Array,
-  v8__Uint16Array__New,
-  v8__Uint16Array__kMaxLength
-);
-typed_array!(Int16Array, v8__Int16Array__New, v8__Int16Array__kMaxLength);
-typed_array!(
-  Uint32Array,
-  v8__Uint32Array__New,
-  v8__Uint32Array__kMaxLength
-);
-typed_array!(Int32Array, v8__Int32Array__New, v8__Int32Array__kMaxLength);
-typed_array!(
-  Float32Array,
-  v8__Float32Array__New,
-  v8__Float32Array__kMaxLength
-);
-typed_array!(
-  Float64Array,
-  v8__Float64Array__New,
-  v8__Float64Array__kMaxLength
-);
-typed_array!(
-  BigUint64Array,
-  v8__BigUint64Array__New,
-  v8__BigUint64Array__kMaxLength
-);
-typed_array!(
-  BigInt64Array,
-  v8__BigInt64Array__New,
-  v8__BigInt64Array__kMaxLength
-);
+typed_array!(Uint8Array);
+typed_array!(Uint8ClampedArray);
+typed_array!(Int8Array);
+typed_array!(Uint16Array);
+typed_array!(Int16Array);
+typed_array!(Uint32Array);
+typed_array!(Int32Array);
+typed_array!(Float32Array);
+typed_array!(Float64Array);
+typed_array!(BigUint64Array);
+typed_array!(BigInt64Array);

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -320,7 +320,7 @@ fn test_string() {
   }
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let mut buffer = Vec::with_capacity(v8::String::max_length());
+    let mut buffer = Vec::with_capacity(v8::String::MAX_LENGTH);
     for _ in 0..buffer.capacity() / 4 {
       // U+10348 in UTF-8
       buffer.push(0xF0_u8);
@@ -332,13 +332,13 @@ fn test_string() {
       v8::String::new_from_utf8(scope, &buffer, v8::NewStringType::Normal)
         .unwrap();
     // U+10348 is 2 UTF-16 code units, which is the unit of v8::String.length().
-    assert_eq!(v8::String::max_length() / 2, local.length());
+    assert_eq!(v8::String::MAX_LENGTH / 2, local.length());
     assert_eq!(
       buffer.as_slice(),
       local.to_rust_string_lossy(scope).as_bytes()
     );
 
-    let mut too_long = Vec::with_capacity(v8::String::max_length() + 4);
+    let mut too_long = Vec::with_capacity(v8::String::MAX_LENGTH + 4);
     for _ in 0..too_long.capacity() / 4 {
       // U+10348 in UTF-8
       too_long.push(0xF0_u8);
@@ -5764,109 +5764,109 @@ fn typed_array_constructors() {
   assert!(t.is_uint8_array());
   assert_eq!(t.length(), 0);
 
-  // Uint8Array::max_length() ought to be 1 << 53 - 1 on 64 bits when heap
+  // Uint8Array::MAX_LENGTH ought to be 1 << 53 - 1 on 64 bits when heap
   // sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 53) - 1, v8::Uint8Array::max_length());
+  assert_eq!((1 << 53) - 1, v8::Uint8Array::MAX_LENGTH);
 
   let t = v8::Uint8ClampedArray::new(scope, ab, 0, 0).unwrap();
   assert!(t.is_uint8_clamped_array());
   assert_eq!(t.length(), 0);
 
-  // Uint8ClampedArray::max_length() ought to be 1 << 53 - 1 on 64 bits when
+  // Uint8ClampedArray::MAX_LENGTH ought to be 1 << 53 - 1 on 64 bits when
   // heap sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 53) - 1, v8::Uint8ClampedArray::max_length());
+  assert_eq!((1 << 53) - 1, v8::Uint8ClampedArray::MAX_LENGTH);
 
   let t = v8::Int8Array::new(scope, ab, 0, 0).unwrap();
   assert!(t.is_int8_array());
   assert_eq!(t.length(), 0);
 
-  // Int8Array::max_length() ought to be 1 << 53 - 1 on 64 bits when heap
+  // Int8Array::MAX_LENGTH ought to be 1 << 53 - 1 on 64 bits when heap
   // sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 53) - 1, v8::Int8Array::max_length());
+  assert_eq!((1 << 53) - 1, v8::Int8Array::MAX_LENGTH);
 
   let t = v8::Uint16Array::new(scope, ab, 0, 0).unwrap();
   assert!(t.is_uint16_array());
   assert_eq!(t.length(), 0);
 
-  // Uint16Array::max_length() ought to be 1 << 52 - 1 on 64 bits when heap
+  // Uint16Array::MAX_LENGTH ought to be 1 << 52 - 1 on 64 bits when heap
   // sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 52) - 1, v8::Uint16Array::max_length());
+  assert_eq!((1 << 52) - 1, v8::Uint16Array::MAX_LENGTH);
 
   let t = v8::Int16Array::new(scope, ab, 0, 0).unwrap();
   assert!(t.is_int16_array());
   assert_eq!(t.length(), 0);
 
-  // Int16Array::max_length() ought to be 1 << 52 - 1 on 64 bits when heap
+  // Int16Array::MAX_LENGTH ought to be 1 << 52 - 1 on 64 bits when heap
   // sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 52) - 1, v8::Int16Array::max_length());
+  assert_eq!((1 << 52) - 1, v8::Int16Array::MAX_LENGTH);
 
   let t = v8::Uint32Array::new(scope, ab, 0, 0).unwrap();
   assert!(t.is_uint32_array());
   assert_eq!(t.length(), 0);
 
-  // Uint32Array::max_length() ought to be 1 << 51 - 1 on 64 bits when heap
+  // Uint32Array::MAX_LENGTH ought to be 1 << 51 - 1 on 64 bits when heap
   // sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 51) - 1, v8::Uint32Array::max_length());
+  assert_eq!((1 << 51) - 1, v8::Uint32Array::MAX_LENGTH);
 
   let t = v8::Int32Array::new(scope, ab, 0, 0).unwrap();
   assert!(t.is_int32_array());
   assert_eq!(t.length(), 0);
 
-  // Int32Array::max_length() ought to be 1 << 51 - 1 on 64 bits when heap
+  // Int32Array::MAX_LENGTH ought to be 1 << 51 - 1 on 64 bits when heap
   // sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 51) - 1, v8::Int32Array::max_length());
+  assert_eq!((1 << 51) - 1, v8::Int32Array::MAX_LENGTH);
 
   let t = v8::Float32Array::new(scope, ab, 0, 0).unwrap();
   assert!(t.is_float32_array());
   assert_eq!(t.length(), 0);
 
-  // Float32Array::max_length() ought to be 1 << 51 - 1 on 64 bits when heap
+  // Float32Array::MAX_LENGTH ought to be 1 << 51 - 1 on 64 bits when heap
   // sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 51) - 1, v8::Float32Array::max_length());
+  assert_eq!((1 << 51) - 1, v8::Float32Array::MAX_LENGTH);
 
   let t = v8::Float64Array::new(scope, ab, 0, 0).unwrap();
   assert!(t.is_float64_array());
   assert_eq!(t.length(), 0);
 
-  // Float64Array::max_length() ought to be 1 << 50 - 1 on 64 bits when heap
+  // Float64Array::MAX_LENGTH ought to be 1 << 50 - 1 on 64 bits when heap
   // sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 50) - 1, v8::Float64Array::max_length());
+  assert_eq!((1 << 50) - 1, v8::Float64Array::MAX_LENGTH);
 
   let t = v8::BigUint64Array::new(scope, ab, 0, 0).unwrap();
   assert!(t.is_big_uint64_array());
   assert_eq!(t.length(), 0);
 
-  // BigUint64Array::max_length() ought to be 1 << 50 - 1 on 64 bits when heap
+  // BigUint64Array::MAX_LENGTH ought to be 1 << 50 - 1 on 64 bits when heap
   // sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 50) - 1, v8::BigUint64Array::max_length());
+  assert_eq!((1 << 50) - 1, v8::BigUint64Array::MAX_LENGTH);
 
   let t = v8::BigInt64Array::new(scope, ab, 0, 0).unwrap();
   assert!(t.is_big_int64_array());
   assert_eq!(t.length(), 0);
 
-  // BigInt64Array::max_length() ought to be 1 << 50 - 1 on 64 bits when heap
+  // BigInt64Array::MAX_LENGTH ought to be 1 << 50 - 1 on 64 bits when heap
   // sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 50) - 1, v8::BigInt64Array::max_length());
+  assert_eq!((1 << 50) - 1, v8::BigInt64Array::MAX_LENGTH);
 
-  // TypedArray::max_byte_length() ought to be 1 << 53 - 1 on 64 bits when heap
+  // TypedArray::MAX_BYTE_LENGTH ought to be 1 << 53 - 1 on 64 bits when heap
   // sandbox is disabled.
   #[cfg(target_pointer_width = "64")]
-  assert_eq!((1 << 53) - 1, v8::TypedArray::max_byte_length());
+  assert_eq!((1 << 53) - 1, v8::TypedArray::MAX_BYTE_LENGTH);
 
-  // TypedArray::max_byte_length() ought to be >= 2^28 < 2^30 in 32 bits
+  // TypedArray::MAX_BYTE_LENGTH ought to be >= 2^28 < 2^30 in 32 bits
   #[cfg(target_pointer_width = "32")]
-  assert!(((2 << 28)..(2 << 30)).contains(&v8::TypedArray::max_byte_length()));
+  assert!(((2 << 28)..(2 << 30)).contains(&v8::TypedArray::MAX_BYTE_LENGTH));
 
   // v8::ArrayBuffer::new raises a fatal if the length is > kMaxLength, so we test this behavior
   // through the JS side of things, where a non-fatal RangeError is thrown in such cases.
@@ -5874,7 +5874,7 @@ fn typed_array_constructors() {
     let scope = &mut v8::TryCatch::new(scope);
     eval(
       scope,
-      &format!("new Uint8Array({})", v8::Uint8Array::max_length() + 1),
+      &format!("new Uint8Array({})", v8::Uint8Array::MAX_LENGTH + 1),
     );
     // Array is too big (> max_length) - expecting this threw a RangeError
     assert!(scope.has_caught());


### PR DESCRIPTION
Gets rid of some superfluous functions and also deletes the unneeded `RUST_` prefix. also fixed a missing destructor.