### PR TITLE
fix: Check for null pointer returned by `ValueSerializer::Release`

### DIFF
--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -536,13 +536,13 @@ impl<'a> ValueSerializer<'a> {
         &mut ptr,
         &mut size,
       );
-      if ptr.is_null() {
-        return Vec::new();
-      }
       let capacity = self
         .value_serializer_heap
         .buffer_size
         .swap(0, std::sync::atomic::Ordering::Relaxed);
+      if ptr.is_null() {
+        return Vec::new();
+      }
       assert!(size <= capacity);
       // SAFETY: ptr is non-null, was allocated by us in `v8__ValueSerializer__Delegate__ReallocateBufferMemory`, and
       // the capacity is correctly updated during reallocation. Size is asserted to be valid above.

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -536,14 +536,17 @@ impl<'a> ValueSerializer<'a> {
         &mut ptr,
         &mut size,
       );
-      Vec::from_raw_parts(
-        ptr,
-        size,
-        self
-          .value_serializer_heap
-          .buffer_size
-          .swap(0, std::sync::atomic::Ordering::Relaxed),
-      )
+      if ptr.is_null() {
+        return Vec::new();
+      }
+      let capacity = self
+        .value_serializer_heap
+        .buffer_size
+        .swap(0, std::sync::atomic::Ordering::Relaxed);
+      assert!(size <= capacity);
+      // SAFETY: ptr is non-null, was allocated by us in `v8__ValueSerializer__Delegate__ReallocateBufferMemory`, and
+      // the capacity is correctly updated during reallocation. Size is asserted to be valid above.
+      Vec::from_raw_parts(ptr, size, capacity)
     }
   }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8070,6 +8070,7 @@ fn value_serializer_and_deserializer() {
     value_serializer.write_double(55.44);
     value_serializer.write_uint32(22);
     buffer = value_serializer.release();
+    assert_eq!(value_serializer.release(), Vec::new());
   }
 
   let mut double: f64 = 0.0;


### PR DESCRIPTION
The internal buffer pointer gets set to null upon release, and then returned by v8 to us.