### PR TITLE
chore: cleanup format args

### DIFF
--- a/benches/function.rs
+++ b/benches/function.rs
@@ -130,17 +130,16 @@ fn main() {
       &["undefined_from_scope", "undefined_from_isolate"][..],
     ),
   ] {
-    println!("Running {} ...", group_name);
+    println!("Running {group_name} ...");
     for x in benches {
       let code = format!(
         "
-            function bench() {{ return {}(); }};
-            runs = {};
+            function bench() {{ return {x}(); }};
+            runs = {runs};
             start = Date.now();
             for (i = 0; i < runs; i++) bench();
             Date.now() - start;
           ",
-        x, runs
       );
 
       let r = eval(scope, &code).unwrap();
@@ -150,8 +149,7 @@ fn main() {
       let ns_per_run = total_ns / (runs as f64);
       let mops_per_sec = (runs as f64) / (total_ms / 1000.0) / 1e6;
       println!(
-        "  {:.1} ns per run {:.1} million ops/sec → {}",
-        ns_per_run, mops_per_sec, x
+        "  {ns_per_run:.1} ns per run {mops_per_sec:.1} million ops/sec → {x}"
       );
     }
   }

--- a/build.rs
+++ b/build.rs
@@ -134,7 +134,7 @@ fn acquire_lock() -> LockFile {
   let mut lockfile = LockFile::open(&lockfilepath)
     .expect("Couldn't open lib download lockfile.");
   lockfile.lock_with_pid().expect("Couldn't get lock");
-  println!("lockfile: {:?}", &lockfilepath);
+  println!("lockfile: {lockfilepath:?}");
   lockfile
 }
 
@@ -429,9 +429,7 @@ fn static_lib_url() -> String {
   let profile = prebuilt_profile();
   let features = prebuilt_features_suffix();
   format!(
-    "{}/v{}/{}.gz",
-    base,
-    version,
+    "{base}/v{version}/{}.gz",
     static_lib_name(&format!("{features}_{profile}_{target}")),
   )
 }
@@ -835,7 +833,7 @@ fn maybe_symlink_root_dir(dirs: &mut Dirs) {
     let symlink = &*out.join("gn_root");
     let target = &*root.canonicalize().unwrap();
 
-    println!("Creating symlink {:?} to {:?}", &symlink, &root);
+    println!("Creating symlink {symlink:?} to {root:?}");
 
     let mut retries = 0;
     loop {
@@ -843,19 +841,19 @@ fn maybe_symlink_root_dir(dirs: &mut Dirs) {
         Ok(existing) if existing == target => break,
         Ok(_) => remove_dir_all(symlink).expect("remove_dir_all failed"),
         Err(err) => {
-          println!("symlink.canonicalize failed: {:?}", err);
+          println!("symlink.canonicalize failed: {err:?}");
           // we're having very strange issues on GHA when the cache
           // is restored, so trying this out temporarily
           if let Err(err) = remove_dir_all(symlink) {
-            eprintln!("remove_dir_all failed: {:?}", err);
+            eprintln!("remove_dir_all failed: {err:?}");
             if let Err(err) = remove_file(symlink) {
-              eprintln!("remove_file failed: {:?}", err);
+              eprintln!("remove_file failed: {err:?}");
             }
           }
           match symlink_dir(target, symlink) {
             Ok(_) => break,
             Err(err) => {
-              println!("symlink_dir failed: {:?}", err);
+              println!("symlink_dir failed: {err:?}");
               retries += 1;
               std::thread::sleep(std::time::Duration::from_millis(
                 50 * retries,

--- a/examples/android/lib.rs
+++ b/examples/android/lib.rs
@@ -103,7 +103,7 @@ fn execute_script(
       .map(|value| value.to_rust_string_lossy(try_catch))
       .unwrap_or_else(|| "no stack trace".into());
 
-    panic!("{}", exception_string);
+    panic!("{exception_string}");
   }
 }
 
@@ -128,7 +128,7 @@ fn draw(
         .map(|value| value.to_rust_string_lossy(try_catch))
         .unwrap_or_else(|| "no stack trace".into());
 
-      panic!("{}", exception_string);
+      panic!("{exception_string}");
     }
   };
 

--- a/examples/cppgc-object.rs
+++ b/examples/cppgc-object.rs
@@ -120,6 +120,6 @@ fn execute_script(
       .map(|value| value.to_rust_string_lossy(try_catch))
       .unwrap_or_else(|| "no stack trace".into());
 
-    panic!("{}", exception_string);
+    panic!("{exception_string}");
   }
 }

--- a/examples/cppgc.rs
+++ b/examples/cppgc.rs
@@ -14,7 +14,7 @@ impl std::fmt::Display for Rope {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     write!(f, "{}", self.part)?;
     if let Some(next) = self.next.borrow() {
-      write!(f, "{}", next)?;
+      write!(f, "{next}")?;
     }
     Ok(())
   }
@@ -67,7 +67,7 @@ fn main() {
       )
     };
 
-    println!("{}", rope);
+    println!("{rope}");
 
     // Manually trigger garbage collection.
     heap.enable_detached_garbage_collections_for_testing();
@@ -80,7 +80,7 @@ fn main() {
     }
 
     // Should still be live here:
-    println!("{}", rope);
+    println!("{rope}");
 
     println!("Collect: NoHeapPointers");
     unsafe {

--- a/examples/process.rs
+++ b/examples/process.rs
@@ -13,7 +13,7 @@ fn log_callback(
     .unwrap()
     .to_rust_string_lossy(scope);
 
-  println!("Logged: {}", message);
+  println!("Logged: {message}");
 }
 
 fn main() {
@@ -32,7 +32,7 @@ fn main() {
   let mut scope = v8::HandleScope::new(&mut isolate);
 
   let source = std::fs::read_to_string(&file)
-    .unwrap_or_else(|err| panic!("failed to open {}: {}", file, err));
+    .unwrap_or_else(|err| panic!("failed to open {file}: {err}"));
   let source = v8::String::new(&mut scope, &source).unwrap();
 
   let mut processor = JsHttpRequestProcessor::new(&mut scope, source, options);
@@ -376,7 +376,7 @@ where
       let key = key.to_string(scope).unwrap().to_rust_string_lossy(scope);
       let value = value.to_string(scope).unwrap().to_rust_string_lossy(scope);
 
-      println!("{}: {}", key, value);
+      println!("{key}: {value}");
     }
   }
 }

--- a/examples/process.rs
+++ b/examples/process.rs
@@ -223,7 +223,7 @@ where
         .unwrap()
         .to_rust_string_lossy(try_catch);
 
-      panic!("{}", exception_string);
+      panic!("{exception_string}");
     }
   }
 
@@ -251,7 +251,7 @@ where
         .unwrap()
         .to_rust_string_lossy(try_catch);
 
-      panic!("{}", exception_string);
+      panic!("{exception_string}");
     }
   }
 

--- a/examples/shell.rs
+++ b/examples/shell.rs
@@ -44,7 +44,7 @@ fn run_shell(scope: &mut v8::HandleScope) {
 
         execute_string(scope, &buf, "(shell)", true, true);
       }
-      Err(error) => println!("error: {}", error),
+      Err(error) => println!("error: {error}"),
     }
   }
 }
@@ -89,7 +89,7 @@ fn run_main(
       }
       arg => {
         if arg.starts_with("--") {
-          eprintln!("Warning: unknown flag {}.\nTry --help for options", arg);
+          eprintln!("Warning: unknown flag {arg}.\nTry --help for options");
           continue;
         }
 
@@ -174,7 +174,7 @@ fn report_exceptions(mut try_catch: v8::TryCatch<v8::HandleScope>) {
   let message = if let Some(message) = try_catch.message() {
     message
   } else {
-    eprintln!("{}", exception_string);
+    eprintln!("{exception_string}");
     return;
   };
 
@@ -191,7 +191,7 @@ fn report_exceptions(mut try_catch: v8::TryCatch<v8::HandleScope>) {
     );
   let line_number = message.get_line_number(&mut try_catch).unwrap_or_default();
 
-  eprintln!("{}:{}: {}", filename, line_number, exception_string);
+  eprintln!("{filename}:{line_number}: {exception_string}");
 
   // Print line of source code.
   let source_line = message
@@ -202,7 +202,7 @@ fn report_exceptions(mut try_catch: v8::TryCatch<v8::HandleScope>) {
         .to_rust_string_lossy(&mut try_catch)
     })
     .unwrap();
-  eprintln!("{}", source_line);
+  eprintln!("{source_line}");
 
   // Print wavy underline (GetUnderline is deprecated).
   let start_column = message.get_start_column();
@@ -231,6 +231,6 @@ fn report_exceptions(mut try_catch: v8::TryCatch<v8::HandleScope>) {
     .map(|s| s.to_rust_string_lossy(&mut try_catch));
 
   if let Some(stack_trace) = stack_trace {
-    eprintln!("{}", stack_trace);
+    eprintln!("{stack_trace}");
   }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -253,10 +253,10 @@ impl Display for DataError {
   fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
     match self {
       Self::BadType { expected, actual } => {
-        write!(f, "expected type `{}`, got `{}`", expected, actual)
+        write!(f, "expected type `{expected}`, got `{actual}`")
       }
       Self::NoData { expected } => {
-        write!(f, "expected `Some({})`, found `None`", expected)
+        write!(f, "expected `Some({expected})`, found `None`")
       }
     }
   }

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -758,8 +758,8 @@ impl StringView<'static> {
 impl fmt::Display for StringView<'_> {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      Self::U16(v) => write!(f, "{}", v),
-      Self::U8(v) => write!(f, "{}", v),
+      Self::U16(v) => write!(f, "{v}"),
+      Self::U8(v) => write!(f, "{v}"),
     }
   }
 }

--- a/src/support.rs
+++ b/src/support.rs
@@ -360,13 +360,10 @@ fn assert_shared_ptr_use_count_eq<T: Shared>(
   };
   assert!(
     ok,
-    "assertion failed: `{}<{}>` reference count does not match expectation\
-       \n   actual: {}\
-       \n expected: {}",
-    wrapper_type_name,
+    "assertion failed: `{wrapper_type_name}<{}>` reference count does not match expectation\
+       \n   actual: {actual}\
+       \n expected: {expected}",
     type_name::<T>(),
-    actual,
-    expected
   );
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -69,7 +69,7 @@ impl WasmStreaming {
   pub fn set_url(&mut self, url: &str) {
     // Although not documented, V8 requires the url to be null terminated.
     // See https://chromium-review.googlesource.com/c/v8/v8/+/3289148.
-    let null_terminated_url = format!("{}\0", url);
+    let null_terminated_url = format!("{url}\0");
     unsafe {
       v8__WasmStreaming__SetUrl(
         &mut self.0,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -6675,8 +6675,7 @@ impl v8::inspector::ChannelImpl for ChannelCounter {
     message: v8::UniquePtr<v8::inspector::StringBuffer>,
   ) {
     println!(
-      "send_response call_id {} message {}",
-      call_id,
+      "send_response call_id {call_id} message {}",
       message.unwrap().string()
     );
     self.count_send_response += 1;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -4140,7 +4140,7 @@ fn function_script_origin_and_id() {
   let mut num_cases = 10;
   let mut prev_id = None;
   while num_cases > 0 {
-    let resource_name = format!("google.com/{}", num_cases);
+    let resource_name = format!("google.com/{num_cases}");
     let mut source = mock_source(
       scope,
       resource_name.as_str(), // make sure each source has a different resource name
@@ -6686,7 +6686,7 @@ impl v8::inspector::ChannelImpl for ChannelCounter {
     message: v8::UniquePtr<v8::inspector::StringBuffer>,
   ) {
     let msg = message.unwrap().string().to_string();
-    println!("send_notification message {}", msg);
+    println!("send_notification message {msg}");
     self.count_send_notification += 1;
     self.notifications.push(msg);
   }

--- a/tests/test_concurrent_isolate_creation_and_disposal.rs
+++ b/tests/test_concurrent_isolate_creation_and_disposal.rs
@@ -12,7 +12,7 @@ fn concurrent_isolate_creation_and_disposal() {
   v8::V8::initialize();
 
   for round in 0..1000 {
-    eprintln!("round {}", round);
+    eprintln!("round {round}");
 
     let threads = repeat_with(|| {
       thread::spawn(|| {

--- a/tests/test_cppgc.rs
+++ b/tests/test_cppgc.rs
@@ -236,6 +236,6 @@ fn execute_script(
       .map(|value| value.to_rust_string_lossy(scope))
       .unwrap_or_else(|| "no stack trace".into());
 
-    panic!("{}", exception_string);
+    panic!("{exception_string}");
   }
 }


### PR DESCRIPTION
Apply [`uninlined_format_args`](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) clippy lint -- makes code a bit more readable.