### PR TITLE
remove unused submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "tools/clang"]
 	path = tools/clang
 	url = https://chromium.googlesource.com/chromium/src/tools/clang.git
-[submodule "base/trace_event/common"]
-	path = base/trace_event/common
-	url = https://chromium.googlesource.com/chromium/src/base/trace_event/common.git
 [submodule "third_party/jinja2"]
 	path = third_party/jinja2
 	url = https://chromium.googlesource.com/chromium/src/third_party/jinja2.git


### PR DESCRIPTION
v8 vendored its own copy of trace-events because chromium stopped using it in favor of perfetto.