### PR TITLE
Fixes for disabling `v8_enable_pointer_compression_shared_cage`

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -1617,8 +1617,8 @@ impl Drop for OwnedIsolate {
         self.cxx_isolate.as_mut() as *mut Isolate == v8__Isolate__GetCurrent(),
         "v8::OwnedIsolate instances must be dropped in the reverse order of creation. They are entered upon creation and exited upon being dropped."
       );
-      self.exit();
       self.dispose_scope_root();
+      self.exit();
       self.dispose_annex();
       self.dispose();
     }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -554,10 +554,10 @@ fn context_scope() {
 fn context_scope_param_and_context_must_share_isolate() {
   let _setup_guard = setup::parallel_test();
   let isolate1 = &mut v8::Isolate::new(Default::default());
-  let isolate2 = &mut v8::Isolate::new(Default::default());
   let scope1 = &mut v8::HandleScope::new(isolate1);
-  let scope2 = &mut v8::HandleScope::new(isolate2);
   let context1 = v8::Context::new(scope1);
+  let isolate2 = &mut v8::Isolate::new(Default::default());
+  let scope2 = &mut v8::HandleScope::new(isolate2);
   let context2 = v8::Context::new(scope2);
   let _context_scope_12 = &mut v8::ContextScope::new(scope1, context2);
   let _context_scope_21 = &mut v8::ContextScope::new(scope2, context1);
@@ -570,15 +570,17 @@ fn context_scope_param_and_context_must_share_isolate() {
 fn handle_scope_param_and_context_must_share_isolate() {
   let _setup_guard = setup::parallel_test();
   let isolate1 = &mut v8::Isolate::new(Default::default());
-  let isolate2 = &mut v8::Isolate::new(Default::default());
   let global_context1;
-  let global_context2;
   {
     let scope1 = &mut v8::HandleScope::new(isolate1);
-    let scope2 = &mut v8::HandleScope::new(isolate2);
     let local_context_1 = v8::Context::new(scope1);
-    let local_context_2 = v8::Context::new(scope2);
     global_context1 = v8::Global::new(scope1, local_context_1);
+  }
+  let isolate2 = &mut v8::Isolate::new(Default::default());
+  let global_context2;
+  {
+    let scope2 = &mut v8::HandleScope::new(isolate2);
+    let local_context_2 = v8::Context::new(scope2);
     global_context2 = v8::Global::new(scope2, local_context_2);
   }
   let _handle_scope_12 =


### PR DESCRIPTION
When turning off `v8_enable_pointer_compression_shared_cage` (_to get more than 4GB of heap available for several isolates running in the same process_), several tests fail or crash.

Here are a few fixes to make them pass:

When dropping an Isolate, we should dispose its scopes before exiting the Isolate. The issue surfaces only when `pointer_compression_shared_cage` is disabled, but I believe this is the right way to do it.

The tests using several Isolates crashes the process. This is because of the way Isolates are automatically entered when created (_and exited when dropped_). At least when  `pointer_compression_shared_cage` is disabled, some state is kept in a thread local, and entering `isolate2` makes `isolate1` unusable.

This is probably another discussion but unless the Rust API provides an explicit way to enter/exit Isolates, I'm not sure if it is a good idea to have 2 Isolates on the same thread. Maybe it should be forbidden (_I don't think we can prevent that statically but it could be checked and prevented at runtime_).