### PR TITLE
feat: changes for vm

### DIFF
--- a/benches/function.rs
+++ b/benches/function.rs
@@ -11,7 +11,7 @@ fn main() {
   v8::V8::initialize();
   let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
   let handle_scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(handle_scope);
+  let context = v8::Context::new(handle_scope, Default::default());
   let scope = &mut v8::ContextScope::new(handle_scope, context);
   let global = context.global(scope);
   {

--- a/examples/cppgc-object.rs
+++ b/examples/cppgc-object.rs
@@ -36,7 +36,7 @@ fn main() {
       &mut v8::Isolate::new(v8::CreateParams::default().cpp_heap(heap));
 
     let handle_scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(handle_scope);
+    let context = v8::Context::new(handle_scope, Default::default());
     let scope = &mut v8::ContextScope::new(handle_scope, context);
     let global = context.global(scope);
     {

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -12,7 +12,7 @@ fn main() {
     let handle_scope = &mut v8::HandleScope::new(isolate);
 
     // Create a new context.
-    let context = v8::Context::new(handle_scope);
+    let context = v8::Context::new(handle_scope, Default::default());
 
     // Enter the context for compiling and running the hello world script.
     let scope = &mut v8::ContextScope::new(handle_scope, context);

--- a/examples/process.rs
+++ b/examples/process.rs
@@ -148,7 +148,13 @@ where
       v8::FunctionTemplate::new(isolate_scope, log_callback).into(),
     );
 
-    let context = v8::Context::new_from_template(isolate_scope, global);
+    let context = v8::Context::new(
+      isolate_scope,
+      v8::ContextOptions {
+        global_template: Some(global),
+        ..Default::default()
+      },
+    );
     let mut context_scope = v8::ContextScope::new(isolate_scope, context);
 
     let request_template = v8::ObjectTemplate::new(&mut context_scope);

--- a/examples/shell.rs
+++ b/examples/shell.rs
@@ -12,7 +12,7 @@ fn main() {
   let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
   let handle_scope = &mut v8::HandleScope::new(isolate);
 
-  let context = v8::Context::new(handle_scope);
+  let context = v8::Context::new(handle_scope, Default::default());
 
   let context_scope = &mut v8::ContextScope::new(handle_scope, context);
   let scope = &mut v8::HandleScope::new(context_scope);

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -345,6 +345,11 @@ void v8__Isolate__SetWasmStreamingCallback(v8::Isolate* isolate,
   isolate->SetWasmStreamingCallback(callback);
 }
 
+void v8__Isolate__SetAllowWasmCodeGenerationCallback(
+    v8::Isolate* isolate, v8::AllowWasmCodeGenerationCallback callback) {
+  isolate->SetAllowWasmCodeGenerationCallback(callback);
+}
+
 bool v8__Isolate__HasPendingBackgroundTasks(v8::Isolate* isolate) {
   return isolate->HasPendingBackgroundTasks();
 }
@@ -1651,6 +1656,13 @@ const v8::Value* v8__Object__GetRealNamedProperty(const v8::Object& self,
       ptr_to_local(&context), ptr_to_local(&key)));
 }
 
+MaybeBool v8__Object__HasRealNamedProperty(const v8::Object& self,
+                                           const v8::Context& context,
+                                           const v8::Name& key) {
+  return maybe_to_maybe_bool(ptr_to_local(&self)->HasRealNamedProperty(
+      ptr_to_local(&context), ptr_to_local(&key)));
+}
+
 void v8__Object__GetRealNamedPropertyAttributes(
     const v8::Object& self, const v8::Context& context, const v8::Name& key,
     v8::Maybe<v8::PropertyAttribute>* out) {
@@ -1943,12 +1955,13 @@ void DeserializeInternalFields(v8::Local<v8::Object> holder, int index,
 
 const v8::Context* v8__Context__New(v8::Isolate* isolate,
                                     const v8::ObjectTemplate* templ,
-                                    const v8::Value* global_object) {
-  return local_to_ptr(
-      v8::Context::New(isolate, nullptr, ptr_to_maybe_local(templ),
-                       ptr_to_maybe_local(global_object),
-                       v8::DeserializeInternalFieldsCallback(
-                           DeserializeInternalFields, nullptr)));
+                                    const v8::Value* global_object,
+                                    v8::MicrotaskQueue* microtask_queue) {
+  return local_to_ptr(v8::Context::New(
+      isolate, nullptr, ptr_to_maybe_local(templ),
+      ptr_to_maybe_local(global_object),
+      v8::DeserializeInternalFieldsCallback(DeserializeInternalFields, nullptr),
+      microtask_queue));
 }
 
 bool v8__Context__EQ(const v8::Context& self, const v8::Context& other) {
@@ -2035,10 +2048,13 @@ void v8__Context__SetMicrotaskQueue(v8::Context& self,
   ptr_to_local(&self)->SetMicrotaskQueue(microtask_queue);
 }
 
-const v8::Context* v8__Context__FromSnapshot(v8::Isolate* isolate,
-                                             size_t context_snapshot_index) {
-  v8::MaybeLocal<v8::Context> maybe_local =
-      v8::Context::FromSnapshot(isolate, context_snapshot_index);
+const v8::Context* v8__Context__FromSnapshot(
+    v8::Isolate* isolate, size_t context_snapshot_index,
+    v8::Value* global_object, v8::MicrotaskQueue* microtask_queue) {
+  v8::MaybeLocal<v8::Context> maybe_local = v8::Context::FromSnapshot(
+      isolate, context_snapshot_index,
+      v8::DeserializeInternalFieldsCallback(DeserializeInternalFields, nullptr),
+      nullptr, ptr_to_maybe_local(global_object), microtask_queue);
   return maybe_local_to_ptr(maybe_local);
 }
 

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -170,6 +170,9 @@ pub type WasmAsyncResolvePromiseCallback = extern "C" fn(
   WasmAsyncSuccess,
 );
 
+pub type AllowWasmCodeGenerationCallback =
+  extern "C" fn(Local<Context>, Local<String>) -> bool;
+
 /// HostInitializeImportMetaObjectCallback is called the first time import.meta
 /// is accessed for a module. Subsequent access will reuse the same value.
 ///
@@ -472,6 +475,10 @@ extern "C" {
   fn v8__Isolate__SetWasmAsyncResolvePromiseCallback(
     isolate: *mut Isolate,
     callback: WasmAsyncResolvePromiseCallback,
+  );
+  fn v8__Isolate__SetAllowWasmCodeGenerationCallback(
+    isolate: *mut Isolate,
+    callback: AllowWasmCodeGenerationCallback,
   );
   fn v8__Isolate__SetHostInitializeImportMetaObjectCallback(
     isolate: *mut Isolate,
@@ -1030,6 +1037,16 @@ impl Isolate {
     callback: WasmAsyncResolvePromiseCallback,
   ) {
     unsafe { v8__Isolate__SetWasmAsyncResolvePromiseCallback(self, callback) }
+  }
+
+  #[inline(always)]
+  pub fn set_allow_wasm_code_generation_callback(
+    &mut self,
+    callback: AllowWasmCodeGenerationCallback,
+  ) {
+    unsafe {
+      v8__Isolate__SetAllowWasmCodeGenerationCallback(self, callback);
+    }
   }
 
   #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! let isolate = &mut v8::Isolate::new(Default::default());
 //!
 //! let scope = &mut v8::HandleScope::new(isolate);
-//! let context = v8::Context::new(scope);
+//! let context = v8::Context::new(scope, Default::default());
 //! let scope = &mut v8::ContextScope::new(scope, context);
 //!
 //! let code = v8::String::new(scope, "'Hello' + ' World!'").unwrap();
@@ -32,6 +32,7 @@ mod array_buffer_view;
 mod bigint;
 mod binding;
 mod context;
+pub use context::ContextOptions;
 pub mod cppgc;
 mod data;
 mod date;

--- a/src/object.rs
+++ b/src/object.rs
@@ -220,6 +220,11 @@ extern "C" {
     context: *const Context,
     key: *const Name,
   ) -> *const Value;
+  fn v8__Object__HasRealNamedProperty(
+    this: *const Object,
+    context: *const Context,
+    key: *const Name,
+  ) -> MaybeBool;
   fn v8__Object__GetRealNamedPropertyAttributes(
     this: *const Object,
     context: *const Context,
@@ -980,6 +985,22 @@ impl Object {
         v8__Object__GetRealNamedProperty(self, sd.get_current_context(), &*key)
       })
     }
+  }
+
+  #[inline(always)]
+  pub fn has_real_named_property(
+    &self,
+    scope: &mut HandleScope,
+    key: Local<Name>,
+  ) -> Option<bool> {
+    unsafe {
+      v8__Object__HasRealNamedProperty(
+        self,
+        &*scope.get_current_context(),
+        &*key,
+      )
+    }
+    .into()
   }
 
   /// Gets the property attributes of a real property which can be

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -2224,6 +2224,7 @@ mod raw {
 mod tests {
   use super::*;
   use crate::new_default_platform;
+  use crate::ContextOptions;
   use crate::Global;
   use crate::V8;
   use std::any::type_name;
@@ -2261,7 +2262,7 @@ mod tests {
     AssertTypeOf(isolate).is::<OwnedIsolate>();
     let l1_hs = &mut HandleScope::new(isolate);
     AssertTypeOf(l1_hs).is::<HandleScope<()>>();
-    let context = Context::new(l1_hs);
+    let context = Context::new(l1_hs, ContextOptions::default());
     {
       let l2_cxs = &mut ContextScope::new(l1_hs, context);
       AssertTypeOf(l2_cxs).is::<ContextScope<HandleScope>>();
@@ -2437,7 +2438,7 @@ mod tests {
     {
       let l1_hs = &mut HandleScope::new(isolate);
       AssertTypeOf(l1_hs).is::<HandleScope<()>>();
-      let context = Context::new(l1_hs);
+      let context = Context::new(l1_hs, Default::default());
       global_context = Global::new(l1_hs, context);
       AssertTypeOf(&HandleScope::new(l1_hs)).is::<HandleScope<()>>();
       {
@@ -2541,7 +2542,7 @@ mod tests {
     {
       let l1_cbs = &mut unsafe { CallbackScope::new(&mut *isolate) };
       AssertTypeOf(l1_cbs).is::<CallbackScope<()>>();
-      let context = Context::new(l1_cbs);
+      let context = Context::new(l1_cbs, Default::default());
       AssertTypeOf(&ContextScope::new(l1_cbs, context))
         .is::<ContextScope<HandleScope>>();
       AssertTypeOf(&HandleScope::new(l1_cbs)).is::<HandleScope<()>>();

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -196,7 +196,7 @@ impl Drop for Source {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CompileOptions {
   NoCompileOptions = 0,
   ConsumeCodeCache,
@@ -232,11 +232,11 @@ pub enum NoCacheReason {
 #[inline(always)]
 pub fn compile_module<'s>(
   scope: &mut HandleScope<'s>,
-  mut source: Source,
+  source: &mut Source,
 ) -> Option<Local<'s, Module>> {
   compile_module2(
     scope,
-    &mut source,
+    source,
     CompileOptions::NoCompileOptions,
     NoCacheReason::NoReason,
   )
@@ -284,7 +284,7 @@ pub fn compile<'s>(
 #[inline(always)]
 pub fn compile_function<'s>(
   scope: &mut HandleScope<'s>,
-  mut source: Source,
+  source: &mut Source,
   arguments: &[Local<String>],
   context_extensions: &[Local<Object>],
   options: CompileOptions,
@@ -296,7 +296,7 @@ pub fn compile_function<'s>(
     scope.cast_local(|sd| {
       v8__ScriptCompiler__CompileFunction(
         &*sd.get_current_context(),
-        &mut source,
+        source,
         arguments.len(),
         arguments.as_ptr(),
         context_extensions.len(),
@@ -311,7 +311,7 @@ pub fn compile_function<'s>(
 #[inline(always)]
 pub fn compile_unbound_script<'s>(
   scope: &mut HandleScope<'s>,
-  mut source: Source,
+  source: &mut Source,
   options: CompileOptions,
   no_cache_reason: NoCacheReason,
 ) -> Option<Local<'s, UnboundScript>> {
@@ -319,7 +319,7 @@ pub fn compile_unbound_script<'s>(
     scope.cast_local(|sd| {
       v8__ScriptCompiler__CompileUnboundScript(
         sd.get_isolate_ptr(),
-        &mut source,
+        source,
         options,
         no_cache_reason,
       )

--- a/tests/compile_fail/try_catch_exception_lifetime.rs
+++ b/tests/compile_fail/try_catch_exception_lifetime.rs
@@ -3,7 +3,7 @@
 pub fn main() {
   let mut isolate = v8::Isolate::new(mock());
   let mut scope1 = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope1);
+  let context = v8::Context::new(&mut scope1, Default::default());
   let mut scope2 = v8::ContextScope::new(&mut scope1, context);
 
   let _exception = {

--- a/tests/compile_fail/try_catch_message_lifetime.rs
+++ b/tests/compile_fail/try_catch_message_lifetime.rs
@@ -3,7 +3,7 @@
 pub fn main() {
   let mut isolate = v8::Isolate::new(mock());
   let mut scope1 = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope1);
+  let context = v8::Context::new(&mut scope1, Default::default());
   let mut scope2 = v8::ContextScope::new(&mut scope1, context);
 
   let _message = {

--- a/tests/slots.rs
+++ b/tests/slots.rs
@@ -46,7 +46,7 @@ impl CoreIsolate {
   // Returns false if there was an error.
   fn execute(&mut self, code: &str) -> bool {
     let scope = &mut v8::HandleScope::new(&mut self.0);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = v8::String::new(scope, code).unwrap();
     let script = v8::Script::compile(scope, source, None).unwrap();
@@ -255,17 +255,17 @@ fn context_slots() {
   setup();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
 
-  assert!(context.set_slot(scope, TestState(0)));
-  assert!(!context.set_slot(scope, TestState(1)));
+  assert!(context.set_slot(TestState(0)));
+  assert!(!context.set_slot(TestState(1)));
 
-  context.get_slot_mut::<TestState>(scope).unwrap().0 += 5;
-  assert_eq!(context.get_slot::<TestState>(scope).unwrap().0, 6);
+  context.get_slot_mut::<TestState>().unwrap().0 += 5;
+  assert_eq!(context.get_slot::<TestState>().unwrap().0, 6);
 
-  let value = context.remove_slot::<TestState>(scope).unwrap();
+  let value = context.remove_slot::<TestState>().unwrap();
   assert_eq!(value.0, 6);
-  assert!(context.remove_slot::<TestState>(scope).is_none());
+  assert!(context.remove_slot::<TestState>().is_none());
 }
 
 #[test]
@@ -285,9 +285,9 @@ fn dropped_context_slots() {
   let dropped = Rc::new(Cell::new(false));
   {
     let scope = &mut v8::HandleScope::new(isolate.deref_mut());
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
 
-    context.set_slot(scope, DropMarker(dropped.clone()));
+    context.set_slot(DropMarker(dropped.clone()));
   }
 
   assert!(isolate.execute("gc()"));
@@ -311,9 +311,9 @@ fn dropped_context_slots_on_kept_context() {
   let _global_context;
   {
     let scope = &mut v8::HandleScope::new(isolate.deref_mut());
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
 
-    context.set_slot(scope, DropMarker(dropped.clone()));
+    context.set_slot(DropMarker(dropped.clone()));
 
     _global_context = v8::Global::new(scope, context);
   }
@@ -330,12 +330,12 @@ fn clear_all_context_slots() {
 
   {
     let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
-    context.set_slot(scope, TestState(0));
-    context.clear_all_slots(scope);
-    assert!(context.get_slot::<TestState>(scope).is_none());
+    context.set_slot(TestState(0));
+    context.clear_all_slots();
+    assert!(context.get_slot::<TestState>().is_none());
     scope.set_default_context(context);
   }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -174,7 +174,7 @@ fn global_from_into_raw() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let (raw, weak) = {
@@ -206,7 +206,7 @@ fn local_handle_deref() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
   let key = v8::String::new(scope, "key").unwrap();
   let obj: v8::Local<v8::Object> = v8::Object::new(scope);
@@ -529,14 +529,14 @@ fn context_scope() {
   let isolate = &mut v8::Isolate::new(Default::default());
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context1 = v8::Context::new(scope);
+  let context1 = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context1);
 
   assert!(scope.get_current_context() == context1);
   assert!(scope.get_entered_or_microtask_context() == context1);
 
   {
-    let context2 = v8::Context::new(scope);
+    let context2 = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context2);
 
     assert!(scope.get_current_context() == context2);
@@ -557,8 +557,8 @@ fn context_scope_param_and_context_must_share_isolate() {
   let isolate2 = &mut v8::Isolate::new(Default::default());
   let scope1 = &mut v8::HandleScope::new(isolate1);
   let scope2 = &mut v8::HandleScope::new(isolate2);
-  let context1 = v8::Context::new(scope1);
-  let context2 = v8::Context::new(scope2);
+  let context1 = v8::Context::new(scope1, Default::default());
+  let context2 = v8::Context::new(scope2, Default::default());
   let _context_scope_12 = &mut v8::ContextScope::new(scope1, context2);
   let _context_scope_21 = &mut v8::ContextScope::new(scope2, context1);
 }
@@ -576,8 +576,8 @@ fn handle_scope_param_and_context_must_share_isolate() {
   {
     let scope1 = &mut v8::HandleScope::new(isolate1);
     let scope2 = &mut v8::HandleScope::new(isolate2);
-    let local_context_1 = v8::Context::new(scope1);
-    let local_context_2 = v8::Context::new(scope2);
+    let local_context_1 = v8::Context::new(scope1, Default::default());
+    let local_context_2 = v8::Context::new(scope2, Default::default());
     global_context1 = v8::Global::new(scope1, local_context_1);
     global_context2 = v8::Global::new(scope2, local_context_2);
   }
@@ -603,7 +603,7 @@ fn microtasks() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -701,7 +701,7 @@ fn get_isolate_from_handle() {
   let isolate = &mut v8::Isolate::new(Default::default());
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   check_handle(scope, None, v8::null);
@@ -740,7 +740,7 @@ fn data_view() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let ab = v8::ArrayBuffer::new(scope, 42);
@@ -756,7 +756,7 @@ fn array_buffer() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let ab = v8::ArrayBuffer::new(scope, 42);
@@ -915,7 +915,7 @@ fn backing_store_segfault() {
     let isolate = &mut v8::Isolate::new(params);
     array_buffer_allocator.assert_use_count_eq(2);
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let ab = v8::ArrayBuffer::new(scope, 10);
     let shared_bs = ab.get_backing_store();
@@ -955,7 +955,7 @@ fn array_buffer_with_shared_backing_store() {
   {
     let scope = &mut v8::HandleScope::new(isolate);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let ab1 = v8::ArrayBuffer::new(scope, 42);
@@ -1040,7 +1040,7 @@ fn external() {
   let ex1_handle_a = v8::External::new(scope, ex1_value);
   assert_eq!(ex1_handle_a.value(), ex1_value);
 
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
   let global = context.global(scope);
 
@@ -1096,7 +1096,7 @@ fn try_catch() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     {
       // Error thrown - should be caught.
@@ -1146,7 +1146,7 @@ fn try_catch_caught_lifetime() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
   let (caught_exc, caught_msg) = {
     let tc = &mut v8::TryCatch::new(scope);
@@ -1175,7 +1175,7 @@ fn throw_exception() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     {
       let tc = &mut v8::TryCatch::new(scope);
@@ -1250,7 +1250,7 @@ fn terminate_execution() {
   let handle = isolate.thread_safe_handle();
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let t = std::thread::spawn(move || {
@@ -1285,7 +1285,7 @@ fn request_interrupt_small_scripts() {
   let handle = isolate.thread_safe_handle();
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -1350,7 +1350,7 @@ fn add_message_listener() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = v8::String::new(scope, "throw 'foo'").unwrap();
     let script = v8::Script::compile(scope, source, None).unwrap();
@@ -1391,14 +1391,15 @@ fn set_host_initialize_import_meta_object_callback() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
-    let source = mock_source(
+    let mut source = mock_source(
       scope,
       "google.com",
       "if (import.meta.foo != 'bar') throw 'bad'",
     );
-    let module = v8::script_compiler::compile_module(scope, source).unwrap();
+    let module =
+      v8::script_compiler::compile_module(scope, &mut source).unwrap();
     let result =
       module.instantiate_module(scope, unexpected_module_resolve_callback);
     assert!(result.is_some());
@@ -1414,7 +1415,7 @@ fn script_compile_and_run() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = v8::String::new(scope, "'Hello ' + 13 + 'th planet'").unwrap();
     let script = v8::Script::compile(scope, source, None).unwrap();
@@ -1431,7 +1432,7 @@ fn script_origin() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let resource_name = v8::String::new(scope, "foo.js").unwrap();
@@ -1547,7 +1548,7 @@ fn exception() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let msg_in = v8::String::new(scope, "This is a test error").unwrap();
@@ -1570,7 +1571,7 @@ fn create_message_argument_lifetimes() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   {
@@ -1603,7 +1604,7 @@ fn json() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let json_string = v8::String::new(scope, "{\"a\": 1, \"b\": 2}").unwrap();
     let maybe_value = v8::json::parse(scope, json_string);
@@ -1623,7 +1624,7 @@ fn no_internal_field() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let object = v8::Object::new(scope);
     let value = v8::Integer::new(scope, 42).into();
@@ -1650,7 +1651,7 @@ fn object_template() {
       | v8::PropertyAttribute::DONT_DELETE;
     object_templ.set_internal_field_count(1);
     object_templ.set_with_attr(name.into(), function_templ.into(), attr);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let object = object_templ.new_instance(scope).unwrap();
@@ -1712,7 +1713,7 @@ fn object_template_from_function_template() {
     let object_templ =
       v8::ObjectTemplate::new_from_template(scope, function_templ);
     assert_eq!(0, object_templ.internal_field_count());
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let object = object_templ.new_instance(scope).unwrap();
     assert!(!object.is_null_or_undefined());
@@ -1731,7 +1732,13 @@ fn object_template_immutable_proto() {
     let scope = &mut v8::HandleScope::new(isolate);
     let object_templ = v8::ObjectTemplate::new(scope);
     object_templ.set_immutable_proto();
-    let context = v8::Context::new_from_template(scope, object_templ);
+    let context = v8::Context::new(
+      scope,
+      v8::ContextOptions {
+        global_template: Some(object_templ),
+        ..Default::default()
+      },
+    );
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = r#"
       {
@@ -1766,7 +1773,7 @@ fn function_template_signature() {
       .signature(signature)
       .build(scope);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let scope = &mut v8::TryCatch::new(scope);
     let global = context.global(scope);
@@ -1797,7 +1804,7 @@ fn function_template_prototype() {
   {
     let scope = &mut v8::HandleScope::new(isolate);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let scope = &mut v8::TryCatch::new(scope);
     let function_templ = v8::FunctionTemplate::new(scope, fortytwo_callback);
@@ -1886,7 +1893,7 @@ fn function_template_intrinsic_data_property() {
     );
     function_templ.inherit(intrinsic_error_prototype_interface_template);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let function = function_templ.get_function(scope).unwrap();
@@ -1916,7 +1923,7 @@ fn instance_template_with_internal_field() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   pub fn constructor_callback(
@@ -1957,7 +1964,7 @@ fn object_template_set_accessor() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   {
@@ -2173,7 +2180,7 @@ fn object_template_set_named_property_handler() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   {
@@ -2644,7 +2651,7 @@ fn object_template_set_indexed_property_handler() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let getter = |scope: &mut v8::HandleScope,
@@ -2938,7 +2945,7 @@ fn object() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let null: v8::Local<v8::Value> = v8::null(scope).into();
     let n1: v8::Local<v8::Name> = v8::String::new(scope, "a").unwrap().into();
@@ -3020,7 +3027,7 @@ fn map() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let map = v8::Map::new(scope);
@@ -3064,7 +3071,7 @@ fn set() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let set = v8::Set::new(scope);
@@ -3102,7 +3109,7 @@ fn array() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let s1 = v8::String::new(scope, "a").unwrap();
     let s2 = v8::String::new(scope, "b").unwrap();
@@ -3146,7 +3153,7 @@ fn create_data_property() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     eval(scope, "var a = {};");
@@ -3175,7 +3182,7 @@ fn object_set_accessor() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   {
@@ -3233,7 +3240,7 @@ fn object_set_accessor_with_setter() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   {
@@ -3335,7 +3342,7 @@ fn object_set_accessor_with_setter_with_property() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   {
@@ -3438,7 +3445,7 @@ fn object_set_accessor_with_data() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   {
@@ -3550,7 +3557,7 @@ fn promise_resolved() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let maybe_resolver = v8::PromiseResolver::new(scope);
     assert!(maybe_resolver.is_some());
@@ -3578,7 +3585,7 @@ fn promise_rejected() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let maybe_resolver = v8::PromiseResolver::new(scope);
     assert!(maybe_resolver.is_some());
@@ -3606,7 +3613,7 @@ fn proxy() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let target = v8::Object::new(scope);
     let handler = v8::Object::new(scope);
@@ -3722,7 +3729,7 @@ fn function_builder_raw() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let global = context.global(scope);
     let recv: v8::Local<v8::Value> = global.into();
@@ -3757,7 +3764,7 @@ fn return_value() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let global = context.global(scope);
     let recv: v8::Local<v8::Value> = global.into();
@@ -3930,7 +3937,7 @@ fn function() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let global = context.global(scope);
     let recv: v8::Local<v8::Value> = global.into();
@@ -4042,7 +4049,7 @@ fn function() {
 
   {
     let mut root_scope = v8::HandleScope::new(isolate);
-    let context = v8::Context::new(&mut root_scope);
+    let context = v8::Context::new(&mut root_scope, Default::default());
     let mut scope = v8::ContextScope::new(&mut root_scope, context);
 
     let function: v8::Local<v8::Function> =
@@ -4068,9 +4075,9 @@ fn function_column_and_line_numbers() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
-    let source = mock_source(
+    let mut source = mock_source(
       scope,
       "google.com",
       r#"export function f(a, b) {
@@ -4081,7 +4088,8 @@ export function anotherFunctionG(a, b) {
   return b;
 }"#,
     );
-    let module = v8::script_compiler::compile_module(scope, source).unwrap();
+    let module =
+      v8::script_compiler::compile_module(scope, &mut source).unwrap();
     let result =
       module.instantiate_module(scope, unexpected_module_resolve_callback);
     assert!(result.is_some());
@@ -4127,14 +4135,14 @@ fn function_script_origin_and_id() {
   let isolate = &mut v8::Isolate::new(Default::default());
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let mut num_cases = 10;
   let mut prev_id = None;
   while num_cases > 0 {
     let resource_name = format!("google.com/{}", num_cases);
-    let source = mock_source(
+    let mut source = mock_source(
       scope,
       resource_name.as_str(), // make sure each source has a different resource name
       r#"export function f(a, b) {
@@ -4145,7 +4153,8 @@ fn function_script_origin_and_id() {
           return b;
         }"#,
     );
-    let module = v8::script_compiler::compile_module(scope, source).unwrap();
+    let module =
+      v8::script_compiler::compile_module(scope, &mut source).unwrap();
     let result =
       module.instantiate_module(scope, unexpected_module_resolve_callback);
     assert!(result.is_some());
@@ -4205,7 +4214,7 @@ fn constructor() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let global = context.global(scope);
     let array_name = v8::String::new(scope, "Array").unwrap();
@@ -4238,7 +4247,7 @@ fn set_promise_reject_callback() {
   isolate.set_promise_reject_callback(promise_reject_callback);
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let resolver = v8::PromiseResolver::new(scope).unwrap();
     let value = v8::String::new(scope, "promise rejected").unwrap();
@@ -4262,7 +4271,7 @@ fn promise_reject_callback_no_value() {
   isolate.set_promise_reject_callback(promise_reject_callback);
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = r#"
       function kaboom(resolve, reject) {
@@ -4300,7 +4309,7 @@ fn promise_hook() {
   isolate.set_promise_hook(hook);
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = r#"
       var promises = new Set();
@@ -4335,7 +4344,7 @@ fn context_get_extras_binding_object() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let extras_binding = context.get_extras_binding_object(scope);
     assert!(extras_binding.is_object());
@@ -4356,7 +4365,7 @@ fn context_promise_hooks() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let init_hook = v8::Local::<v8::Function>::try_from(
       eval(
@@ -4462,7 +4471,7 @@ fn context_promise_hooks_partial() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let init_hook = v8::Local::<v8::Function>::try_from(
       eval(
@@ -4536,7 +4545,7 @@ fn security_token() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     // Define a variable in the parent context
@@ -4578,7 +4587,13 @@ fn security_token() {
     // Creates a child context
     {
       let security_token = context.get_security_token(scope);
-      let child_context = v8::Context::new_from_template(scope, templ);
+      let child_context = v8::Context::new(
+        scope,
+        v8::ContextOptions {
+          global_template: Some(templ),
+          ..Default::default()
+        },
+      );
       // Without the security context, the variable can not be shared
       child_context.set_security_token(security_token);
       let child_scope = &mut v8::ContextScope::new(scope, child_context);
@@ -4590,7 +4605,13 @@ fn security_token() {
 
     // Runs the same code but without the security token, it should fail
     {
-      let child_context = v8::Context::new_from_template(scope, templ);
+      let child_context = v8::Context::new(
+        scope,
+        v8::ContextOptions {
+          global_template: Some(templ),
+          ..Default::default()
+        },
+      );
       let child_scope = &mut v8::ContextScope::new(scope, child_context);
       let try_catch = &mut v8::TryCatch::new(child_scope);
       let result = eval(try_catch, source);
@@ -4647,7 +4668,13 @@ fn context_with_object_template() {
     config = config.definer_raw(definer.map_fn_to());
     config = config.setter_raw(setter.map_fn_to());
     object_template.set_named_property_handler(config);
-    let context = v8::Context::new_from_template(scope, object_template);
+    let context = v8::Context::new(
+      scope,
+      v8::ContextOptions {
+        global_template: Some(object_template),
+        ..Default::default()
+      },
+    );
     let scope = &mut v8::ContextScope::new(scope, context);
     eval(scope, r#"Object.defineProperty(globalThis, 'key', { value: 9, enumerable: true, configurable: true, writable: true })"#).unwrap();
     let calls_set =
@@ -4663,7 +4690,7 @@ fn allow_code_generation_from_strings() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     // The code generation is allowed by default
     assert!(context.is_code_generation_from_strings_allowed());
     // This code will try to use generation from strings
@@ -4706,7 +4733,7 @@ fn allow_atomics_wait() {
     isolate.set_allow_atomics_wait(allow);
     {
       let scope = &mut v8::HandleScope::new(isolate);
-      let context = v8::Context::new(scope);
+      let context = v8::Context::new(scope, Default::default());
       let scope = &mut v8::ContextScope::new(scope, context);
       let source = r#"
         const b = new SharedArrayBuffer(4);
@@ -4785,19 +4812,19 @@ fn script_compiler_source() {
   isolate.set_promise_reject_callback(promise_reject_callback);
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let source = "1+2";
     let script_origin = mock_script_origin(scope, "foo.js");
-    let source = v8::script_compiler::Source::new(
+    let mut source = v8::script_compiler::Source::new(
       v8::String::new(scope, source).unwrap(),
       Some(&script_origin),
     );
 
     assert!(source.get_cached_data().is_none());
 
-    let result = v8::script_compiler::compile_module(scope, source);
+    let result = v8::script_compiler::compile_module(scope, &mut source);
     assert!(result.is_some());
   }
 }
@@ -4808,7 +4835,7 @@ fn module_instantiation_failures1() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let source_text = v8::String::new(
@@ -4818,9 +4845,11 @@ fn module_instantiation_failures1() {
     )
     .unwrap();
     let origin = mock_script_origin(scope, "foo.js");
-    let source = v8::script_compiler::Source::new(source_text, Some(&origin));
+    let mut source =
+      v8::script_compiler::Source::new(source_text, Some(&origin));
 
-    let module = v8::script_compiler::compile_module(scope, source).unwrap();
+    let module =
+      v8::script_compiler::compile_module(scope, &mut source).unwrap();
     assert_eq!(v8::ModuleStatus::Uninstantiated, module.get_status());
     let module_requests = module.get_module_requests();
     assert_eq!(2, module_requests.length());
@@ -4884,8 +4913,8 @@ fn compile_specifier_as_module_resolve_callback<'a>(
 ) -> Option<v8::Local<'a, v8::Module>> {
   let scope = &mut unsafe { v8::CallbackScope::new(context) };
   let origin = mock_script_origin(scope, "module.js");
-  let source = v8::script_compiler::Source::new(specifier, Some(&origin));
-  let module = v8::script_compiler::compile_module(scope, source).unwrap();
+  let mut source = v8::script_compiler::Source::new(specifier, Some(&origin));
+  let module = v8::script_compiler::compile_module(scope, &mut source).unwrap();
   Some(module)
 }
 
@@ -4895,7 +4924,7 @@ fn module_evaluation() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let source_text = v8::String::new(
@@ -4905,9 +4934,11 @@ fn module_evaluation() {
     )
     .unwrap();
     let origin = mock_script_origin(scope, "foo.js");
-    let source = v8::script_compiler::Source::new(source_text, Some(&origin));
+    let mut source =
+      v8::script_compiler::Source::new(source_text, Some(&origin));
 
-    let module = v8::script_compiler::compile_module(scope, source).unwrap();
+    let module =
+      v8::script_compiler::compile_module(scope, &mut source).unwrap();
     assert!(module.script_id().is_some());
     assert!(module.is_source_text_module());
     assert!(!module.is_synthetic_module());
@@ -4936,16 +4967,18 @@ fn module_stalled_top_level_await() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let source_text =
       v8::String::new(scope, "await new Promise((_resolve, _reject) => {});")
         .unwrap();
     let origin = mock_script_origin(scope, "foo.js");
-    let source = v8::script_compiler::Source::new(source_text, Some(&origin));
+    let mut source =
+      v8::script_compiler::Source::new(source_text, Some(&origin));
 
-    let module = v8::script_compiler::compile_module(scope, source).unwrap();
+    let module =
+      v8::script_compiler::compile_module(scope, &mut source).unwrap();
     assert!(module.script_id().is_some());
     assert!(module.is_source_text_module());
     assert!(!module.is_synthetic_module());
@@ -5023,8 +5056,9 @@ fn import_assertions() {
 
     let origin = mock_script_origin(scope, "module.js");
     let src = v8::String::new(scope, "export const a = 'a';").unwrap();
-    let source = v8::script_compiler::Source::new(src, Some(&origin));
-    let module = v8::script_compiler::compile_module(scope, source).unwrap();
+    let mut source = v8::script_compiler::Source::new(src, Some(&origin));
+    let module =
+      v8::script_compiler::compile_module(scope, &mut source).unwrap();
     Some(module)
   }
 
@@ -5063,7 +5097,7 @@ fn import_assertions() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let source_text = v8::String::new(
@@ -5073,9 +5107,11 @@ fn import_assertions() {
     )
     .unwrap();
     let origin = mock_script_origin(scope, "foo.js");
-    let source = v8::script_compiler::Source::new(source_text, Some(&origin));
+    let mut source =
+      v8::script_compiler::Source::new(source_text, Some(&origin));
 
-    let module = v8::script_compiler::compile_module(scope, source).unwrap();
+    let module =
+      v8::script_compiler::compile_module(scope, &mut source).unwrap();
     assert!(module.script_id().is_some());
     assert!(module.is_source_text_module());
     assert!(!module.is_synthetic_module());
@@ -5096,7 +5132,7 @@ fn primitive_array() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let length = 3;
@@ -5127,7 +5163,7 @@ fn equality() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     assert!(v8::String::new(scope, "a")
@@ -5153,7 +5189,7 @@ fn equality_edge_cases() {
   let isolate = &mut v8::Isolate::new(Default::default());
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let pos_zero = eval(scope, "0").unwrap();
@@ -5212,7 +5248,7 @@ fn get_hash() {
   let isolate = &mut v8::Isolate::new(Default::default());
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   // Note: the set with hashes and the collition counter is used below in both
@@ -5326,7 +5362,7 @@ fn array_buffer_view() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = v8::String::new(
       scope,
@@ -5367,7 +5403,7 @@ fn continuation_preserved_embedder_data() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let data = scope.get_continuation_preserved_embedder_data();
     assert!(data.is_undefined());
@@ -5397,7 +5433,7 @@ fn snapshot_creator() {
     let mut snapshot_creator = v8::Isolate::snapshot_creator(None, None);
     {
       let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
-      let context = v8::Context::new(scope);
+      let context = v8::Context::new(scope, Default::default());
       let scope = &mut v8::ContextScope::new(scope, context);
       eval(scope, "b = 2 + 3").unwrap();
       scope.set_default_context(context);
@@ -5420,7 +5456,7 @@ fn snapshot_creator() {
       let _ = snapshot_creator.thread_safe_handle();
 
       let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
-      let context = v8::Context::new(scope);
+      let context = v8::Context::new(scope, Default::default());
       let scope = &mut v8::ContextScope::new(scope, context);
       eval(scope, "a = 1 + 2").unwrap();
 
@@ -5445,7 +5481,7 @@ fn snapshot_creator() {
     let isolate = &mut v8::Isolate::new(params);
     {
       let scope = &mut v8::HandleScope::new(isolate);
-      let context = v8::Context::new(scope);
+      let context = v8::Context::new(scope, Default::default());
       let scope = &mut v8::ContextScope::new(scope, context);
       let result = eval(scope, "a === 3").unwrap();
       let true_val = v8::Boolean::new(scope, true).into();
@@ -5488,7 +5524,7 @@ fn snapshot_creator_multiple_contexts() {
     let mut snapshot_creator = v8::Isolate::snapshot_creator(None, None);
     {
       let mut scope = v8::HandleScope::new(&mut snapshot_creator);
-      let context = v8::Context::new(&mut scope);
+      let context = v8::Context::new(&mut scope, Default::default());
       let scope = &mut v8::ContextScope::new(&mut scope, context);
       eval(scope, "globalThis.__bootstrap = { defaultContextProp: 1};")
         .unwrap();
@@ -5502,7 +5538,7 @@ fn snapshot_creator_multiple_contexts() {
     }
     {
       let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
-      let context = v8::Context::new(scope);
+      let context = v8::Context::new(scope, Default::default());
       let scope = &mut v8::ContextScope::new(scope, context);
       eval(scope, "globalThis.__bootstrap = { context0Prop: 2 };").unwrap();
       {
@@ -5527,7 +5563,7 @@ fn snapshot_creator_multiple_contexts() {
       );
     {
       let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
-      let context = v8::Context::new(scope);
+      let context = v8::Context::new(scope, Default::default());
       let scope = &mut v8::ContextScope::new(scope, context);
       {
         let value =
@@ -5550,7 +5586,8 @@ fn snapshot_creator_multiple_contexts() {
     }
     {
       let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
-      let context = v8::Context::from_snapshot(scope, 0).unwrap();
+      let context =
+        v8::Context::from_snapshot(scope, 0, Default::default()).unwrap();
       let scope = &mut v8::ContextScope::new(scope, context);
       {
         let value =
@@ -5580,7 +5617,7 @@ fn snapshot_creator_multiple_contexts() {
     let isolate = &mut v8::Isolate::new(params);
     {
       let scope = &mut v8::HandleScope::new(isolate);
-      let context = v8::Context::new(scope);
+      let context = v8::Context::new(scope, Default::default());
       let scope = &mut v8::ContextScope::new(scope, context);
       {
         let value = eval(scope, "globalThis.__bootstrap.context0Prop").unwrap();
@@ -5606,7 +5643,8 @@ fn snapshot_creator_multiple_contexts() {
     }
     {
       let scope = &mut v8::HandleScope::new(isolate);
-      let context = v8::Context::from_snapshot(scope, 0).unwrap();
+      let context =
+        v8::Context::from_snapshot(scope, 0, Default::default()).unwrap();
       let scope = &mut v8::ContextScope::new(scope, context);
       {
         let value =
@@ -5665,7 +5703,7 @@ fn external_references() {
     let mut snapshot_creator = v8::Isolate::snapshot_creator(Some(refs), None);
     {
       let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
-      let context = v8::Context::new(scope);
+      let context = v8::Context::new(scope, Default::default());
       let scope = &mut v8::ContextScope::new(scope, context);
 
       // create function using template
@@ -5697,7 +5735,7 @@ fn external_references() {
     let isolate = &mut v8::Isolate::new(params);
     {
       let scope = &mut v8::HandleScope::new(isolate);
-      let context = v8::Context::new(scope);
+      let context = v8::Context::new(scope, Default::default());
       let scope = &mut v8::ContextScope::new(scope, context);
 
       let result = eval(scope, "if(F() != 'wrong answer') throw 'boom1'");
@@ -5731,7 +5769,7 @@ fn uint8_array() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source =
       v8::String::new(scope, "new Uint8Array([23,23,23,23])").unwrap();
@@ -5758,7 +5796,7 @@ fn typed_array_constructors() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let ab = v8::ArrayBuffer::new(scope, 8);
@@ -5910,7 +5948,7 @@ fn dynamic_import() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let result = eval(
@@ -5930,7 +5968,7 @@ fn shared_array_buffer() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let sab = v8::SharedArrayBuffer::new(scope, 16).unwrap();
@@ -5988,7 +6026,7 @@ fn typeof_checker() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let value_1 = eval(scope, "").unwrap();
@@ -6009,7 +6047,7 @@ fn value_checker() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let value = eval(scope, "undefined").unwrap();
@@ -6379,10 +6417,10 @@ fn try_from_data() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
-  let module_source = mock_source(scope, "answer.js", "fail()");
+  let mut module_source = mock_source(scope, "answer.js", "fail()");
   let function_callback =
     |_: &mut v8::HandleScope,
      _: v8::FunctionCallbackArguments,
@@ -6401,7 +6439,7 @@ fn try_from_data() {
   );
 
   let module =
-    v8::script_compiler::compile_module(scope, module_source).unwrap();
+    v8::script_compiler::compile_module(scope, &mut module_source).unwrap();
   let d: v8::Local<v8::Data> = module.into();
   assert!(!d.is_function_template());
   assert!(d.is_module());
@@ -6456,7 +6494,7 @@ fn try_from_value() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     {
@@ -6731,7 +6769,7 @@ fn inspector_dispatch_protocol_message() {
   let mut inspector = V8Inspector::create(isolate, &mut default_client);
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let mut _scope = v8::ContextScope::new(scope, context);
 
   let name = b"";
@@ -6769,7 +6807,7 @@ fn inspector_exception_thrown() {
   let mut inspector = V8Inspector::create(isolate, &mut default_client);
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let mut context_scope = v8::ContextScope::new(scope, context);
 
   let name = b"";
@@ -6837,7 +6875,7 @@ fn inspector_schedule_pause_on_next_statement() {
   let mut inspector = V8Inspector::create(isolate, &mut client);
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let mut channel = ChannelCounter::new();
@@ -6948,7 +6986,7 @@ fn inspector_console_api_message() {
   let mut inspector = V8Inspector::create(isolate, &mut client);
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let name = b"";
@@ -6976,7 +7014,13 @@ fn context_from_object_template() {
     let function_templ = v8::FunctionTemplate::new(scope, fortytwo_callback);
     let name = v8::String::new(scope, "f").unwrap();
     object_templ.set(name.into(), function_templ.into());
-    let context = v8::Context::new_from_template(scope, object_templ);
+    let context = v8::Context::new(
+      scope,
+      v8::ContextOptions {
+        global_template: Some(object_templ),
+        ..Default::default()
+      },
+    );
     let scope = &mut v8::ContextScope::new(scope, context);
     let actual = eval(scope, "f()").unwrap();
     let expected = v8::Integer::new(scope, 42);
@@ -6990,7 +7034,7 @@ fn take_heap_snapshot() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = r#"
       {
@@ -7015,7 +7059,7 @@ fn get_constructor_name() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   fn check_ctor_name(
@@ -7054,7 +7098,7 @@ fn get_property_attributes() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let obj = eval(scope, "({ a: 1 })").unwrap();
@@ -7092,7 +7136,7 @@ fn get_own_property_descriptor() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let obj = eval(scope, "({ a: 1 })").unwrap();
@@ -7140,7 +7184,7 @@ fn preview_entries() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   {
@@ -7220,7 +7264,7 @@ fn test_prototype_api() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let obj = v8::Object::new(scope);
@@ -7243,7 +7287,7 @@ fn test_prototype_api() {
   }
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let obj = v8::Object::new(scope);
@@ -7254,7 +7298,7 @@ fn test_prototype_api() {
   }
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let val = eval(scope, "({ __proto__: null })").unwrap();
@@ -7270,7 +7314,7 @@ fn test_map_api() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let value = eval(scope, "new Map([['r','s'],['v',8]])").unwrap();
@@ -7307,7 +7351,7 @@ fn test_object_get_property_names() {
 
   let scope = &mut v8::HandleScope::new(isolate);
 
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let js_test_str: v8::Local<v8::Value> =
@@ -7383,7 +7427,7 @@ fn test_object_get_property_names() {
   }
 
   {
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let val = eval(scope, "({ 'a': 3, 2: 'b', '7': 'c' })").unwrap();
@@ -7487,7 +7531,7 @@ fn module_snapshot() {
     let mut snapshot_creator = v8::Isolate::snapshot_creator(None, None);
     {
       let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
-      let context = v8::Context::new(scope);
+      let context = v8::Context::new(scope, Default::default());
       let scope = &mut v8::ContextScope::new(scope, context);
 
       let source_text = v8::String::new(
@@ -7497,9 +7541,11 @@ fn module_snapshot() {
       )
       .unwrap();
       let origin = mock_script_origin(scope, "foo.js");
-      let source = v8::script_compiler::Source::new(source_text, Some(&origin));
+      let mut source =
+        v8::script_compiler::Source::new(source_text, Some(&origin));
 
-      let module = v8::script_compiler::compile_module(scope, source).unwrap();
+      let module =
+        v8::script_compiler::compile_module(scope, &mut source).unwrap();
       assert_eq!(v8::ModuleStatus::Uninstantiated, module.get_status());
 
       let script_id = module.script_id();
@@ -7530,7 +7576,7 @@ fn module_snapshot() {
     let isolate = &mut v8::Isolate::new(params);
     {
       let scope = &mut v8::HandleScope::new(isolate);
-      let context = v8::Context::new(scope);
+      let context = v8::Context::new(scope, Default::default());
       let scope = &mut v8::ContextScope::new(scope, context);
 
       let true_val = v8::Boolean::new(scope, true).into();
@@ -7576,7 +7622,7 @@ fn heap_limits() {
   isolate.add_near_heap_limit_callback(heap_limit_callback, state_ptr);
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   // Allocate JavaScript arrays until V8 calls the near-heap-limit callback.
@@ -7629,7 +7675,7 @@ fn heap_statistics() {
   assert_eq!(s.number_of_native_contexts(), 0);
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let local = eval(scope, "").unwrap();
@@ -7687,7 +7733,7 @@ fn synthetic_module() {
 
   let scope = &mut v8::HandleScope::new(isolate);
 
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let export_names = [
@@ -7736,7 +7782,7 @@ fn date() {
 
   let scope = &mut v8::HandleScope::new(isolate);
 
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let date = v8::Date::new(scope, time).unwrap();
@@ -7788,7 +7834,7 @@ fn symbol() {
   assert!(s_api2 != s_pub);
   assert!(s_api == s_api2);
 
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let s = eval(scope, "Symbol.asyncIterator").unwrap();
@@ -7816,7 +7862,7 @@ fn private() {
   assert!(p_api2 != p);
   assert!(p_api == p_api2);
 
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let object = v8::Object::new(scope);
@@ -7868,7 +7914,7 @@ fn bigint() {
     setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let b = v8::BigInt::new_from_u64(scope, 1337);
@@ -8010,7 +8056,7 @@ fn value_serializer_and_deserializer() {
 
   let scope = &mut v8::HandleScope::new(isolate);
 
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
   let buffer;
   {
@@ -8051,7 +8097,7 @@ fn value_serializer_and_deserializer_js_objects() {
 
     let scope = &mut v8::HandleScope::new(isolate);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let objects: v8::Local<v8::Value> = eval(
@@ -8085,7 +8131,7 @@ fn value_serializer_and_deserializer_js_objects() {
 
     let scope = &mut v8::HandleScope::new(isolate);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let mut value_deserializer =
@@ -8165,7 +8211,7 @@ fn value_serializer_and_deserializer_array_buffers() {
 
     let scope = &mut v8::HandleScope::new(isolate);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let objects: v8::Local<v8::Value> = eval(
@@ -8191,7 +8237,7 @@ fn value_serializer_and_deserializer_array_buffers() {
 
     let scope = &mut v8::HandleScope::new(isolate);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let mut value_deserializer =
@@ -8230,7 +8276,7 @@ fn value_serializer_and_deserializer_embedder_host_object() {
 
     let scope = &mut v8::HandleScope::new(isolate);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let template = v8::ObjectTemplate::new(scope);
@@ -8256,7 +8302,7 @@ fn value_serializer_and_deserializer_embedder_host_object() {
 
     let scope = &mut v8::HandleScope::new(isolate);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let mut value_deserializer =
@@ -8307,7 +8353,7 @@ fn value_serializer_not_implemented() {
 
   let scope = &mut v8::HandleScope::new(isolate);
 
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
   let scope = &mut v8::TryCatch::new(scope);
 
@@ -8421,7 +8467,7 @@ fn value_serializer_and_deserializer_custom_host_object() {
 
     let scope = &mut v8::HandleScope::new(isolate);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let host_object = v8::Object::new(scope);
@@ -8444,7 +8490,7 @@ fn value_serializer_and_deserializer_custom_host_object() {
 
     let scope = &mut v8::HandleScope::new(isolate);
 
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let mut value_deserializer = Custom3Value::deserializer(scope, &buffer);
@@ -8485,7 +8531,7 @@ fn clear_kept_objects() {
   isolate.set_microtasks_policy(v8::MicrotasksPolicy::Explicit);
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let step1 = r#"
@@ -8527,7 +8573,7 @@ fn wasm_streaming_callback() {
   isolate.set_wasm_streaming_callback(callback);
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let script = r#"
@@ -8593,7 +8639,7 @@ fn unbound_script_conversion() {
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
   let unbound_script = {
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = v8::String::new(
       scope,
@@ -8606,7 +8652,7 @@ fn unbound_script_conversion() {
 
   {
     // Execute the script in another context.
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let global_object = scope.get_current_context().global(scope);
     let key = v8::String::new(scope, "value").unwrap();
@@ -8624,7 +8670,7 @@ fn get_source_mapping_from_comment() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   // TODO(bartlomieju): add a shorter version of `v8::ScriptOrigin`
@@ -8674,7 +8720,7 @@ fn origin_source_map_overrides_source_mapping_url_comment() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let expected_source_map_url = "http://override/foo.js.map";
@@ -8726,7 +8772,7 @@ fn ignore_origin_source_map_empty_string() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   // TODO(bartlomieju): add a shorter version of `v8::ScriptOrigin`
@@ -8777,7 +8823,7 @@ fn no_source_map_comment() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   // TODO(bartlomieju): add a shorter version of `v8::ScriptOrigin`
@@ -8829,7 +8875,7 @@ fn ept_torture_test() {
   // to GC.
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = v8::String::new(
       scope,
@@ -8906,7 +8952,7 @@ fn run_with_rust_allocator() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = v8::String::new(
       scope,
@@ -8935,7 +8981,7 @@ fn run_with_rust_allocator() {
   // to GC.
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = v8::String::new(
       scope,
@@ -8992,7 +9038,7 @@ fn prepare_stack_trace_callback() {
   isolate.set_prepare_stack_trace_callback(callback);
 
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
   let scope = &mut v8::TryCatch::new(scope);
 
@@ -9054,7 +9100,7 @@ fn icu_date() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = r#"
       (new Date(Date.UTC(2020, 5, 26, 7, 0, 0))).toLocaleString("de-DE", {
@@ -9084,7 +9130,7 @@ fn icu_format() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = r#"
       new Intl.NumberFormat("ja-JP", { style: "currency", currency: "JPY" }).format(
@@ -9103,7 +9149,7 @@ fn icu_collator() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
   let source = v8::String::new(scope, "new Intl.Collator('en-US')").unwrap();
   let script = v8::Script::compile(scope, source, None).unwrap();
@@ -9174,7 +9220,7 @@ fn unbound_module_script_conversion() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let mut scope = v8::ContextScope::new(scope, context);
   create_unbound_module_script(&mut scope, "'Hello ' + value", None);
 }
@@ -9210,7 +9256,7 @@ fn code_cache() {
   let code_cache = {
     let isolate = &mut v8::Isolate::new(Default::default());
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let mut scope = v8::ContextScope::new(scope, context);
     let unbound_module_script =
       create_unbound_module_script(&mut scope, CODE, None);
@@ -9219,7 +9265,7 @@ fn code_cache() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let mut scope = v8::ContextScope::new(scope, context);
   let module = create_module(
     &mut scope,
@@ -9250,16 +9296,16 @@ fn function_code_cache() {
   let code_cache = {
     let isolate = &mut v8::Isolate::new(Default::default());
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
-    let source = v8::script_compiler::Source::new(
+    let mut source = v8::script_compiler::Source::new(
       v8::String::new(scope, CODE).unwrap(),
       None,
     );
     let word = v8::String::new(scope, "word").unwrap();
     let function = v8::script_compiler::compile_function(
       scope,
-      source,
+      &mut source,
       &[word],
       &[],
       v8::script_compiler::CompileOptions::EagerCompile,
@@ -9271,10 +9317,10 @@ fn function_code_cache() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
-  let source = v8::script_compiler::Source::new_with_cached_data(
+  let mut source = v8::script_compiler::Source::new_with_cached_data(
     v8::String::new(scope, CODE).unwrap(),
     None,
     code_cache,
@@ -9282,7 +9328,7 @@ fn function_code_cache() {
   let word = v8::String::new(scope, "word").unwrap();
   let function = v8::script_compiler::compile_function(
     scope,
-    source,
+    &mut source,
     &[word],
     &[],
     v8::script_compiler::CompileOptions::EagerCompile,
@@ -9301,7 +9347,7 @@ fn eager_compile_script() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let code = v8::String::new(scope, "1 + 1").unwrap();
@@ -9324,14 +9370,14 @@ fn code_cache_script() {
   let code_cache = {
     let isolate = &mut v8::Isolate::new(Default::default());
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let code = v8::String::new(scope, CODE).unwrap();
-    let source = v8::script_compiler::Source::new(code, None);
+    let mut source = v8::script_compiler::Source::new(code, None);
     let script = v8::script_compiler::compile_unbound_script(
       scope,
-      source,
+      &mut source,
       v8::script_compiler::CompileOptions::EagerCompile,
       v8::script_compiler::NoCacheReason::NoReason,
     )
@@ -9341,7 +9387,7 @@ fn code_cache_script() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let code = v8::String::new(scope, CODE).unwrap();
@@ -9369,7 +9415,7 @@ fn compile_function() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let x = v8::Integer::new(scope, 42);
@@ -9381,10 +9427,10 @@ fn compile_function() {
   extension.set(scope, name.into(), y.into()).unwrap();
 
   let source = v8::String::new(scope, "return x * y").unwrap();
-  let source = v8::script_compiler::Source::new(source, None);
+  let mut source = v8::script_compiler::Source::new(source, None);
   let function = v8::script_compiler::compile_function(
     scope,
-    source,
+    &mut source,
     &[argument],
     &[extension],
     v8::script_compiler::CompileOptions::NoCompileOptions,
@@ -9407,7 +9453,7 @@ fn external_strings() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   // Parse JSON from an external string
@@ -9510,7 +9556,7 @@ fn counter_lookup_callback() {
   let params = v8::CreateParams::default().counter_lookup_callback(callback);
   let isolate = &mut v8::Isolate::new(params);
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
   let _ = eval(scope, "console.log(42);").unwrap();
 
@@ -9540,7 +9586,7 @@ fn compiled_wasm_module() {
   let compiled_module = {
     let isolate = &mut v8::Isolate::new(Default::default());
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let wire_bytes = &[
@@ -9564,7 +9610,7 @@ fn compiled_wasm_module() {
   {
     let isolate = &mut v8::Isolate::new(Default::default());
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let global = context.global(scope);
@@ -9597,7 +9643,7 @@ fn function_names() {
   // Setup isolate
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   // Rust function
@@ -9665,7 +9711,7 @@ fn backing_store_from_empty_boxed_slice() {
 
   let mut isolate = v8::Isolate::new(Default::default());
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
   let mut scope = v8::ContextScope::new(&mut scope, context);
 
   let store = v8::ArrayBuffer::new_backing_store_from_boxed_slice(Box::new([]))
@@ -9679,7 +9725,7 @@ fn backing_store_from_empty_vec() {
 
   let mut isolate = v8::Isolate::new(Default::default());
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
   let mut scope = v8::ContextScope::new(&mut scope, context);
 
   let store =
@@ -9693,7 +9739,7 @@ fn backing_store_data() {
 
   let mut isolate = v8::Isolate::new(Default::default());
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
   let mut scope = v8::ContextScope::new(&mut scope, context);
 
   let v = vec![1, 2, 3, 4, 5];
@@ -9724,7 +9770,7 @@ fn backing_store_resizable() {
 
   let mut isolate = v8::Isolate::new(Default::default());
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
   let mut scope = v8::ContextScope::new(&mut scope, context);
 
   let ab_val =
@@ -9740,7 +9786,7 @@ fn current_stack_trace() {
   // Setup isolate
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   // A simple JS-facing function that returns its call depth, max of 5
@@ -9806,7 +9852,13 @@ fn current_script_name_or_source_url() {
   let tmpl = v8::FunctionTemplate::new(scope, analyze_script_url_in_stack);
   let obj_template = v8::ObjectTemplate::new(scope);
   obj_template.set(key.into(), tmpl.into());
-  let context = v8::Context::new_from_template(scope, obj_template);
+  let context = v8::Context::new(
+    scope,
+    v8::ContextOptions {
+      global_template: Some(obj_template),
+      ..Default::default()
+    },
+  );
 
   let scope = &mut v8::ContextScope::new(scope, context);
   let src = r#"function foo() {
@@ -9849,7 +9901,7 @@ fn instance_of() {
 
   let mut isolate = v8::Isolate::new(Default::default());
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
   let mut scope = v8::ContextScope::new(&mut scope, context);
   let global = context.global(&mut scope);
   let array_name = v8::String::new(&mut scope, "Array").unwrap();
@@ -9875,7 +9927,7 @@ fn weak_handle() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let weak = {
@@ -9908,7 +9960,7 @@ fn finalizers() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   // The finalizer for a dropped Weak is never called.
@@ -9975,7 +10027,7 @@ fn guaranteed_finalizers() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   // The finalizer for a dropped Weak is never called.
@@ -10038,7 +10090,7 @@ fn weak_from_global() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = {
@@ -10065,7 +10117,7 @@ fn weak_from_into_raw() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let finalizer_called = Rc::new(Cell::new(false));
@@ -10178,7 +10230,7 @@ fn drop_weak_from_raw_in_finalizer() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let weak_ptr = Rc::new(Cell::new(None));
@@ -10229,7 +10281,7 @@ fn finalizer_on_kept_global() {
   {
     let isolate = &mut v8::Isolate::new(Default::default());
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let object = v8::Object::new(scope);
@@ -10293,7 +10345,7 @@ fn context_embedder_data() {
   let expected1 = 123.456f64;
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
 
     unsafe {
       context.set_aligned_pointer_in_embedder_data(
@@ -10329,7 +10381,7 @@ fn host_create_shadow_realm_context_callback() {
 
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   {
@@ -10379,7 +10431,7 @@ fn host_create_shadow_realm_context_callback() {
     };
     assert_eq!(scope.get_current_context(), main_context);
 
-    let new_context = v8::Context::new(scope);
+    let new_context = v8::Context::new(scope, Default::default());
     {
       let scope = &mut v8::ContextScope::new(scope, new_context);
       let global = new_context.global(scope);
@@ -10424,7 +10476,7 @@ fn test_fast_calls() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
@@ -10487,7 +10539,7 @@ fn test_fast_calls_empty_buffer() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
@@ -10541,7 +10593,7 @@ fn test_fast_calls_sequence() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
@@ -10600,7 +10652,7 @@ fn test_fast_calls_arraybuffer() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
@@ -10664,7 +10716,7 @@ fn test_fast_calls_typedarray() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
@@ -10736,7 +10788,7 @@ fn test_fast_calls_reciever() {
     ),
   );
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let object_template = v8::ObjectTemplate::new(scope);
@@ -10820,7 +10872,7 @@ fn test_fast_calls_overload() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
@@ -10894,7 +10946,7 @@ fn test_fast_calls_callback_options_fallback() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
@@ -10961,7 +11013,7 @@ fn test_fast_calls_callback_options_data() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
@@ -10996,7 +11048,7 @@ fn test_detach_key() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   // Object detach key
@@ -11068,7 +11120,7 @@ fn test_fast_calls_onebytestring() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
@@ -11134,7 +11186,7 @@ fn test_fast_calls_i64representation() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
@@ -11252,7 +11304,7 @@ fn gc_callbacks() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     scope
@@ -11265,7 +11317,7 @@ fn gc_callbacks() {
   isolate.remove_gc_prologue_callback(callback2, state_ptr);
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     scope
@@ -11306,7 +11358,7 @@ fn test_fast_calls_pointer() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
@@ -11352,7 +11404,7 @@ fn object_define_property() {
   let isolate = &mut v8::Isolate::new(Default::default());
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let mut desc = v8::PropertyDescriptor::new();
@@ -11376,7 +11428,7 @@ fn object_define_property() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let mut desc = v8::PropertyDescriptor::new_from_value_writable(
@@ -11403,7 +11455,7 @@ fn object_define_property() {
 
   {
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
 
     let mut desc = v8::PropertyDescriptor::new_from_value(
@@ -11434,7 +11486,7 @@ fn bubbling_up_exception() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   fn boom_fn(
@@ -11478,7 +11530,7 @@ fn bubbling_up_exception_in_function_call() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   fn boom_fn(
@@ -11533,7 +11585,7 @@ fn exception_thrown_but_continues_execution() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
 
   static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -11607,7 +11659,7 @@ fn disallow_javascript_execution_scope() {
 
   let mut isolate = v8::Isolate::new(Default::default());
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
   let mut scope = v8::ContextScope::new(&mut scope, context);
 
   // We can run JS before the scope begins.
@@ -11646,7 +11698,7 @@ fn allow_javascript_execution_scope() {
 
   let mut isolate = v8::Isolate::new(Default::default());
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
   let mut scope = v8::ContextScope::new(&mut scope, context);
 
   let disallow_scope = &mut v8::DisallowJavascriptExecutionScope::new(
@@ -11704,7 +11756,7 @@ fn allow_scope_in_read_host_object() {
 
   let mut isolate = v8::Isolate::new(Default::default());
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
   let mut scope = v8::ContextScope::new(&mut scope, context);
 
   let serialized = {
@@ -11728,7 +11780,7 @@ fn microtask_queue() {
   let mut isolate = v8::Isolate::new(Default::default());
 
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
 
   let queue = context.get_microtask_queue();
   let mut scope = v8::ContextScope::new(&mut scope, context);
@@ -11759,7 +11811,7 @@ fn microtask_queue_new() {
   let mut scope = v8::HandleScope::new(&mut isolate);
   let queue = v8::MicrotaskQueue::new(&mut scope, v8::MicrotasksPolicy::Auto);
 
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
 
   context.set_microtask_queue(queue.as_ref());
   assert!(std::ptr::eq(context.get_microtask_queue(), queue.as_ref()));
@@ -11774,7 +11826,7 @@ fn clear_slots_annex_uninitialized() {
 
   let mut scope = v8::HandleScope::new(&mut isolate);
 
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
 
   let r = 0;
   // This would increase slot count without initializing the annex.
@@ -11784,7 +11836,7 @@ fn clear_slots_annex_uninitialized() {
 
   // This was trying to deallocate a garbage value when the annex was not
   // initialized.
-  context.clear_all_slots(&mut scope);
+  context.clear_all_slots();
 }
 
 #[test]
@@ -11792,7 +11844,7 @@ fn string_valueview() {
   let _setup_guard = setup::parallel_test();
   let mut isolate = v8::Isolate::new(Default::default());
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
   let scope = &mut v8::ContextScope::new(&mut scope, context);
 
   {
@@ -11823,7 +11875,7 @@ fn host_defined_options() {
   let _setup_guard = setup::parallel_test();
   let mut isolate = v8::Isolate::new(Default::default());
   let mut scope = v8::HandleScope::new(&mut isolate);
-  let context = v8::Context::new(&mut scope);
+  let context = v8::Context::new(&mut scope, Default::default());
   let scope = &mut v8::ContextScope::new(&mut scope, context);
 
   let test = v8::Function::new(

--- a/tests/test_api_entropy_source.rs
+++ b/tests/test_api_entropy_source.rs
@@ -28,7 +28,7 @@ fn set_entropy_source() {
   for _ in 0..N {
     let isolate = &mut v8::Isolate::new(Default::default());
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = v8::String::new(scope, "Math.random()").unwrap();
     let script = v8::Script::compile(scope, source, None).unwrap();

--- a/tests/test_api_flags.rs
+++ b/tests/test_api_flags.rs
@@ -10,7 +10,7 @@ fn set_flags_from_string() {
   v8::V8::initialize();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
   let source = "(function() { return this })()";
   let source = v8::String::new(scope, source).unwrap();

--- a/tests/test_cppgc.rs
+++ b/tests/test_cppgc.rs
@@ -102,7 +102,7 @@ fn cppgc_object_wrap() {
       &mut v8::Isolate::new(v8::CreateParams::default().cpp_heap(heap));
 
     let handle_scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(handle_scope);
+    let context = v8::Context::new(handle_scope, Default::default());
     let scope = &mut v8::ContextScope::new(handle_scope, context);
     let global = context.global(scope);
     {

--- a/tests/test_platform_atomics_pump_message_loop.rs
+++ b/tests/test_platform_atomics_pump_message_loop.rs
@@ -9,7 +9,7 @@ fn atomics_pump_message_loop() {
   v8::V8::initialize();
   let isolate = &mut v8::Isolate::new(Default::default());
   let scope = &mut v8::HandleScope::new(isolate);
-  let context = v8::Context::new(scope);
+  let context = v8::Context::new(scope, Default::default());
   let scope = &mut v8::ContextScope::new(scope, context);
   let source = r#"
     function assertEquals(a, b) {

--- a/tests/test_single_threaded_default_platform.rs
+++ b/tests/test_single_threaded_default_platform.rs
@@ -9,7 +9,7 @@ fn single_threaded_default_platform() {
   {
     let isolate = &mut v8::Isolate::new(Default::default());
     let scope = &mut v8::HandleScope::new(isolate);
-    let context = v8::Context::new(scope);
+    let context = v8::Context::new(scope, Default::default());
     let scope = &mut v8::ContextScope::new(scope, context);
     let source = v8::String::new(scope, "Math.random()").unwrap();
     let script = v8::Script::compile(scope, source, None).unwrap();


### PR DESCRIPTION
- Context::new takes options
- add Isolate::SetAllowWasmCodeGenerationCallback
- Annex slots can be accessed without passing `scope` (used in deno inside code generation callback)
- add Object::HasRealNamedProperty

Fixes: #1438 