### PR TITLE
Allow `ValueSerializerImpl` and `ValueDeserializerImpl` impls to be re-entrant

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3538,6 +3538,10 @@ void v8__ValueSerializer__Release(v8::ValueSerializer* self, uint8_t** ptr,
   *size = result.second;
 }
 
+void v8__ValueSerializer__SetTreatArrayBufferViewsAsHostObjects(v8::ValueSerializer* self, bool mode) {
+  self->SetTreatArrayBufferViewsAsHostObjects(mode);
+}
+
 void v8__ValueSerializer__WriteHeader(v8::ValueSerializer* self) {
   self->WriteHeader();
 }
@@ -3676,6 +3680,10 @@ bool v8__ValueDeserializer__ReadDouble(v8::ValueDeserializer* self,
 bool v8__ValueDeserializer__ReadRawBytes(v8::ValueDeserializer* self,
                                          size_t length, const void** data) {
   return self->ReadRawBytes(length, data);
+}
+
+uint32_t v8__ValueDeserializer__GetWireFormatVersion(v8::ValueDeserializer* self) {
+  return self->GetWireFormatVersion();
 }
 }  // extern "C"
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3538,7 +3538,8 @@ void v8__ValueSerializer__Release(v8::ValueSerializer* self, uint8_t** ptr,
   *size = result.second;
 }
 
-void v8__ValueSerializer__SetTreatArrayBufferViewsAsHostObjects(v8::ValueSerializer* self, bool mode) {
+void v8__ValueSerializer__SetTreatArrayBufferViewsAsHostObjects(
+    v8::ValueSerializer* self, bool mode) {
   self->SetTreatArrayBufferViewsAsHostObjects(mode);
 }
 
@@ -3682,7 +3683,8 @@ bool v8__ValueDeserializer__ReadRawBytes(v8::ValueDeserializer* self,
   return self->ReadRawBytes(length, data);
 }
 
-uint32_t v8__ValueDeserializer__GetWireFormatVersion(v8::ValueDeserializer* self) {
+uint32_t v8__ValueDeserializer__GetWireFormatVersion(
+    v8::ValueDeserializer* self) {
   return self->GetWireFormatVersion();
 }
 }  // extern "C"

--- a/src/value_deserializer.rs
+++ b/src/value_deserializer.rs
@@ -155,6 +155,10 @@ extern "C" {
     length: usize,
     data: *mut *const c_void,
   ) -> bool;
+
+  fn v8__ValueDeserializer__GetWireFormatVersion(
+    this: *mut CxxValueDeserializer,
+  ) -> u32;
 }
 
 /// The ValueDeserializerImpl trait allows for
@@ -338,6 +342,14 @@ pub trait ValueDeserializerHelper {
       )
     }
   }
+
+  fn get_wire_format_version(&mut self) -> u32 {
+    unsafe {
+      ValueDeserializer::get_wire_format_version_raw(
+        self.get_cxx_value_deserializer(),
+      )
+    }
+  }
 }
 
 impl ValueDeserializerHelper for CxxValueDeserializer {
@@ -470,6 +482,12 @@ impl<'a> ValueDeserializer<'a> {
     array_buffer: Local<ArrayBuffer>,
   ) {
     v8__ValueDeserializer__TransferArrayBuffer(de, transfer_id, array_buffer)
+  }
+
+  pub unsafe fn get_wire_format_version_raw(
+    de: *mut CxxValueDeserializer,
+  ) -> u32 {
+    v8__ValueDeserializer__GetWireFormatVersion(de)
   }
 }
 

--- a/src/value_deserializer.rs
+++ b/src/value_deserializer.rs
@@ -30,7 +30,7 @@ pub struct CxxValueDeserializerDelegate {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn v8__ValueDeserializer__Delegate__ReadHostObject(
+unsafe extern "C" fn v8__ValueDeserializer__Delegate__ReadHostObject(
   this: &CxxValueDeserializerDelegate,
   isolate: *mut Isolate,
 ) -> *const Object {
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn v8__ValueDeserializer__Delegate__ReadHostObject(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn v8__ValueDeserializer__Delegate__GetSharedArrayBufferFromId(
+unsafe extern "C" fn v8__ValueDeserializer__Delegate__GetSharedArrayBufferFromId(
   this: &CxxValueDeserializerDelegate,
   isolate: *mut Isolate,
   transfer_id: u32,
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn v8__ValueDeserializer__Delegate__GetSharedArrayBufferFr
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn v8__ValueDeserializer__Delegate__GetWasmModuleFromId(
+unsafe extern "C" fn v8__ValueDeserializer__Delegate__GetWasmModuleFromId(
   this: &mut CxxValueDeserializerDelegate,
   isolate: *mut Isolate,
   clone_id: u32,

--- a/src/value_deserializer.rs
+++ b/src/value_deserializer.rs
@@ -489,6 +489,12 @@ impl<'a> ValueDeserializer<'a> {
   ) -> u32 {
     v8__ValueDeserializer__GetWireFormatVersion(de)
   }
+
+  pub unsafe fn get_cxx_value_deserializer_raw(
+    de: *mut Self,
+  ) -> *mut CxxValueDeserializer {
+    std::ptr::addr_of_mut!((*de).value_deserializer_heap.cxx_value_deserializer)
+  }
 }
 
 impl<'a> ValueDeserializer<'a> {

--- a/src/value_deserializer.rs
+++ b/src/value_deserializer.rs
@@ -269,15 +269,16 @@ impl<'a> Drop for ValueDeserializerHeap<'a> {
 /// Mostly used by the read_host_object callback function in the
 /// ValueDeserializerImpl trait to create custom deserialization logic.
 pub trait ValueDeserializerHelper {
-  fn get_cxx_value_deserializer(&mut self) -> *mut CxxValueDeserializer;
+  fn get_cxx_value_deserializer(&mut self) -> &mut CxxValueDeserializer;
 
   fn read_header(&mut self, context: Local<Context>) -> Option<bool> {
     unsafe {
-      ValueDeserializer::read_header_raw(
+      v8__ValueDeserializer__ReadHeader(
         self.get_cxx_value_deserializer(),
         context,
       )
     }
+    .into()
   }
 
   fn read_value<'s>(
@@ -285,16 +286,16 @@ pub trait ValueDeserializerHelper {
     context: Local<'s, Context>,
   ) -> Option<Local<'s, Value>> {
     unsafe {
-      ValueDeserializer::read_value_raw(
+      Local::from_raw(v8__ValueDeserializer__ReadValue(
         self.get_cxx_value_deserializer(),
         context,
-      )
+      ))
     }
   }
 
   fn read_uint32(&mut self, value: &mut u32) -> bool {
     unsafe {
-      ValueDeserializer::read_uint32_raw(
+      v8__ValueDeserializer__ReadUint32(
         self.get_cxx_value_deserializer(),
         value,
       )
@@ -303,7 +304,7 @@ pub trait ValueDeserializerHelper {
 
   fn read_uint64(&mut self, value: &mut u64) -> bool {
     unsafe {
-      ValueDeserializer::read_uint64_raw(
+      v8__ValueDeserializer__ReadUint64(
         self.get_cxx_value_deserializer(),
         value,
       )
@@ -312,7 +313,7 @@ pub trait ValueDeserializerHelper {
 
   fn read_double(&mut self, value: &mut f64) -> bool {
     unsafe {
-      ValueDeserializer::read_double_raw(
+      v8__ValueDeserializer__ReadDouble(
         self.get_cxx_value_deserializer(),
         value,
       )
@@ -320,12 +321,19 @@ pub trait ValueDeserializerHelper {
   }
 
   fn read_raw_bytes(&mut self, length: usize) -> Option<&[u8]> {
-    unsafe {
-      ValueDeserializer::read_raw_bytes_raw(
+    let mut data: *const c_void = std::ptr::null_mut();
+    let ok = unsafe {
+      v8__ValueDeserializer__ReadRawBytes(
         self.get_cxx_value_deserializer(),
         length,
+        &mut data,
       )
-      .map(|data| std::slice::from_raw_parts(data, length))
+    };
+    if ok {
+      assert!(!data.is_null());
+      unsafe { Some(std::slice::from_raw_parts(data as *const u8, length)) }
+    } else {
+      None
     }
   }
 
@@ -335,17 +343,17 @@ pub trait ValueDeserializerHelper {
     array_buffer: Local<ArrayBuffer>,
   ) {
     unsafe {
-      ValueDeserializer::transfer_array_buffer_raw(
+      v8__ValueDeserializer__TransferArrayBuffer(
         self.get_cxx_value_deserializer(),
         transfer_id,
         array_buffer,
       )
-    }
+    };
   }
 
   fn get_wire_format_version(&mut self) -> u32 {
     unsafe {
-      ValueDeserializer::get_wire_format_version_raw(
+      v8__ValueDeserializer__GetWireFormatVersion(
         self.get_cxx_value_deserializer(),
       )
     }
@@ -353,19 +361,19 @@ pub trait ValueDeserializerHelper {
 }
 
 impl ValueDeserializerHelper for CxxValueDeserializer {
-  fn get_cxx_value_deserializer(&mut self) -> *mut CxxValueDeserializer {
+  fn get_cxx_value_deserializer(&mut self) -> &mut CxxValueDeserializer {
     self
   }
 }
 
 impl<'a> ValueDeserializerHelper for ValueDeserializerHeap<'a> {
-  fn get_cxx_value_deserializer(&mut self) -> *mut CxxValueDeserializer {
+  fn get_cxx_value_deserializer(&mut self) -> &mut CxxValueDeserializer {
     &mut self.cxx_value_deserializer
   }
 }
 
 impl<'a> ValueDeserializerHelper for ValueDeserializer<'a> {
-  fn get_cxx_value_deserializer(&mut self) -> *mut CxxValueDeserializer {
+  fn get_cxx_value_deserializer(&mut self) -> &mut CxxValueDeserializer {
     &mut self.value_deserializer_heap.cxx_value_deserializer
   }
 }
@@ -425,75 +433,6 @@ impl<'a> ValueDeserializer<'a> {
     ValueDeserializer {
       value_deserializer_heap,
     }
-  }
-
-  pub unsafe fn read_header_raw(
-    de: *mut CxxValueDeserializer,
-    context: Local<Context>,
-  ) -> Option<bool> {
-    v8__ValueDeserializer__ReadHeader(de, context).into()
-  }
-
-  pub unsafe fn read_value_raw(
-    de: *mut CxxValueDeserializer,
-    context: Local<Context>,
-  ) -> Option<Local<Value>> {
-    Local::from_raw(v8__ValueDeserializer__ReadValue(de, context))
-  }
-
-  pub unsafe fn read_uint32_raw(
-    de: *mut CxxValueDeserializer,
-    value: &mut u32,
-  ) -> bool {
-    v8__ValueDeserializer__ReadUint32(de, value)
-  }
-
-  pub unsafe fn read_uint64_raw(
-    de: *mut CxxValueDeserializer,
-    value: &mut u64,
-  ) -> bool {
-    v8__ValueDeserializer__ReadUint64(de, value)
-  }
-
-  pub unsafe fn read_double_raw(
-    de: *mut CxxValueDeserializer,
-    value: &mut f64,
-  ) -> bool {
-    v8__ValueDeserializer__ReadDouble(de, value)
-  }
-
-  pub unsafe fn read_raw_bytes_raw(
-    de: *mut CxxValueDeserializer,
-    length: usize,
-  ) -> Option<*mut u8> {
-    let mut data: *const c_void = std::ptr::null_mut();
-    let ok = v8__ValueDeserializer__ReadRawBytes(de, length, &mut data);
-    if ok {
-      assert!(!data.is_null());
-      Some(data.cast_mut().cast())
-    } else {
-      None
-    }
-  }
-
-  pub unsafe fn transfer_array_buffer_raw(
-    de: *mut CxxValueDeserializer,
-    transfer_id: u32,
-    array_buffer: Local<ArrayBuffer>,
-  ) {
-    v8__ValueDeserializer__TransferArrayBuffer(de, transfer_id, array_buffer)
-  }
-
-  pub unsafe fn get_wire_format_version_raw(
-    de: *mut CxxValueDeserializer,
-  ) -> u32 {
-    v8__ValueDeserializer__GetWireFormatVersion(de)
-  }
-
-  pub unsafe fn get_cxx_value_deserializer_raw(
-    de: *mut Self,
-  ) -> *mut CxxValueDeserializer {
-    std::ptr::addr_of_mut!((*de).value_deserializer_heap.cxx_value_deserializer)
   }
 }
 

--- a/src/value_deserializer.rs
+++ b/src/value_deserializer.rs
@@ -33,19 +33,18 @@ pub struct CxxValueDeserializerDelegate {
 
 #[no_mangle]
 pub unsafe extern "C" fn v8__ValueDeserializer__Delegate__ReadHostObject(
-  this: &mut CxxValueDeserializerDelegate,
+  this: &CxxValueDeserializerDelegate,
   isolate: *mut Isolate,
 ) -> *const Object {
-  let value_deserializer_heap = ValueDeserializerHeap::dispatch_mut(this);
+  let value_deserializer_heap = ValueDeserializerHeap::dispatch(this);
   let scope = &mut CallbackScope::new(isolate.as_mut().unwrap());
   let context = value_deserializer_heap.context.get(scope).unwrap();
   let scope = &mut ContextScope::new(scope, context);
-  let value_deserializer_impl =
-    value_deserializer_heap.value_deserializer_impl.as_mut();
-  match value_deserializer_impl.read_host_object(
-    scope,
-    &mut value_deserializer_heap.cxx_value_deserializer,
-  ) {
+
+  match value_deserializer_heap
+    .value_deserializer_impl
+    .read_host_object(scope, &value_deserializer_heap.cxx_value_deserializer)
+  {
     None => std::ptr::null(),
     Some(x) => x.as_non_null().as_ptr(),
   }
@@ -53,18 +52,17 @@ pub unsafe extern "C" fn v8__ValueDeserializer__Delegate__ReadHostObject(
 
 #[no_mangle]
 pub unsafe extern "C" fn v8__ValueDeserializer__Delegate__GetSharedArrayBufferFromId(
-  this: &mut CxxValueDeserializerDelegate,
+  this: &CxxValueDeserializerDelegate,
   isolate: *mut Isolate,
   transfer_id: u32,
 ) -> *const SharedArrayBuffer {
-  let value_deserializer_heap = ValueDeserializerHeap::dispatch_mut(this);
+  let value_deserializer_heap = ValueDeserializerHeap::dispatch(this);
   let scope = &mut CallbackScope::new(isolate.as_mut().unwrap());
   let context = value_deserializer_heap.context.get(scope).unwrap();
   let scope = &mut ContextScope::new(scope, context);
 
-  let value_deserializer_impl =
-    value_deserializer_heap.value_deserializer_impl.as_mut();
-  match value_deserializer_impl
+  match value_deserializer_heap
+    .value_deserializer_impl
     .get_shared_array_buffer_from_id(scope, transfer_id)
   {
     None => std::ptr::null(),
@@ -78,13 +76,15 @@ pub unsafe extern "C" fn v8__ValueDeserializer__Delegate__GetWasmModuleFromId(
   isolate: *mut Isolate,
   clone_id: u32,
 ) -> *const WasmModuleObject {
-  let value_deserializer_heap = ValueDeserializerHeap::dispatch_mut(this);
+  let value_deserializer_heap = ValueDeserializerHeap::dispatch(this);
   let scope = &mut CallbackScope::new(isolate.as_mut().unwrap());
   let context = value_deserializer_heap.context.get(scope).unwrap();
   let scope = &mut ContextScope::new(scope, context);
-  let value_deserializer_impl =
-    value_deserializer_heap.value_deserializer_impl.as_mut();
-  match value_deserializer_impl.get_wasm_module_from_id(scope, clone_id) {
+
+  match value_deserializer_heap
+    .value_deserializer_impl
+    .get_wasm_module_from_id(scope, clone_id)
+  {
     None => std::ptr::null(),
     Some(x) => x.as_non_null().as_ptr(),
   }
@@ -165,9 +165,9 @@ extern "C" {
 /// custom callback functions used by v8.
 pub trait ValueDeserializerImpl: GarbageCollected {
   fn read_host_object<'s>(
-    &mut self,
+    &self,
     scope: &mut HandleScope<'s>,
-    _value_deserializer: &mut dyn ValueDeserializerHelper,
+    _value_deserializer: &dyn ValueDeserializerHelper,
   ) -> Option<Local<'s, Object>> {
     let msg =
       String::new(scope, "Deno deserializer: read_host_object not implemented")
@@ -178,7 +178,7 @@ pub trait ValueDeserializerImpl: GarbageCollected {
   }
 
   fn get_shared_array_buffer_from_id<'s>(
-    &mut self,
+    &self,
     scope: &mut HandleScope<'s>,
     _transfer_id: u32,
   ) -> Option<Local<'s, SharedArrayBuffer>> {
@@ -193,7 +193,7 @@ pub trait ValueDeserializerImpl: GarbageCollected {
   }
 
   fn get_wasm_module_from_id<'s>(
-    &mut self,
+    &self,
     scope: &mut HandleScope<'s>,
     _clone_id: u32,
   ) -> Option<Local<'s, WasmModuleObject>> {
@@ -206,6 +206,10 @@ pub trait ValueDeserializerImpl: GarbageCollected {
     scope.throw_exception(exc);
     None
   }
+}
+
+fn cast_to_ptr<T>(t: &T) -> *mut T {
+  t as *const _ as *mut _
 }
 
 /// The ValueDeserializerHeap object contains all objects related to a
@@ -246,15 +250,6 @@ impl<'a> ValueDeserializerHeap<'a> {
     Self::get_cxx_value_deserializer_delegate_offset()
       .to_embedder::<Self>(value_serializer_delegate)
   }
-
-  /// Starting from 'this' pointer the ValueDeserializerHeap mut ref can be
-  /// created
-  pub unsafe fn dispatch_mut(
-    value_serializer_delegate: &mut CxxValueDeserializerDelegate,
-  ) -> &mut Self {
-    Self::get_cxx_value_deserializer_delegate_offset()
-      .to_embedder_mut::<Self>(value_serializer_delegate)
-  }
 }
 
 impl<'a> Drop for ValueDeserializerHeap<'a> {
@@ -269,12 +264,12 @@ impl<'a> Drop for ValueDeserializerHeap<'a> {
 /// Mostly used by the read_host_object callback function in the
 /// ValueDeserializerImpl trait to create custom deserialization logic.
 pub trait ValueDeserializerHelper {
-  fn get_cxx_value_deserializer(&mut self) -> &mut CxxValueDeserializer;
+  fn get_cxx_value_deserializer(&self) -> &CxxValueDeserializer;
 
-  fn read_header(&mut self, context: Local<Context>) -> Option<bool> {
+  fn read_header(&self, context: Local<Context>) -> Option<bool> {
     unsafe {
       v8__ValueDeserializer__ReadHeader(
-        self.get_cxx_value_deserializer(),
+        cast_to_ptr(self.get_cxx_value_deserializer()),
         context,
       )
     }
@@ -282,49 +277,49 @@ pub trait ValueDeserializerHelper {
   }
 
   fn read_value<'s>(
-    &mut self,
+    &self,
     context: Local<'s, Context>,
   ) -> Option<Local<'s, Value>> {
     unsafe {
       Local::from_raw(v8__ValueDeserializer__ReadValue(
-        self.get_cxx_value_deserializer(),
+        cast_to_ptr(self.get_cxx_value_deserializer()),
         context,
       ))
     }
   }
 
-  fn read_uint32(&mut self, value: &mut u32) -> bool {
+  fn read_uint32(&self, value: &mut u32) -> bool {
     unsafe {
       v8__ValueDeserializer__ReadUint32(
-        self.get_cxx_value_deserializer(),
+        cast_to_ptr(self.get_cxx_value_deserializer()),
         value,
       )
     }
   }
 
-  fn read_uint64(&mut self, value: &mut u64) -> bool {
+  fn read_uint64(&self, value: &mut u64) -> bool {
     unsafe {
       v8__ValueDeserializer__ReadUint64(
-        self.get_cxx_value_deserializer(),
+        cast_to_ptr(self.get_cxx_value_deserializer()),
         value,
       )
     }
   }
 
-  fn read_double(&mut self, value: &mut f64) -> bool {
+  fn read_double(&self, value: &mut f64) -> bool {
     unsafe {
       v8__ValueDeserializer__ReadDouble(
-        self.get_cxx_value_deserializer(),
+        cast_to_ptr(self.get_cxx_value_deserializer()),
         value,
       )
     }
   }
 
-  fn read_raw_bytes(&mut self, length: usize) -> Option<&[u8]> {
+  fn read_raw_bytes(&self, length: usize) -> Option<&[u8]> {
     let mut data: *const c_void = std::ptr::null_mut();
     let ok = unsafe {
       v8__ValueDeserializer__ReadRawBytes(
-        self.get_cxx_value_deserializer(),
+        cast_to_ptr(self.get_cxx_value_deserializer()),
         length,
         &mut data,
       )
@@ -338,43 +333,43 @@ pub trait ValueDeserializerHelper {
   }
 
   fn transfer_array_buffer(
-    &mut self,
+    &self,
     transfer_id: u32,
     array_buffer: Local<ArrayBuffer>,
   ) {
     unsafe {
       v8__ValueDeserializer__TransferArrayBuffer(
-        self.get_cxx_value_deserializer(),
+        cast_to_ptr(self.get_cxx_value_deserializer()),
         transfer_id,
         array_buffer,
       )
     };
   }
 
-  fn get_wire_format_version(&mut self) -> u32 {
+  fn get_wire_format_version(&self) -> u32 {
     unsafe {
-      v8__ValueDeserializer__GetWireFormatVersion(
+      v8__ValueDeserializer__GetWireFormatVersion(cast_to_ptr(
         self.get_cxx_value_deserializer(),
-      )
+      ))
     }
   }
 }
 
 impl ValueDeserializerHelper for CxxValueDeserializer {
-  fn get_cxx_value_deserializer(&mut self) -> &mut CxxValueDeserializer {
+  fn get_cxx_value_deserializer(&self) -> &CxxValueDeserializer {
     self
   }
 }
 
 impl<'a> ValueDeserializerHelper for ValueDeserializerHeap<'a> {
-  fn get_cxx_value_deserializer(&mut self) -> &mut CxxValueDeserializer {
-    &mut self.cxx_value_deserializer
+  fn get_cxx_value_deserializer(&self) -> &CxxValueDeserializer {
+    &self.cxx_value_deserializer
   }
 }
 
 impl<'a> ValueDeserializerHelper for ValueDeserializer<'a> {
-  fn get_cxx_value_deserializer(&mut self) -> &mut CxxValueDeserializer {
-    &mut self.value_deserializer_heap.cxx_value_deserializer
+  fn get_cxx_value_deserializer(&self) -> &CxxValueDeserializer {
+    &self.value_deserializer_heap.cxx_value_deserializer
   }
 }
 
@@ -385,6 +380,9 @@ impl<'a> ValueDeserializerHelper for ValueDeserializer<'a> {
 /// a Local<'s, Context> for the CallbackScopes
 pub struct ValueDeserializer<'a> {
   value_deserializer_heap: Pin<Box<ValueDeserializerHeap<'a>>>,
+  // ValueDeserializerHeap is already !Send and !Sync
+  // but this is just making it explicit
+  _phantom: std::marker::PhantomData<*mut ()>,
 }
 
 impl<'a> GarbageCollected for ValueDeserializer<'a> {
@@ -401,56 +399,65 @@ impl<'a> ValueDeserializer<'a> {
   ) -> Self {
     let context = scope.get_current_context();
     // create dummy ValueDeserializerHeap and move to heap + pin to address
-    let mut value_deserializer_heap = Box::pin(ValueDeserializerHeap {
-      value_deserializer_impl,
-      cxx_value_deserializer: CxxValueDeserializer {
-        _cxx_vtable: CxxVTable(std::ptr::null()),
-      },
-      cxx_value_deserializer_delegate: CxxValueDeserializerDelegate {
-        _cxx_vtable: CxxVTable(std::ptr::null()),
-      },
-      context: TracedReference::new(scope, context),
-    });
+    let value_deserializer_heap_ptr =
+      Box::into_raw(Box::new(ValueDeserializerHeap {
+        value_deserializer_impl,
+        cxx_value_deserializer: CxxValueDeserializer {
+          _cxx_vtable: CxxVTable(std::ptr::null()),
+        },
+        cxx_value_deserializer_delegate: CxxValueDeserializerDelegate {
+          _cxx_vtable: CxxVTable(std::ptr::null()),
+        },
+        context: TracedReference::new(scope, context),
+      }));
 
     unsafe {
+      let delegate_ptr = std::ptr::addr_of_mut!(
+        (*value_deserializer_heap_ptr).cxx_value_deserializer_delegate
+      );
+      let deserializer_ptr = std::ptr::addr_of_mut!(
+        (*value_deserializer_heap_ptr).cxx_value_deserializer
+      );
       v8__ValueDeserializer__Delegate__CONSTRUCT(
-        &mut value_deserializer_heap.cxx_value_deserializer_delegate
-          as *mut CxxValueDeserializerDelegate
-          as *mut std::mem::MaybeUninit<CxxValueDeserializerDelegate>,
+        delegate_ptr
+          .cast::<std::mem::MaybeUninit<CxxValueDeserializerDelegate>>(),
       );
 
       v8__ValueDeserializer__CONSTRUCT(
-        &mut value_deserializer_heap.cxx_value_deserializer
-          as *mut CxxValueDeserializer
-          as *mut std::mem::MaybeUninit<CxxValueDeserializer>,
+        deserializer_ptr.cast::<std::mem::MaybeUninit<CxxValueDeserializer>>(),
         scope.get_isolate_ptr(),
         data.as_ptr(),
         data.len(),
-        &mut value_deserializer_heap.cxx_value_deserializer_delegate,
+        delegate_ptr,
       );
     };
 
+    // SAFETY: pointer from Box::into_raw is valid
+    let value_deserializer_heap =
+      Pin::new(unsafe { Box::from_raw(value_deserializer_heap_ptr) });
+
     ValueDeserializer {
       value_deserializer_heap,
+      _phantom: std::marker::PhantomData,
     }
   }
 }
 
 impl<'a> ValueDeserializer<'a> {
   pub fn set_supports_legacy_wire_format(
-    &mut self,
+    &self,
     supports_legacy_wire_format: bool,
   ) {
     unsafe {
       v8__ValueDeserializer__SetSupportsLegacyWireFormat(
-        &mut self.value_deserializer_heap.cxx_value_deserializer,
+        cast_to_ptr(&self.value_deserializer_heap.cxx_value_deserializer),
         supports_legacy_wire_format,
       );
     }
   }
 
   pub fn read_value<'t>(
-    &mut self,
+    &self,
     context: Local<'t, Context>,
   ) -> Option<Local<'t, Value>> {
     self.value_deserializer_heap.read_value(context)

--- a/src/value_deserializer.rs
+++ b/src/value_deserializer.rs
@@ -243,7 +243,6 @@ impl<'a> ValueDeserializerHeap<'a> {
   }
 
   /// Starting from 'this' pointer a ValueDeserializerHeap ref can be created
-  #[allow(dead_code)]
   pub unsafe fn dispatch(
     value_serializer_delegate: &CxxValueDeserializerDelegate,
   ) -> &Self {

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -36,7 +36,7 @@ pub struct CxxValueSerializerDelegate {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn v8__ValueSerializer__Delegate__ThrowDataCloneError(
+unsafe extern "C" fn v8__ValueSerializer__Delegate__ThrowDataCloneError(
   this: &CxxValueSerializerDelegate,
   message: Local<String>,
 ) {
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn v8__ValueSerializer__Delegate__ThrowDataCloneError(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn v8__ValueSerializer__Delegate__HasCustomHostObject(
+unsafe extern "C" fn v8__ValueSerializer__Delegate__HasCustomHostObject(
   this: &CxxValueSerializerDelegate,
   isolate: *mut Isolate,
 ) -> bool {
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn v8__ValueSerializer__Delegate__HasCustomHostObject(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn v8__ValueSerializer__Delegate__IsHostObject(
+unsafe extern "C" fn v8__ValueSerializer__Delegate__IsHostObject(
   this: &CxxValueSerializerDelegate,
   isolate: *mut Isolate,
   object: Local<Object>,
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn v8__ValueSerializer__Delegate__IsHostObject(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn v8__ValueSerializer__Delegate__WriteHostObject(
+unsafe extern "C" fn v8__ValueSerializer__Delegate__WriteHostObject(
   this: &CxxValueSerializerDelegate,
   isolate: *mut Isolate,
   object: Local<Object>,
@@ -100,7 +100,7 @@ pub unsafe extern "C" fn v8__ValueSerializer__Delegate__WriteHostObject(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn v8__ValueSerializer__Delegate__GetSharedArrayBufferId(
+unsafe extern "C" fn v8__ValueSerializer__Delegate__GetSharedArrayBufferId(
   this: &CxxValueSerializerDelegate,
   isolate: *mut Isolate,
   shared_array_buffer: Local<SharedArrayBuffer>,
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn v8__ValueSerializer__Delegate__GetSharedArrayBufferId(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn v8__ValueSerializer__Delegate__GetWasmModuleTransferId(
+unsafe extern "C" fn v8__ValueSerializer__Delegate__GetWasmModuleTransferId(
   this: &CxxValueSerializerDelegate,
   isolate: *mut Isolate,
   module: Local<WasmModuleObject>,
@@ -146,7 +146,7 @@ pub unsafe extern "C" fn v8__ValueSerializer__Delegate__GetWasmModuleTransferId(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn v8__ValueSerializer__Delegate__ReallocateBufferMemory(
+unsafe extern "C" fn v8__ValueSerializer__Delegate__ReallocateBufferMemory(
   this: &CxxValueSerializerDelegate,
   old_buffer: *mut c_void,
   size: usize,
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn v8__ValueSerializer__Delegate__ReallocateBufferMemory(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn v8__ValueSerializer__Delegate__FreeBufferMemory(
+unsafe extern "C" fn v8__ValueSerializer__Delegate__FreeBufferMemory(
   this: &mut CxxValueSerializerDelegate,
   buffer: *mut c_void,
 ) {

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -238,6 +238,10 @@ extern "C" {
     source: *const c_void,
     length: usize,
   );
+  fn v8__ValueSerializer__SetTreatArrayBufferViewsAsHostObjects(
+    this: *mut CxxValueSerializer,
+    mode: bool,
+  );
 }
 
 /// The ValueSerializerImpl trait allows for
@@ -429,6 +433,15 @@ pub trait ValueSerializerHelper {
       )
     };
   }
+
+  fn set_treat_array_buffer_views_as_host_objects(&mut self, mode: bool) {
+    unsafe {
+      ValueSerializer::set_treat_array_buffer_views_as_host_objects_raw(
+        self.get_cxx_value_serializer(),
+        mode,
+      )
+    };
+  }
 }
 
 impl ValueSerializerHelper for CxxValueSerializer {
@@ -543,6 +556,13 @@ impl<'a> ValueSerializer<'a> {
     value: Local<Value>,
   ) -> MaybeBool {
     v8__ValueSerializer__WriteValue(ser, context, value)
+  }
+
+  pub unsafe fn set_treat_array_buffer_views_as_host_objects_raw(
+    ser: *mut CxxValueSerializer,
+    mode: bool,
+  ) {
+    v8__ValueSerializer__SetTreatArrayBufferViewsAsHostObjects(ser, mode)
   }
 }
 

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -564,6 +564,12 @@ impl<'a> ValueSerializer<'a> {
   ) {
     v8__ValueSerializer__SetTreatArrayBufferViewsAsHostObjects(ser, mode)
   }
+
+  pub unsafe fn get_cxx_value_serializer_raw(
+    ser: *mut Self,
+  ) -> *mut CxxValueSerializer {
+    std::ptr::addr_of_mut!((*ser).value_serializer_heap.cxx_value_serializer)
+  }
 }
 
 impl<'a> ValueSerializer<'a> {

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -346,7 +346,6 @@ impl<'a> ValueSerializerHeap<'a> {
   }
 
   /// Starting from 'this' pointer a ValueSerializerHeap ref can be created
-  #[allow(dead_code)]
   pub unsafe fn dispatch(
     value_serializer_delegate: &CxxValueSerializerDelegate,
   ) -> &Self {

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -240,7 +240,7 @@ extern "C" {
 
 /// The ValueSerializerImpl trait allows for
 /// custom callback functions used by v8.
-pub trait ValueSerializerImpl {
+pub trait ValueSerializerImpl: GarbageCollected {
   fn throw_data_clone_error<'s>(
     &mut self,
     scope: &mut HandleScope<'s>,
@@ -316,6 +316,13 @@ pub struct ValueSerializerHeap<'a> {
   buffer_size: usize,
   context: TracedReference<Context>,
   isolate_ptr: *mut Isolate,
+}
+
+impl<'a> crate::cppgc::GarbageCollected for ValueSerializerHeap<'a> {
+  fn trace(&self, visitor: &crate::cppgc::Visitor) {
+    self.value_serializer_impl.trace(visitor);
+    self.context.trace(visitor);
+  }
 }
 
 impl<'a> ValueSerializerHeap<'a> {
@@ -446,7 +453,7 @@ pub struct ValueSerializer<'a> {
 
 impl<'a> crate::cppgc::GarbageCollected for ValueSerializer<'a> {
   fn trace(&self, visitor: &crate::cppgc::Visitor) {
-    self.value_serializer_heap.context.trace(visitor);
+    self.value_serializer_heap.trace(visitor);
   }
 }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -15,7 +15,6 @@ use std::ptr::{addr_of, addr_of_mut, NonNull};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
-use v8::cppgc::GarbageCollected;
 use v8::fast_api;
 use v8::inspector::ChannelBase;
 use v8::AccessorConfiguration;
@@ -7956,8 +7955,6 @@ struct Custom1Value<'a> {
   array_buffers: RefCell<&'a mut ArrayBuffers>,
 }
 
-impl<'a> GarbageCollected for Custom1Value<'a> {}
-
 impl<'a> Custom1Value<'a> {
   fn serializer<'s>(
     scope: &mut v8::HandleScope<'s>,
@@ -8329,8 +8326,6 @@ fn value_serializer_and_deserializer_embedder_host_object() {
 
 struct Custom2Value {}
 
-impl GarbageCollected for Custom2Value {}
-
 impl<'a> Custom2Value {
   fn serializer<'s>(
     scope: &mut v8::HandleScope<'s>,
@@ -8390,8 +8385,6 @@ fn value_serializer_not_implemented() {
 }
 
 struct Custom3Value {}
-
-impl GarbageCollected for Custom3Value {}
 
 impl<'a> Custom3Value {
   fn serializer<'s>(
@@ -11751,7 +11744,6 @@ fn allow_scope_in_read_host_object() {
   // internally a DisallowJavascriptExecutionScope, so an allow scope must be
   // created in order to run JS code in that callback.
   struct Serializer;
-  impl GarbageCollected for Serializer {}
   impl v8::ValueSerializerImpl for Serializer {
     fn write_host_object<'s>(
       &self,
@@ -11773,7 +11765,6 @@ fn allow_scope_in_read_host_object() {
   }
 
   struct Deserializer;
-  impl GarbageCollected for Deserializer {}
   impl v8::ValueDeserializerImpl for Deserializer {
     fn read_host_object<'s>(
       &self,


### PR DESCRIPTION
Currently, if you were to call (for instance) `write_value` as part of a custom `write_host_object` implementation, you would be forced to create aliased exclusive references to the serializer (which is instant UB).

The underlying v8 de/serializers are re-entrant, so for the most part we simply need to pass around shared references instead of exclusive references.

Also adds some bindings to some missing functions, and makes `ValueSerializer` (and deserializer) garbage collectable.