### PR TITLE
re-add deprecated cppgc api

### DIFF
--- a/.gn
+++ b/.gn
@@ -40,6 +40,8 @@ default_args = {
 
   v8_enable_pointer_compression = false
 
+  v8_imminent_deprecation_warnings = false
+
   # This flag speeds up the performance of fork/execve on Linux systems for
   # embedders which use it (like Node.js). It works by marking the pages that
   # V8 allocates as MADV_DONTFORK. Without MADV_DONTFORK, the Linux kernel

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3888,13 +3888,25 @@ void v8__Object__Wrap(v8::Isolate* isolate, const v8::Object& wrapper,
                    tag);
 }
 
+v8::CppHeap* v8__Isolate__GetCppHeap(v8::Isolate* isolate) {
+  return isolate->GetCppHeap();
+}
+
+void v8__Isolate__AttachCppHeap(v8::Isolate* isolate, v8::CppHeap* cpp_heap) {
+  isolate->AttachCppHeap(cpp_heap);
+}
+
+void v8__Isolate__DetachCppHeap(v8::Isolate* isolate) {
+  isolate->DetachCppHeap();
+}
+
 void cppgc__initialize_process(v8::Platform* platform) {
   cppgc::InitializeProcess(platform->GetPageAllocator());
 }
 
 void cppgc__shutdown_process() { cppgc::ShutdownProcess(); }
 
-v8::CppHeap* cppgc__heap__create(v8::Platform* platform,
+v8::CppHeap* v8__CppHeap__Create(v8::Platform* platform,
                                  cppgc::Heap::MarkingType marking_support,
                                  cppgc::Heap::SweepingType sweeping_support) {
   v8::CppHeapCreateParams params{{}};
@@ -3904,11 +3916,9 @@ v8::CppHeap* cppgc__heap__create(v8::Platform* platform,
   return heap.release();
 }
 
-v8::CppHeap* v8__Isolate__GetCppHeap(v8::Isolate* isolate) {
-  return isolate->GetCppHeap();
-}
+void v8__CppHeap__Terminate(v8::CppHeap* cpp_heap) { cpp_heap->Terminate(); }
 
-void cppgc__heap__DELETE(v8::CppHeap* self) { delete self; }
+void v8__CppHeap__DELETE(v8::CppHeap* self) { delete self; }
 
 void cppgc__heap__enable_detached_garbage_collections_for_testing(
     v8::CppHeap* heap) {

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -18,6 +18,7 @@ use crate::support::MapFnFrom;
 use crate::support::MapFnTo;
 use crate::support::Opaque;
 use crate::support::ToCFn;
+use crate::support::UniqueRef;
 use crate::support::UnitType;
 use crate::wasm::trampoline;
 use crate::wasm::WasmStreaming;
@@ -467,6 +468,8 @@ extern "C" {
     change_in_bytes: i64,
   ) -> i64;
   fn v8__Isolate__GetCppHeap(isolate: *mut Isolate) -> *mut Heap;
+  fn v8__Isolate__AttachCppHeap(isolate: *mut Isolate, cpp_heap: *mut Heap);
+  fn v8__Isolate__DetachCppHeap(isolate: *mut Isolate);
   fn v8__Isolate__SetPrepareStackTraceCallback(
     isolate: *mut Isolate,
     callback: PrepareStackTraceCallback,
@@ -1219,8 +1222,19 @@ impl Isolate {
     }
   }
 
+  #[inline(always)]
   pub fn get_cpp_heap(&mut self) -> Option<&Heap> {
     unsafe { v8__Isolate__GetCppHeap(self).as_ref() }
+  }
+
+  #[inline(always)]
+  pub fn attach_cpp_heap(&mut self, cpp_heap: &mut UniqueRef<Heap>) {
+    unsafe { v8__Isolate__AttachCppHeap(self, cpp_heap.deref_mut()) }
+  }
+
+  #[inline(always)]
+  pub fn detach_cpp_heap(&mut self) {
+    unsafe { v8__Isolate__DetachCppHeap(self) }
   }
 
   #[inline(always)]


### PR DESCRIPTION
blink is still only manually attaching cppgc heaps, and the other code paths are untested, so continue exposing this to avoid bugs (for example: https://github.com/denoland/deno_core/issues/894)