### PR TITLE
chore: disable android in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,26 +77,6 @@ jobs:
             variant: release
             cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: aarch64-linux-android
-            variant: debug
-            cargo: cross
-
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: aarch64-linux-android
-            variant: release
-            cargo: cross
-
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: x86_64-linux-android
-            variant: debug
-            cargo: cross
-
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: x86_64-linux-android
-            variant: release
-            cargo: cross
-
     env:
       V8_FROM_SOURCE: true
       CARGO_VARIANT_FLAG: ${{ matrix.config.variant == 'release' && '--release' || '' }}
@@ -142,13 +122,6 @@ jobs:
 
       - name: Write git_submodule_status.txt
         run: git submodule status --recursive > git_submodule_status.txt
-
-      - name: Install cross and build custom image
-        if: contains(matrix.config.target, 'linux-android')
-        run: |
-          mkdir -p /home/runner/.local/bin
-          curl -qL https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-musl.tar.gz  | tar xz -C /home/runner/.local/bin
-          sudo docker build --build-arg CROSS_BASE_IMAGE=ghcr.io/cross-rs/${{ matrix.config.target }}:0.2.5 -t cross-rusty_v8:${{ matrix.config.target }} .
 
       - name: Cache
         uses: actions/cache@v3


### PR DESCRIPTION
we don't use android, it takes forever, and `cross clippy` is causing sporadic ci failures on rust 1.80