### PR TITLE
Add `v8::Eternal<T>`

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -441,6 +441,31 @@ const v8::Data* v8__TracedReference__Get(v8::TracedReference<v8::Data>* self,
   return local_to_ptr(self->Get(isolate));
 }
 
+void v8__Eternal__CONSTRUCT(
+    uninit_t<v8::Eternal<v8::Data>>* buf) {
+  construct_in_place<v8::Eternal<v8::Data>>(buf);
+}
+
+void v8__Eternal__DESTRUCT(v8::Eternal<v8::Data>* self) {
+  self->~Eternal();
+}
+
+void v8__Eternal__Clear(v8::Eternal<v8::Data>* self) {
+  self->Clear();
+}
+
+bool v8__Eternal__IsEmpty(v8::Eternal<v8::Data>* self) { return self->IsEmpty(); }
+
+void v8__Eternal__Set(v8::Eternal<v8::Data>* self, v8::Isolate* isolate,
+		      const v8::Data* value) {
+  self->Set(isolate, ptr_to_local(value));
+}
+
+const v8::Data* v8__Eternal__Get(v8::Eternal<v8::Data>* self,
+                                         v8::Isolate* isolate) {
+  return local_to_ptr(self->Get(isolate));
+}
+
 v8::Isolate* v8__WeakCallbackInfo__GetIsolate(
     const v8::WeakCallbackInfo<void>* self) {
   return self->GetIsolate();

--- a/src/binding.hpp
+++ b/src/binding.hpp
@@ -18,6 +18,8 @@ static size_t cppgc__WeakMember_SIZE = sizeof(cppgc::WeakMember<RustObj>);
 
 static size_t v8__TracedReference_SIZE = sizeof(v8::TracedReference<v8::Data>);
 
+static size_t v8__Eternal_SIZE = sizeof(v8::Eternal<v8::Data>);
+
 static size_t v8__String__ValueView_SIZE = sizeof(v8::String::ValueView);
 
 static int v8__String__kMaxLength = v8::String::kMaxLength;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ pub use external_references::ExternalReferences;
 pub use function::*;
 pub use gc::*;
 pub use get_property_names_args_builder::*;
+pub use handle::Eternal;
 pub use handle::Global;
 pub use handle::Handle;
 pub use handle::Local;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -11977,3 +11977,24 @@ fn use_counter_callback() {
 
   assert_eq!(COUNT.load(Ordering::Relaxed), 1);
 }
+
+#[test]
+fn test_eternals() {
+  let _setup_guard = setup::parallel_test();
+  let eternal1 = v8::Eternal::empty();
+
+  let mut isolate = v8::Isolate::new(Default::default());
+  let mut scope = v8::HandleScope::new(&mut isolate);
+
+  let str1 = v8::String::new(&mut scope, "hello").unwrap();
+
+  assert!(eternal1.is_empty());
+  eternal1.set(&mut scope, str1);
+  assert!(!eternal1.is_empty());
+
+  let str1_get = eternal1.get(&mut scope);
+  assert_eq!(str1, str1_get);
+
+  eternal1.clear();
+  assert!(eternal1.is_empty());
+}


### PR DESCRIPTION
Eternal handles are set-once handles that live for the lifetime of the isolate.

https://v8.github.io/api/head/classv8_1_1Eternal.html