### PR TITLE
update fast calls api

### DIFF
--- a/benches/function.rs
+++ b/benches/function.rs
@@ -65,12 +65,14 @@ fn main() {
     fn fast_fn() -> i32 {
       42
     }
-    const FAST_CALL: v8::fast_api::FastFunction =
-      v8::fast_api::FastFunction::new(
-        &[v8::fast_api::Type::V8Value],
-        v8::fast_api::CType::Int32,
-        fast_fn as _,
-      );
+    const FAST_CALL: v8::fast_api::CFunction = v8::fast_api::CFunction::new(
+      fast_fn as _,
+      &v8::fast_api::CFunctionInfo::new(
+        v8::fast_api::Type::Int32.scalar(),
+        &[v8::fast_api::Type::V8Value.scalar()],
+        v8::fast_api::Int64Representation::Number,
+      ),
+    );
     let template = v8::FunctionTemplate::builder(
       |scope: &mut v8::HandleScope,
        _: v8::FunctionCallbackArguments,
@@ -78,7 +80,7 @@ fn main() {
         rv.set(v8::Integer::new(scope, 42).into());
       },
     )
-    .build_fast(scope, &FAST_CALL, None, None, None);
+    .build_fast(scope, &[FAST_CALL]);
     let name = v8::String::new(scope, "new_fast").unwrap();
     let value = template.get_function(scope).unwrap();
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2247,70 +2247,17 @@ const v8::Signature* v8__Signature__New(v8::Isolate* isolate,
   return local_to_ptr(v8::Signature::New(isolate, ptr_to_local(templ)));
 }
 
-v8::CTypeInfo* v8__CTypeInfo__New(v8::CTypeInfo::Type ty) {
-  std::unique_ptr<v8::CTypeInfo> u =
-      std::make_unique<v8::CTypeInfo>(v8::CTypeInfo(ty));
-  return u.release();
-}
-
-void v8__CTypeInfo__DELETE(v8::CTypeInfo* self) { delete self; }
-
-struct CTypeSequenceType {
-  v8::CTypeInfo::Type c_type;
-  v8::CTypeInfo::SequenceType sequence_type;
-};
-
-v8::CTypeInfo* v8__CTypeInfo__New__From__Slice(unsigned int len,
-                                               CTypeSequenceType* ty) {
-  v8::CTypeInfo* v = (v8::CTypeInfo*)malloc(sizeof(v8::CTypeInfo) * len);
-  for (size_t i = 0; i < len; i += 1) {
-    v[i] = v8::CTypeInfo(ty[i].c_type, ty[i].sequence_type);
-  }
-  return v;
-}
-
-v8::CFunctionInfo* v8__CFunctionInfo__New(
-    const v8::CTypeInfo& return_info, unsigned int args_len,
-    v8::CTypeInfo* args_info, v8::CFunctionInfo::Int64Representation repr) {
-  std::unique_ptr<v8::CFunctionInfo> info = std::make_unique<v8::CFunctionInfo>(
-      v8::CFunctionInfo(return_info, args_len, args_info, repr));
-  return info.release();
-}
-
-void v8__CFunctionInfo__DELETE(v8::CFunctionInfo* self) { delete self; }
-
 const v8::FunctionTemplate* v8__FunctionTemplate__New(
     v8::Isolate* isolate, v8::FunctionCallback callback,
     const v8::Value* data_or_null, const v8::Signature* signature_or_null,
     int length, v8::ConstructorBehavior constructor_behavior,
-    v8::SideEffectType side_effect_type, void* func_ptr1,
-    const v8::CFunctionInfo* c_function_info1, void* func_ptr2,
-    const v8::CFunctionInfo* c_function_info2) {
-  // Support upto 2 overloads. V8 requires TypedArray to have a
-  // v8::Array overload.
-  if (func_ptr1) {
-    if (func_ptr2 == nullptr) {
-      const v8::CFunction o[] = {v8::CFunction(func_ptr1, c_function_info1)};
-      auto overload = v8::MemorySpan<const v8::CFunction>{o, 1};
-      return local_to_ptr(v8::FunctionTemplate::NewWithCFunctionOverloads(
-          isolate, callback, ptr_to_local(data_or_null),
-          ptr_to_local(signature_or_null), length, constructor_behavior,
-          side_effect_type, overload));
-    } else {
-      const v8::CFunction o[] = {v8::CFunction(func_ptr1, c_function_info1),
-                                 v8::CFunction(func_ptr2, c_function_info2)};
-      auto overload = v8::MemorySpan<const v8::CFunction>{o, 2};
-      return local_to_ptr(v8::FunctionTemplate::NewWithCFunctionOverloads(
-          isolate, callback, ptr_to_local(data_or_null),
-          ptr_to_local(signature_or_null), length, constructor_behavior,
-          side_effect_type, overload));
-    }
-  }
-  auto overload = v8::MemorySpan<const v8::CFunction>{};
+    v8::SideEffectType side_effect_type, const v8::CFunction* c_functions,
+    size_t c_functions_len) {
+  v8::MemorySpan<const v8::CFunction> overloads{c_functions, c_functions_len};
   return local_to_ptr(v8::FunctionTemplate::NewWithCFunctionOverloads(
       isolate, callback, ptr_to_local(data_or_null),
       ptr_to_local(signature_or_null), length, constructor_behavior,
-      side_effect_type, overload));
+      side_effect_type, overloads));
 }
 
 const v8::Function* v8__FunctionTemplate__GetFunction(

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -1,4 +1,5 @@
 #include <v8-cppgc.h>
+#include <v8-fast-api-calls.h>
 #include <v8-message.h>
 #include <v8-typed-array.h>
 
@@ -28,3 +29,6 @@ static size_t v8__TypedArray__kMaxByteLength = v8::TypedArray::kMaxByteLength;
   static size_t v8__##name##__kMaxLength = v8::name::kMaxLength;
 EACH_TYPED_ARRAY(TYPED_ARRAY_MAX_LENGTH)
 #undef TYPED_ARRAY_MAX_LENGTH
+
+using v8__CFunction = v8::CFunction;
+using v8__CFunctionInfo = v8::CFunctionInfo;

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -1,3 +1,4 @@
+#![allow(unused)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/src/external_references.rs
+++ b/src/external_references.rs
@@ -1,5 +1,6 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
 
+use crate::fast_api::CFunctionInfo;
 use crate::support::intptr_t;
 use crate::FunctionCallback;
 use crate::IndexedDefinerCallback;
@@ -33,6 +34,7 @@ pub union ExternalReference<'s> {
   pub enumerator: PropertyEnumeratorCallback<'s>,
   pub message: MessageCallback,
   pub pointer: *mut c_void,
+  pub type_info: *const CFunctionInfo,
 }
 
 impl<'s> Debug for ExternalReference<'s> {


### PR DESCRIPTION
uses bindgen to generate types for fast api interfaces, which allows us to clean up the interface. also implements CTypeInfo flags which allows ArrayBufferView.