### PR TITLE
Update to v0.105.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,7 +1452,7 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "v8"
-version = "0.105.0"
+version = "0.105.1"
 dependencies = [
  "align-data",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v8"
-version = "0.105.0"
+version = "0.105.1"
 description = "Rust bindings to V8"
 readme = "README.md"
 authors = ["the Deno authors"]


### PR DESCRIPTION
To pick up https://github.com/denoland/rusty_v8/commit/eb29f6bd8cf9c259303613e19377fb44f626bf4b plus some v8 fixes.