### PR TITLE
fix: add back incorrectly spelled initalize_process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "v8"
-version = "130.0.6"
+version = "130.0.7"
 dependencies = [
  "align-data",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v8"
-version = "130.0.6"
+version = "130.0.7"
 description = "Rust bindings to V8"
 readme = "README.md"
 authors = ["the Deno authors"]

--- a/src/cppgc.rs
+++ b/src/cppgc.rs
@@ -152,6 +152,12 @@ pub fn initialize_process(platform: SharedRef<Platform>) {
   }
 }
 
+#[deprecated(note = "use correctly spelled initialize_process")]
+#[inline]
+pub fn initalize_process(platform: SharedRef<Platform>) {
+  initialize_process(platform)
+}
+
 /// # Safety
 ///
 /// Must be called after destroying the last used heap. Some process-global


### PR DESCRIPTION
We need to add this back until we do a major release.