### PR TITLE
Disable relative vtable on Android

### DIFF
--- a/.gn
+++ b/.gn
@@ -86,4 +86,6 @@ default_args = {
   #
   # rusty_v8 scopes are not on the stack.
   v8_enable_v8_checks = false
+
+  use_relative_vtables_abi = false
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -9444,7 +9444,6 @@ fn compile_function() {
   assert_eq!(42 * 1337, result.int32_value(scope).unwrap());
 }
 
-#[cfg(not(target_os = "android"))]
 static EXAMPLE_STRING: v8::OneByteConst =
   v8::String::create_external_onebyte_const(b"const static");
 
@@ -9516,7 +9515,6 @@ fn external_strings() {
   assert!(latin1.contains_only_onebyte());
 
   // one-byte "const" test
-  #[cfg(not(target_os = "android"))]
   {
     assert_eq!(EXAMPLE_STRING.as_bytes(), b"const static");
     let const_ref_string =


### PR DESCRIPTION
Fixes https://github.com/denoland/rusty_v8/issues/1475

> This is safe to enable only when all C++ code is built with the
    flag set to the same value.

This is enabled by default for Android builds but our OneByteConst code assume pointer vtables.
