### PR TITLE
disable pointer compression

### DIFF
--- a/.gn
+++ b/.gn
@@ -38,6 +38,8 @@ default_args = {
   v8_use_external_startup_data = false
   v8_use_snapshot = true
 
+  v8_enable_pointer_compression = false
+
   # This flag speeds up the performance of fork/execve on Linux systems for
   # embedders which use it (like Node.js). It works by marking the pages that
   # V8 allocates as MADV_DONTFORK. Without MADV_DONTFORK, the Linux kernel

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3367,14 +3367,6 @@ void v8__HeapProfiler__TakeHeapSnapshot(v8::Isolate* isolate,
   const_cast<v8::HeapSnapshot*>(snapshot)->Delete();
 }
 
-// This is necessary for v8__internal__GetIsolateFromHeapObject() to be
-// reliable enough for our purposes.
-#if UINTPTR_MAX == 0xffffffffffffffff && \
-    !(defined V8_SHARED_RO_HEAP or defined V8_COMPRESS_POINTERS)
-#error V8 must be built with either the 'v8_enable_pointer_compression' or \
-'v8_enable_shared_ro_heap' feature enabled.
-#endif
-
 v8::Isolate* v8__internal__GetIsolateFromHeapObject(const v8::Data& data) {
   namespace i = v8::internal;
   i::Tagged<i::Object> object(reinterpret_cast<const i::Address&>(data));


### PR DESCRIPTION
This causes issues with heap cages, limiting the process to 4G of heap, and also may prevent use of upcoming js features like shared structs.