### PR TITLE
fix: glibc version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo dd of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
           sudo apt-get update
           sudo apt-get -qq remove 'clang-*'
-          sudo apt-get install lld clang clang-tools clang-tidy clang-format -y
+          sudo apt-get install lld-19 clang-19 clang-tools-19 clang-tidy-19 clang-format-19 -y
 
       - name: Install Rust (nightly)
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,12 @@ jobs:
             variant: release
             cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-24.04-xl' || 'ubuntu-24.04' }}
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
             target: x86_64-unknown-linux-gnu
             variant: debug
             cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-24.04-xl' || 'ubuntu-24.04' }}
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
             target: x86_64-unknown-linux-gnu
             variant: release
             cargo: cargo
@@ -67,12 +67,12 @@ jobs:
             variant: release # Note: we do not support windows debug builds.
             cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-24.04-xl' || 'ubuntu-24.04' }}
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
             target: aarch64-unknown-linux-gnu
             variant: debug
             cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-24.04-xl' || 'ubuntu-24.04' }}
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
             target: aarch64-unknown-linux-gnu
             variant: release
             cargo: cargo
@@ -103,11 +103,6 @@ jobs:
           python-version: 3.11.x
           architecture: x64
 
-      - name: Install ubuntu deps
-        if: startsWith(matrix.config.os, 'ubuntu')
-        run: |
-          sudo apt-get install -y glib2.0
-
       - name: Install cross compilation toolchain
         if: matrix.config.target == 'aarch64-unknown-linux-gnu'
         run: |
@@ -116,7 +111,7 @@ jobs:
           sudo apt update
           sudo apt install -yq --no-install-suggests --no-install-recommends \
             binfmt-support g++-10-aarch64-linux-gnu g++-10-multilib \
-            gcc-10-aarch64-linux-gnu libc6-arm64-cross qemu-system qemu-user \
+            gcc-10-aarch64-linux-gnu libc6-arm64-cross qemu qemu-user \
             qemu-user-binfmt
 
           sudo ln -s /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 \
@@ -237,7 +232,7 @@ jobs:
 
   publish:
     needs: build
-    runs-on: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-24.04-xl' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
     if: github.repository == 'denoland/rusty_v8' && startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Configure git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,15 @@ jobs:
           . $basename/sccache --start-server
           echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Install Clang
+        if: startsWith(matrix.config.os, 'ubuntu')
+        run: |
+          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" | sudo dd of=/etc/apt/sources.list.d/llvm-toolchain-jammy-19.list
+          curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo dd of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
+          sudo apt-get update
+          sudo apt-get -qq remove 'clang-*'
+          sudo apt-get install lld clang clang-tools clang-tidy clang-format -y
+
       - name: Install Rust (nightly)
         uses: dtolnay/rust-toolchain@nightly
         if: matrix.config.variant == 'asan'
@@ -174,7 +183,6 @@ jobs:
       - name: check c++ code formatting
         if: startsWith(matrix.config.os, 'ubuntu')
         run: |
-          sudo apt-get install -y clang-format
           clang-format --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h
 
       - name: Test (ASAN)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
       - name: check c++ code formatting
         if: startsWith(matrix.config.os, 'ubuntu')
         run: |
-          clang-format --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h
+          clang-format-19 --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h
 
       - name: Test (ASAN)
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.3",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -713,7 +713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 components = ["rustfmt", "clippy"]
 targets = [
     "x86_64-apple-darwin",

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -11029,8 +11029,7 @@ fn test_fast_calls_callback_options_data() {
   let scope = &mut v8::ContextScope::new(scope, context);
 
   let global = context.global(scope);
-  let external =
-    v8::External::new(scope, unsafe { addr_of_mut!(DATA) as *mut c_void });
+  let external = v8::External::new(scope, addr_of_mut!(DATA) as *mut c_void);
 
   let template = v8::FunctionTemplate::builder(slow_fn)
     .data(external.into())


### PR DESCRIPTION
go back to 22.04 to fix glibc version. updates clang for newer features used in v8. also requires a rust toolchain upgrade to build correctly for mysterious and unknown reasons.

Fixes: https://github.com/denoland/rusty_v8/issues/1655