### PR TITLE
Disable pointer compression shared cage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "tools/clang"]
 	path = tools/clang
 	url = https://chromium.googlesource.com/chromium/src/tools/clang.git
-[submodule "base/trace_event/common"]
-	path = base/trace_event/common
-	url = https://chromium.googlesource.com/chromium/src/base/trace_event/common.git
 [submodule "third_party/jinja2"]
 	path = third_party/jinja2
 	url = https://chromium.googlesource.com/chromium/src/third_party/jinja2.git

--- a/.gn
+++ b/.gn
@@ -38,6 +38,8 @@ default_args = {
   v8_use_external_startup_data = false
   v8_use_snapshot = true
 
+  v8_enable_pointer_compression_shared_cage = false
+
   # This flag speeds up the performance of fork/execve on Linux systems for
   # embedders which use it (like Node.js). It works by marking the pages that
   # V8 allocates as MADV_DONTFORK. Without MADV_DONTFORK, the Linux kernel
@@ -74,7 +76,7 @@ default_args = {
 
   # Enable V8 object print for debugging.
   # v8_enable_object_print = true
-  
+
   # V8 12.3 added google/fuzztest as a third party dependency.
   # https://chromium.googlesource.com/v8/v8.git/+/d5acece0c9b89b18716c177d1fcc8f734191e1e2%5E%21/#F4
   #

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -162,7 +162,9 @@ void v8__Isolate__Enter(v8::Isolate* isolate) { isolate->Enter(); }
 
 void v8__Isolate__Exit(v8::Isolate* isolate) { isolate->Exit(); }
 
-v8::Isolate* v8__Isolate__GetCurrent() { return v8::Isolate::GetCurrent(); }
+v8::Isolate* v8__Isolate__TryGetCurrent() {
+  return v8::Isolate::TryGetCurrent();
+}
 
 const v8::Data* v8__Isolate__GetCurrentHostDefinedOptions(
     v8::Isolate* isolate) {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -547,46 +547,6 @@ fn context_scope() {
 }
 
 #[test]
-#[should_panic(
-  expected = "HandleScope<()> and Context do not belong to the same Isolate"
-)]
-fn context_scope_param_and_context_must_share_isolate() {
-  let _setup_guard = setup::parallel_test();
-  let isolate1 = &mut v8::Isolate::new(Default::default());
-  let isolate2 = &mut v8::Isolate::new(Default::default());
-  let scope1 = &mut v8::HandleScope::new(isolate1);
-  let scope2 = &mut v8::HandleScope::new(isolate2);
-  let context1 = v8::Context::new(scope1, Default::default());
-  let context2 = v8::Context::new(scope2, Default::default());
-  let _context_scope_12 = &mut v8::ContextScope::new(scope1, context2);
-  let _context_scope_21 = &mut v8::ContextScope::new(scope2, context1);
-}
-
-#[test]
-#[should_panic(
-  expected = "attempt to use Handle in an Isolate that is not its host"
-)]
-fn handle_scope_param_and_context_must_share_isolate() {
-  let _setup_guard = setup::parallel_test();
-  let isolate1 = &mut v8::Isolate::new(Default::default());
-  let isolate2 = &mut v8::Isolate::new(Default::default());
-  let global_context1;
-  let global_context2;
-  {
-    let scope1 = &mut v8::HandleScope::new(isolate1);
-    let scope2 = &mut v8::HandleScope::new(isolate2);
-    let local_context_1 = v8::Context::new(scope1, Default::default());
-    let local_context_2 = v8::Context::new(scope2, Default::default());
-    global_context1 = v8::Global::new(scope1, local_context_1);
-    global_context2 = v8::Global::new(scope2, local_context_2);
-  }
-  let _handle_scope_12 =
-    &mut v8::HandleScope::with_context(isolate1, global_context2);
-  let _handle_scope_21 =
-    &mut v8::HandleScope::with_context(isolate2, global_context1);
-}
-
-#[test]
 fn microtasks() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());
@@ -632,17 +592,6 @@ fn microtasks() {
 
     assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 2);
   }
-}
-
-#[test]
-#[should_panic(
-  expected = "v8::OwnedIsolate instances must be dropped in the reverse order of creation. They are entered upon creation and exited upon being dropped."
-)]
-fn isolate_drop_order() {
-  let isolate1 = v8::Isolate::new(Default::default());
-  let isolate2 = v8::Isolate::new(Default::default());
-  drop(isolate1);
-  drop(isolate2);
 }
 
 #[test]


### PR DESCRIPTION
Shared cage forces all isolates to use the same 4gb region for their heaps, which means there is not enough memory available for code using worker threads. Disabling shared cage reveals some other issues with rusty_v8's handling of entering multiple isolates on a single thread so I've disallowed it for now. Note that you can still use multiple isolates in a single thread, you just have to manually call `enter`/`exit`.