### PR TITLE
perf: speed up v8::String::to_rust_*_lossy()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           sudo apt install -yq --no-install-suggests --no-install-recommends \
             binfmt-support g++-10-aarch64-linux-gnu g++-10-multilib \
             gcc-10-aarch64-linux-gnu libc6-arm64-cross qemu qemu-user \
-            qemu-user-binfmt
+            qemu-user-binfmt aarch64-linux-gnu-g++
 
           sudo ln -s /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 \
                      /lib/ld-linux-aarch64.so.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simdutf"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1945a45633804474a6f1aef87f072d7564c6421025a865f6777709a571fdfae"
+dependencies = [
+ "bitflags 2.5.0",
+ "cc",
+]
+
+[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1466,7 @@ dependencies = [
  "once_cell",
  "paste",
  "rustversion",
+ "simdutf",
  "trybuild",
  "which",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ use_custom_libcxx = []
 bitflags = "2.5"
 once_cell = "1.19"
 paste = "1.0"
+simdutf = "0.5.1"
 
 [build-dependencies]
 miniz_oxide = "0.7.2"

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1228,22 +1228,6 @@ void v8__String__ValueView__DESTRUCT(v8::String::ValueView* self) {
   self->~ValueView();
 }
 
-bool v8__String__ValueView__is_one_byte(const v8::String::ValueView& self) {
-  return self.is_one_byte();
-}
-
-const void* v8__String__ValueView__data(const v8::String::ValueView& self) {
-  if (self.is_one_byte()) {
-    return reinterpret_cast<const void*>(self.data8());
-  } else {
-    return reinterpret_cast<const void*>(self.data16());
-  }
-}
-
-int v8__String__ValueView__length(const v8::String::ValueView& self) {
-  return self.length();
-}
-
 const v8::Symbol* v8__Symbol__New(v8::Isolate* isolate,
                                   const v8::String* description) {
   return local_to_ptr(v8::Symbol::New(isolate, ptr_to_local(description)));


### PR DESCRIPTION
This commit speeds up this common conversion
method between by 2x for many common cases. Short
one byte ASCII strings are now 20% faster. Longer
one byte ASCII strings are 2.5x faster. Short UTF8
strings are marginally slower (5%) but longer UTF8
strings are upwards of 2x faster.

A follow up will make the short UTF8 strings about
2x faster than the current implementation as well.
