### PR TITLE
upgrade deprecated workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         uses: dsherret/rust-toolchain-file@v1
 
       - name: Install python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11.x
           architecture: x64
@@ -124,7 +124,7 @@ jobs:
         run: git submodule status --recursive > git_submodule_status.txt
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # Note: rusty_v8 targets always get get rebuilt, and their outputs
           # ('librusty_v8.rlib', the whole 'gn_out' directory, etc.) can be


### PR DESCRIPTION
Fixes this spam on CI runs:
> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/setup-python@v4, actions/cache@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/