### PR TITLE
Update bindgen to fix builds with LLVM 19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,16 +82,14 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -100,7 +98,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.60",
- "which 4.4.2",
 ]
 
 [[package]]
@@ -692,12 +689,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -1466,7 +1457,7 @@ dependencies = [
  "paste",
  "rustversion",
  "trybuild",
- "which 6.0.1",
+ "which",
 ]
 
 [[package]]
@@ -1717,18 +1708,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e15e44ba88ec415466e18e91881319e7c9e96cb905dc623305168aea65b85ccc"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ gzip-header = "1.0.0"
 fslock = "0.2"
 which = "6"
 home = "0"
-bindgen = "0.69"
+bindgen = "0.70"
 
 [dev-dependencies]
 miniz_oxide = "0.7.3"
@@ -110,7 +110,7 @@ trybuild = "1.0.96"
 which = "6"
 home = "0"
 rustversion = "1"
-bindgen = "0.69"
+bindgen = "0.70"
 
 [[example]]
 name = "hello_world"


### PR DESCRIPTION
To pick up this fix: https://github.com/rust-lang/rust-bindgen/commit/600f63895f73c80d6bf7ff3c71b86a068d1663d2