### PR TITLE
chore: fix semicolons

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -205,7 +205,7 @@ fn build_v8(is_asan: bool) {
   ));
   // Fix GN's host_cpu detection when using x86_64 bins on Apple Silicon
   if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
-    gn_args.push("host_cpu=\"arm64\"".to_string())
+    gn_args.push("host_cpu=\"arm64\"".to_string());
   }
 
   if env::var_os("DISABLE_CLANG").is_some() {

--- a/src/V8.rs
+++ b/src/V8.rs
@@ -185,7 +185,7 @@ pub fn initialize_platform(platform: SharedRef<Platform>) {
 
   {
     unsafe {
-      v8__V8__InitializePlatform(&*platform as *const Platform as *mut _)
+      v8__V8__InitializePlatform(&*platform as *const Platform as *mut _);
     };
   }
 }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -124,7 +124,7 @@ impl BigInt {
         sign_bit.as_mut_ptr(),
         &mut word_count,
         words.as_mut_ptr(),
-      )
+      );
     }
 
     let sign_bit = unsafe { sign_bit.assume_init() };

--- a/src/context.rs
+++ b/src/context.rs
@@ -189,7 +189,7 @@ impl Context {
         self,
         Self::ANNEX_SLOT,
         annex_ptr as *mut _,
-      )
+      );
     };
     assert!(
       unsafe { v8__Context__GetNumberOfEmbedderDataFields(self) } as int
@@ -311,7 +311,7 @@ impl Context {
           self,
           Self::ANNEX_SLOT,
           null_mut(),
-        )
+        );
       };
     }
   }
@@ -329,7 +329,7 @@ impl Context {
       self,
       slot + Self::INTERNAL_SLOT_COUNT,
       data,
-    )
+    );
   }
 
   #[inline(always)]

--- a/src/cppgc.rs
+++ b/src/cppgc.rs
@@ -155,7 +155,7 @@ pub fn initialize_process(platform: SharedRef<Platform>) {
 #[deprecated(note = "use correctly spelled initialize_process")]
 #[inline]
 pub fn initalize_process(platform: SharedRef<Platform>) {
-  initialize_process(platform)
+  initialize_process(platform);
 }
 
 /// # Safety
@@ -203,7 +203,7 @@ impl<T> Traced for TracedReference<T> {
       cppgc__Visitor__Trace__TracedReference(
         visitor,
         self as *const TracedReference<T> as *const TracedReference<Data>,
-      )
+      );
     }
   }
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -294,7 +294,7 @@ impl<T> Drop for Global<T> {
         // been disposed.
       } else {
         // Destroy the storage cell that contains the contents of this Global.
-        v8__Global__Reset(self.data.cast().as_ptr())
+        v8__Global__Reset(self.data.cast().as_ptr());
       }
     }
   }
@@ -436,7 +436,7 @@ impl<T> Eq for Global<T> where T: Eq {}
 
 impl<'s, T: Hash> Hash for Local<'s, T> {
   fn hash<H: Hasher>(&self, state: &mut H) {
-    (**self).hash(state)
+    (**self).hash(state);
   }
 }
 
@@ -562,7 +562,7 @@ impl HandleHost {
     assert!(
       self.match_host(other, scope_opt),
       "attempt to use Handle in an Isolate that is not its host"
-    )
+    );
   }
 
   #[allow(dead_code)]
@@ -571,7 +571,7 @@ impl HandleHost {
   }
 
   fn assert_match_isolate(self, isolate: &mut Isolate) {
-    self.assert_match_host(isolate.into(), Some(isolate))
+    self.assert_match_host(isolate.into(), Some(isolate));
   }
 
   fn get_isolate(self) -> NonNull<Isolate> {
@@ -873,7 +873,7 @@ impl<T> Weak<T> {
         v8__WeakCallbackInfo__SetSecondPassCallback(
           wci,
           Self::second_pass_callback,
-        )
+        );
       };
     }
   }

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -142,7 +142,7 @@ unsafe extern "C" fn v8_inspector__V8Inspector__Channel__BASE__sendResponse(
   call_id: int,
   message: UniquePtr<StringBuffer>,
 ) {
-  ChannelBase::dispatch_mut(this).send_response(call_id, message)
+  ChannelBase::dispatch_mut(this).send_response(call_id, message);
 }
 
 #[no_mangle]
@@ -150,14 +150,14 @@ unsafe extern "C" fn v8_inspector__V8Inspector__Channel__BASE__sendNotification(
   this: &mut Channel,
   message: UniquePtr<StringBuffer>,
 ) {
-  ChannelBase::dispatch_mut(this).send_notification(message)
+  ChannelBase::dispatch_mut(this).send_notification(message);
 }
 
 #[no_mangle]
 unsafe extern "C" fn v8_inspector__V8Inspector__Channel__BASE__flushProtocolNotifications(
   this: &mut Channel,
 ) {
-  ChannelBase::dispatch_mut(this).flush_protocol_notifications()
+  ChannelBase::dispatch_mut(this).flush_protocol_notifications();
 }
 
 #[no_mangle]
@@ -173,14 +173,14 @@ unsafe extern "C" fn v8_inspector__V8InspectorClient__BASE__runMessageLoopOnPaus
   context_group_id: int,
 ) {
   V8InspectorClientBase::dispatch_mut(this)
-    .run_message_loop_on_pause(context_group_id)
+    .run_message_loop_on_pause(context_group_id);
 }
 
 #[no_mangle]
 unsafe extern "C" fn v8_inspector__V8InspectorClient__BASE__quitMessageLoopOnPause(
   this: &mut V8InspectorClient,
 ) {
-  V8InspectorClientBase::dispatch_mut(this).quit_message_loop_on_pause()
+  V8InspectorClientBase::dispatch_mut(this).quit_message_loop_on_pause();
 }
 
 #[no_mangle]
@@ -189,7 +189,7 @@ unsafe extern "C" fn v8_inspector__V8InspectorClient__BASE__runIfWaitingForDebug
   context_group_id: int,
 ) {
   V8InspectorClientBase::dispatch_mut(this)
-    .run_if_waiting_for_debugger(context_group_id)
+    .run_if_waiting_for_debugger(context_group_id);
 }
 
 #[no_mangle]
@@ -211,7 +211,7 @@ unsafe extern "C" fn v8_inspector__V8InspectorClient__BASE__consoleAPIMessage(
     line_number,
     column_number,
     stack_trace,
-  )
+  );
 }
 
 #[no_mangle]
@@ -240,17 +240,17 @@ impl Channel {
     message: UniquePtr<StringBuffer>,
   ) {
     unsafe {
-      v8_inspector__V8Inspector__Channel__sendResponse(self, call_id, message)
+      v8_inspector__V8Inspector__Channel__sendResponse(self, call_id, message);
     }
   }
   pub fn send_notification(&mut self, message: UniquePtr<StringBuffer>) {
     unsafe {
-      v8_inspector__V8Inspector__Channel__sendNotification(self, message)
+      v8_inspector__V8Inspector__Channel__sendNotification(self, message);
     }
   }
   pub fn flush_protocol_notifications(&mut self) {
     unsafe {
-      v8_inspector__V8Inspector__Channel__flushProtocolNotifications(self)
+      v8_inspector__V8Inspector__Channel__flushProtocolNotifications(self);
     }
   }
 }
@@ -419,7 +419,7 @@ mod tests {
       self.log_call();
     }
     fn flush_protocol_notifications(&mut self) {
-      self.log_call()
+      self.log_call();
     }
   }
 
@@ -464,7 +464,7 @@ impl V8InspectorClient {
       v8_inspector__V8InspectorClient__runMessageLoopOnPause(
         self,
         context_group_id,
-      )
+      );
     }
   }
 
@@ -477,7 +477,7 @@ impl V8InspectorClient {
       v8_inspector__V8InspectorClient__runIfWaitingForDebugger(
         self,
         context_group_id,
-      )
+      );
     }
   }
 
@@ -502,7 +502,7 @@ impl V8InspectorClient {
         line_number,
         column_number,
         stack_trace,
-      )
+      );
     }
   }
 
@@ -668,7 +668,7 @@ impl V8InspectorSession {
 
   pub fn dispatch_protocol_message(&mut self, message: StringView) {
     unsafe {
-      v8_inspector__V8InspectorSession__dispatchProtocolMessage(self, message)
+      v8_inspector__V8InspectorSession__dispatchProtocolMessage(self, message);
     }
   }
 
@@ -680,7 +680,7 @@ impl V8InspectorSession {
     unsafe {
       v8_inspector__V8InspectorSession__schedulePauseOnNextStatement(
         self, reason, detail,
-      )
+      );
     }
   }
 }
@@ -899,7 +899,7 @@ impl<'a, T> Deref for CharacterArray<'a, T> {
     } = *self;
     if m_characters.is_null() {
       assert_eq!(m_length, 0);
-      m_characters = NonNull::dangling().as_ptr()
+      m_characters = NonNull::dangling().as_ptr();
     };
     unsafe { slice::from_raw_parts(m_characters, m_length) }
   }
@@ -1002,7 +1002,7 @@ impl V8Inspector {
         context_group_id,
         human_readable_name,
         aux_data,
-      )
+      );
     }
   }
 

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -792,7 +792,7 @@ impl Isolate {
   /// between 0 and `Isolate::get_number_of_data_slots()`.
   #[inline(always)]
   pub fn set_data(&mut self, slot: u32, data: *mut c_void) {
-    self.set_data_internal(Self::INTERNAL_DATA_SLOT_COUNT + slot, data)
+    self.set_data_internal(Self::INTERNAL_DATA_SLOT_COUNT + slot, data);
   }
 
   /// Returns the maximum number of available embedder data slots. Valid slots
@@ -909,7 +909,7 @@ impl Isolate {
   /// constructed and exited when dropped.
   #[inline(always)]
   pub unsafe fn enter(&mut self) {
-    v8__Isolate__Enter(self)
+    v8__Isolate__Enter(self);
   }
 
   /// Exits this isolate by restoring the previously entered one in the
@@ -922,7 +922,7 @@ impl Isolate {
   /// constructed and exited when dropped.
   #[inline(always)]
   pub unsafe fn exit(&mut self) {
-    v8__Isolate__Exit(self)
+    v8__Isolate__Exit(self);
   }
 
   /// Optional notification that the system is running low on memory.
@@ -976,7 +976,7 @@ impl Isolate {
         self,
         capture,
         frame_limit,
-      )
+      );
     }
   }
 
@@ -1024,7 +1024,7 @@ impl Isolate {
     // it's empty. That is, you can't return None and that's why the Rust API
     // expects Local<Value> instead of Option<Local<Value>>.
     unsafe {
-      v8__Isolate__SetPrepareStackTraceCallback(self, callback.map_fn_to())
+      v8__Isolate__SetPrepareStackTraceCallback(self, callback.map_fn_to());
     };
   }
 
@@ -1071,7 +1071,7 @@ impl Isolate {
     callback: HostInitializeImportMetaObjectCallback,
   ) {
     unsafe {
-      v8__Isolate__SetHostInitializeImportMetaObjectCallback(self, callback)
+      v8__Isolate__SetHostInitializeImportMetaObjectCallback(self, callback);
     }
   }
 
@@ -1086,7 +1086,7 @@ impl Isolate {
       v8__Isolate__SetHostImportModuleDynamicallyCallback(
         self,
         callback.to_c_fn(),
-      )
+      );
     }
   }
 
@@ -1164,7 +1164,7 @@ impl Isolate {
     gc_type_filter: GCType,
   ) {
     unsafe {
-      v8__Isolate__AddGCPrologueCallback(self, callback, data, gc_type_filter)
+      v8__Isolate__AddGCPrologueCallback(self, callback, data, gc_type_filter);
     }
   }
 
@@ -1204,7 +1204,7 @@ impl Isolate {
     heap_limit: usize,
   ) {
     unsafe {
-      v8__Isolate__RemoveNearHeapLimitCallback(self, callback, heap_limit)
+      v8__Isolate__RemoveNearHeapLimitCallback(self, callback, heap_limit);
     };
   }
 
@@ -1312,7 +1312,7 @@ impl Isolate {
       v8__Isolate__DateTimeConfigurationChangeNotification(
         self,
         time_zone_detection,
-      )
+      );
     }
   }
 
@@ -1345,7 +1345,7 @@ impl Isolate {
           GarbageCollectionType::Full => 0,
           GarbageCollectionType::Minor => 1,
         },
-      )
+      );
     }
   }
 
@@ -1385,7 +1385,7 @@ impl Isolate {
 
     let arg = addr_of_mut!(callback);
     unsafe {
-      v8__HeapProfiler__TakeHeapSnapshot(self, trampoline::<F>, arg as _)
+      v8__HeapProfiler__TakeHeapSnapshot(self, trampoline::<F>, arg as _);
     }
   }
 

--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -317,7 +317,7 @@ pub(crate) mod raw {
           self,
           initial_heap_size_in_bytes,
           maximum_heap_size_in_bytes,
-        )
+        );
       };
     }
 
@@ -331,7 +331,7 @@ pub(crate) mod raw {
           self,
           physical_memory,
           virtual_memory_limit,
-        )
+        );
       }
     }
   }

--- a/src/object.rs
+++ b/src/object.rs
@@ -926,7 +926,7 @@ impl Object {
         &*scope.get_current_context(),
         &*key,
         &mut out,
-      )
+      );
     };
     out.into()
   }
@@ -1019,7 +1019,7 @@ impl Object {
         &*scope.get_current_context(),
         &*key,
         &mut out,
-      )
+      );
     }
     out.into()
   }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -209,7 +209,7 @@ impl Platform {
         &**platform as *const Self as *mut _,
         isolate,
         idle_time_in_seconds,
-      )
+      );
     }
   }
 }

--- a/src/primitive_array.rs
+++ b/src/primitive_array.rs
@@ -60,7 +60,7 @@ impl PrimitiveArray {
         scope.get_isolate_ptr(),
         index as int,
         &*item,
-      )
+      );
     }
   }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1459,7 +1459,7 @@ pub(crate) mod data {
     #[inline(always)]
     pub(super) fn new_handle_scope_data(&mut self) -> &mut Self {
       self.new_handle_scope_data_with(|_, _, raw_context_scope| {
-        debug_assert!(raw_context_scope.is_none())
+        debug_assert!(raw_context_scope.is_none());
       })
     }
 
@@ -1776,7 +1776,7 @@ pub(crate) mod data {
               ScopeStatus::Current { zombie: true }
             }
             _ => unreachable!(),
-          })
+          });
         }
         _ => {
           // Regular, immediate exit.
@@ -1937,7 +1937,7 @@ pub(crate) mod data {
         raw_context_scope, ..
       } = self
       {
-        *raw_context_scope = None
+        *raw_context_scope = None;
       }
     }
   }

--- a/src/shared_array_buffer.rs
+++ b/src/shared_array_buffer.rs
@@ -188,7 +188,7 @@ impl SharedArrayBuffer {
     ) {
       // SAFETY: We know that data is a raw T from above
       unsafe {
-        <T as crate::array_buffer::sealed::Rawable>::drop_raw(data as _, len)
+        <T as crate::array_buffer::sealed::Rawable>::drop_raw(data as _, len);
       }
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -640,7 +640,7 @@ impl Template {
   /// Adds a property to each instance created by this template.
   #[inline(always)]
   pub fn set(&self, key: Local<Name>, value: Local<Data>) {
-    self.set_with_attr(key, value, PropertyAttribute::NONE)
+    self.set_with_attr(key, value, PropertyAttribute::NONE);
   }
 
   /// Adds a property to each instance created by this template with
@@ -665,7 +665,7 @@ impl Template {
     attr: PropertyAttribute,
   ) {
     unsafe {
-      v8__Template__SetIntrinsicDataProperty(self, &*key, intrinsic, attr)
+      v8__Template__SetIntrinsicDataProperty(self, &*key, intrinsic, attr);
     }
   }
 }
@@ -920,7 +920,7 @@ impl ObjectTemplate {
     getter: impl for<'s> MapFnTo<AccessorNameGetterCallback<'s>>,
   ) {
     self
-      .set_accessor_with_configuration(key, AccessorConfiguration::new(getter))
+      .set_accessor_with_configuration(key, AccessorConfiguration::new(getter));
   }
 
   #[inline(always)]
@@ -950,7 +950,7 @@ impl ObjectTemplate {
         configuration.setter,
         configuration.data.map_or_else(null, |p| &*p),
         configuration.property_attribute,
-      )
+      );
     }
   }
 
@@ -973,7 +973,7 @@ impl ObjectTemplate {
         configuration.descriptor,
         configuration.data.map_or_else(null, |p| &*p),
         configuration.flags,
-      )
+      );
     }
   }
 
@@ -993,7 +993,7 @@ impl ObjectTemplate {
         configuration.definer,
         configuration.descriptor,
         configuration.data.map_or_else(null, |p| &*p),
-      )
+      );
     }
   }
 
@@ -1018,7 +1018,7 @@ impl ObjectTemplate {
       let setter = setter.map_or_else(std::ptr::null, |v| &*v);
       v8__ObjectTemplate__SetAccessorProperty(
         self, &*key, &*getter, &*setter, attr,
-      )
+      );
     }
   }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -667,7 +667,7 @@ impl Value {
   pub fn number_value(&self, scope: &mut HandleScope) -> Option<f64> {
     let mut out = Maybe::<f64>::default();
     unsafe {
-      v8__Value__NumberValue(self, &*scope.get_current_context(), &mut out)
+      v8__Value__NumberValue(self, &*scope.get_current_context(), &mut out);
     };
     out.into()
   }
@@ -676,7 +676,7 @@ impl Value {
   pub fn integer_value(&self, scope: &mut HandleScope) -> Option<i64> {
     let mut out = Maybe::<i64>::default();
     unsafe {
-      v8__Value__IntegerValue(self, &*scope.get_current_context(), &mut out)
+      v8__Value__IntegerValue(self, &*scope.get_current_context(), &mut out);
     };
     out.into()
   }
@@ -685,7 +685,7 @@ impl Value {
   pub fn uint32_value(&self, scope: &mut HandleScope) -> Option<u32> {
     let mut out = Maybe::<u32>::default();
     unsafe {
-      v8__Value__Uint32Value(self, &*scope.get_current_context(), &mut out)
+      v8__Value__Uint32Value(self, &*scope.get_current_context(), &mut out);
     };
     out.into()
   }
@@ -694,7 +694,7 @@ impl Value {
   pub fn int32_value(&self, scope: &mut HandleScope) -> Option<i32> {
     let mut out = Maybe::<i32>::default();
     unsafe {
-      v8__Value__Int32Value(self, &*scope.get_current_context(), &mut out)
+      v8__Value__Int32Value(self, &*scope.get_current_context(), &mut out);
     };
     out.into()
   }

--- a/src/value_deserializer.rs
+++ b/src/value_deserializer.rs
@@ -251,7 +251,7 @@ impl<'a> ValueDeserializerHeap<'a> {
 impl<'a> Drop for ValueDeserializerHeap<'a> {
   fn drop(&mut self) {
     unsafe {
-      v8__ValueDeserializer__DESTRUCT(&mut self.cxx_value_deserializer)
+      v8__ValueDeserializer__DESTRUCT(&mut self.cxx_value_deserializer);
     };
   }
 }
@@ -338,7 +338,7 @@ pub trait ValueDeserializerHelper {
         cast_to_ptr(self.get_cxx_value_deserializer()),
         transfer_id,
         array_buffer,
-      )
+      );
     };
   }
 
@@ -352,7 +352,7 @@ pub trait ValueDeserializerHelper {
         cast_to_ptr(self.get_cxx_value_deserializer()),
         transfer_id,
         shared_array_buffer,
-      )
+      );
     };
   }
 

--- a/src/value_serializer.rs
+++ b/src/value_serializer.rs
@@ -48,7 +48,7 @@ unsafe extern "C" fn v8__ValueSerializer__Delegate__ThrowDataCloneError(
   let scope = &mut ContextScope::new(scope, context);
   value_serializer_heap
     .value_serializer_impl
-    .throw_data_clone_error(scope, message)
+    .throw_data_clone_error(scope, message);
 }
 
 #[no_mangle]
@@ -181,7 +181,7 @@ unsafe extern "C" fn v8__ValueSerializer__Delegate__FreeBufferMemory(
       1,
     )
     .unwrap();
-    dealloc(buffer as *mut _, layout)
+    dealloc(buffer as *mut _, layout);
   };
 }
 
@@ -365,7 +365,7 @@ pub trait ValueSerializerHelper {
     unsafe {
       v8__ValueSerializer__WriteHeader(cast_to_ptr(
         self.get_cxx_value_serializer(),
-      ))
+      ));
     };
   }
 
@@ -389,7 +389,7 @@ pub trait ValueSerializerHelper {
       v8__ValueSerializer__WriteUint32(
         cast_to_ptr(self.get_cxx_value_serializer()),
         value,
-      )
+      );
     };
   }
 
@@ -398,7 +398,7 @@ pub trait ValueSerializerHelper {
       v8__ValueSerializer__WriteUint64(
         cast_to_ptr(self.get_cxx_value_serializer()),
         value,
-      )
+      );
     };
   }
 
@@ -407,7 +407,7 @@ pub trait ValueSerializerHelper {
       v8__ValueSerializer__WriteDouble(
         cast_to_ptr(self.get_cxx_value_serializer()),
         value,
-      )
+      );
     };
   }
 
@@ -417,7 +417,7 @@ pub trait ValueSerializerHelper {
         cast_to_ptr(self.get_cxx_value_serializer()),
         source.as_ptr() as *const _,
         source.len(),
-      )
+      );
     };
   }
 
@@ -431,7 +431,7 @@ pub trait ValueSerializerHelper {
         cast_to_ptr(self.get_cxx_value_serializer()),
         transfer_id,
         array_buffer,
-      )
+      );
     };
   }
 
@@ -440,7 +440,7 @@ pub trait ValueSerializerHelper {
       v8__ValueSerializer__SetTreatArrayBufferViewsAsHostObjects(
         cast_to_ptr(self.get_cxx_value_serializer()),
         mode,
-      )
+      );
     };
   }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -41,7 +41,11 @@ impl WasmStreaming {
   #[inline(always)]
   pub fn on_bytes_received(&mut self, data: &[u8]) {
     unsafe {
-      v8__WasmStreaming__OnBytesReceived(&mut self.0, data.as_ptr(), data.len())
+      v8__WasmStreaming__OnBytesReceived(
+        &mut self.0,
+        data.as_ptr(),
+        data.len(),
+      );
     }
   }
 
@@ -75,7 +79,7 @@ impl WasmStreaming {
         &mut self.0,
         null_terminated_url.as_ptr() as *const char,
         url.len(),
-      )
+      );
     }
   }
 }
@@ -198,7 +202,7 @@ where
     let zero = null_mut();
     let mut that = WasmStreamingSharedPtr([zero, zero]);
     unsafe {
-      v8__WasmStreaming__Unpack(scope.get_isolate_ptr(), &*data, &mut that)
+      v8__WasmStreaming__Unpack(scope.get_isolate_ptr(), &*data, &mut that);
     };
     let source = args.get(0);
     (F::get())(scope, source, WasmStreaming(that));

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1581,7 +1581,7 @@ fn create_message_argument_lifetimes() {
        mut rv: v8::ReturnValue<v8::Value>| {
         let message = v8::Exception::create_message(scope, args.get(0));
         let message_str = message.get(scope);
-        rv.set(message_str.into())
+        rv.set(message_str.into());
       },
     )
     .unwrap();
@@ -1936,7 +1936,7 @@ fn instance_template_with_internal_field() {
     assert!(args.data().is_undefined());
 
     assert!(this.set_internal_field(0, v8::Integer::new(scope, 42).into()));
-    retval.set(this.into())
+    retval.set(this.into());
   }
 
   let function_templ = v8::FunctionTemplate::new(scope, constructor_callback);
@@ -8698,7 +8698,7 @@ fn get_source_mapping_from_comment() {
     .get_unbound_script(scope)
     .get_source_mapping_url(scope)
     .to_rust_string_lossy(scope);
-  assert_eq!("foo.js.map", source_mapping_url)
+  assert_eq!("foo.js.map", source_mapping_url);
 }
 
 #[test]
@@ -8750,7 +8750,7 @@ fn origin_source_map_overrides_source_mapping_url_comment() {
     .get_unbound_script(scope)
     .get_source_mapping_url(scope)
     .to_rust_string_lossy(scope);
-  assert_eq!(expected_source_map_url, source_mapping_url)
+  assert_eq!(expected_source_map_url, source_mapping_url);
 }
 
 #[test]
@@ -8801,7 +8801,7 @@ fn ignore_origin_source_map_empty_string() {
     .get_unbound_script(scope)
     .get_source_mapping_url(scope)
     .to_rust_string_lossy(scope);
-  assert_eq!("foo.js.map", source_mapping_url)
+  assert_eq!("foo.js.map", source_mapping_url);
 }
 
 #[test]
@@ -8850,7 +8850,7 @@ fn no_source_map_comment() {
     .get_unbound_script(scope)
     .get_source_mapping_url(scope)
     .to_rust_string_lossy(scope);
-  assert_eq!("undefined", source_mapping_url)
+  assert_eq!("undefined", source_mapping_url);
 }
 
 #[test]
@@ -9622,7 +9622,7 @@ fn function_names() {
     _args: v8::FunctionCallbackArguments,
     mut rv: v8::ReturnValue<v8::Value>,
   ) {
-    rv.set(v8::Integer::new(scope, 42).into())
+    rv.set(v8::Integer::new(scope, 42).into());
   }
 
   // named v8 function
@@ -9769,7 +9769,7 @@ fn current_stack_trace() {
   ) {
     let stack = v8::StackTrace::current_stack_trace(scope, 5).unwrap();
     let count = stack.get_frame_count();
-    rv.set(v8::Integer::new(scope, count as i32).into())
+    rv.set(v8::Integer::new(scope, count as i32).into());
   }
 
   let key = v8::String::new(scope, "callDepth").unwrap();
@@ -9814,7 +9814,7 @@ fn current_script_name_or_source_url() {
     let maybe_name = v8::StackTrace::current_script_name_or_source_url(scope);
     assert!(maybe_name.is_some());
     unsafe { USED = 1 };
-    assert_eq!(maybe_name.unwrap().to_rust_string_lossy(scope), "foo.js")
+    assert_eq!(maybe_name.unwrap().to_rust_string_lossy(scope), "foo.js");
   }
 
   // Setup isolate


### PR DESCRIPTION
auto-fixed trailing semicolons by running

```
clippy --fix --all-features --all-targets --workspace -- -W clippy::semicolon_if_nothing_returned
```

See [`semicolon_if_nothing_returned`](https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned) clippy lint.