### PR TITLE
chore: fix map_unwrap_or clippy lint

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -67,8 +67,7 @@ fn main() {
     .as_ref()
     .and_then(|p| p.file_stem())
     .and_then(|f| f.to_str())
-    .map(|s| s.starts_with("rls"))
-    .unwrap_or(false);
+    .is_some_and(|s| s.starts_with("rls"));
 
   // Early exit
   if is_cargo_doc || is_rls {

--- a/examples/cppgc-object.rs
+++ b/examples/cppgc-object.rs
@@ -117,8 +117,10 @@ fn execute_script(
     let exception_string = try_catch
       .stack_trace()
       .or_else(|| try_catch.exception())
-      .map(|value| value.to_rust_string_lossy(try_catch))
-      .unwrap_or_else(|| "no stack trace".into());
+      .map_or_else(
+        || "no stack trace".into(),
+        |value| value.to_rust_string_lossy(try_catch),
+      );
 
     panic!("{}", exception_string);
   }

--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -482,7 +482,7 @@ impl ArrayBuffer {
     // V8 terminates when the ArrayBuffer is not detachable. Non-detachable
     // buffers are buffers that are in use by WebAssembly or asm.js.
     if self.is_detachable() {
-      let key = key.map(|v| &*v as *const Value).unwrap_or(null());
+      let key = key.map_or(null(), |v| &*v as *const Value);
       unsafe { v8__ArrayBuffer__Detach(self, key) }.into()
     } else {
       Some(true)

--- a/src/context.rs
+++ b/src/context.rs
@@ -99,12 +99,8 @@ impl Context {
           sd.get_isolate_ptr(),
           options
             .global_template
-            .map(|t| &*t as *const _)
-            .unwrap_or_else(null),
-          options
-            .global_object
-            .map(|o| &*o as *const _)
-            .unwrap_or_else(null),
+            .map_or_else(null, |t| &*t as *const _),
+          options.global_object.map_or_else(null, |o| &*o as *const _),
           options.microtask_queue.unwrap_or_else(null_mut),
         )
       })
@@ -358,10 +354,7 @@ impl Context {
         v8__Context__FromSnapshot(
           sd.get_isolate_mut(),
           context_snapshot_index,
-          options
-            .global_object
-            .map(|o| &*o as *const _)
-            .unwrap_or_else(null),
+          options.global_object.map_or_else(null, |o| &*o as *const _),
           options.microtask_queue.unwrap_or_else(null_mut),
         )
       })

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -508,8 +508,7 @@ impl From<&'_ mut Isolate> for HandleHost {
 impl From<&'_ IsolateHandle> for HandleHost {
   fn from(isolate_handle: &IsolateHandle) -> Self {
     NonNull::new(unsafe { isolate_handle.get_isolate_ptr() })
-      .map(Self::Isolate)
-      .unwrap_or(Self::DisposedIsolate)
+      .map_or(Self::DisposedIsolate, Self::Isolate)
   }
 }
 
@@ -1097,8 +1096,7 @@ impl<T> TracedReference<T> {
         self as *mut Self as *mut TracedReference<Data>,
         scope.get_isolate_ptr(),
         data
-          .map(|h| h.as_non_null().as_ptr())
-          .unwrap_or(std::ptr::null_mut())
+          .map_or(std::ptr::null_mut(), |h| h.as_non_null().as_ptr())
           .cast(),
       );
     }

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -306,8 +306,7 @@ where
         specifier,
         import_attributes,
       )
-      .map(|return_value| return_value.as_non_null().as_ptr())
-      .unwrap_or_else(null_mut)
+      .map_or_else(null_mut, |return_value| return_value.as_non_null().as_ptr())
     }
 
     #[cfg(all(target_family = "windows", target_arch = "x86_64"))]
@@ -846,8 +845,7 @@ impl Isolate {
   ) {
     let scope_data_ptr = scope_data
       .map(NonNull::cast)
-      .map(NonNull::as_ptr)
-      .unwrap_or_else(null_mut);
+      .map_or_else(null_mut, NonNull::as_ptr);
     self.set_data_internal(Self::CURRENT_SCOPE_DATA_SLOT, scope_data_ptr);
   }
 
@@ -1105,9 +1103,7 @@ impl Isolate {
         .get_slot::<HostCreateShadowRealmContextCallback>()
         .unwrap();
       let context = callback(&mut scope);
-      context
-        .map(|l| l.as_non_null().as_ptr())
-        .unwrap_or_else(null_mut)
+      context.map_or_else(null_mut, |l| l.as_non_null().as_ptr())
     }
 
     // Windows x64 ABI: MaybeLocal<Context> must be returned on the stack.

--- a/src/module.rs
+++ b/src/module.rs
@@ -127,9 +127,7 @@ where
   fn mapping() -> Self {
     let f = |context, module| {
       SyntheticModuleEvaluationStepsRet(
-        (F::get())(context, module)
-          .map(|r| -> *const Value { &*r })
-          .unwrap_or(null()),
+        (F::get())(context, module).map_or(null(), |r| -> *const Value { &*r }),
       )
     };
     f.to_c_fn()

--- a/src/script.rs
+++ b/src/script.rs
@@ -68,7 +68,7 @@ impl Script {
         v8__Script__Compile(
           sd.get_current_context(),
           &*source,
-          origin.map(|r| r as *const _).unwrap_or_else(null),
+          origin.map_or_else(null, |r| r as *const _),
         )
       })
     }
@@ -128,15 +128,11 @@ impl<'s> ScriptOrigin<'s> {
         resource_column_offset,
         resource_is_shared_cross_origin,
         script_id,
-        source_map_url
-          .map(|l| &*l as *const Value)
-          .unwrap_or_else(null),
+        source_map_url.map_or_else(null, |l| &*l as *const Value),
         resource_is_opaque,
         is_wasm,
         is_module,
-        host_defined_options
-          .map(|l| &*l as *const Data)
-          .unwrap_or_else(null),
+        host_defined_options.map_or_else(null, |l| &*l as *const Data),
       );
       buf.assume_init()
     }

--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -151,7 +151,7 @@ impl Source {
       v8__ScriptCompiler__Source__CONSTRUCT(
         &mut buf,
         &*source_string,
-        origin.map(|x| x as *const _).unwrap_or(std::ptr::null()),
+        origin.map_or(std::ptr::null(), |x| x as *const _),
         std::ptr::null_mut(),
       );
       buf.assume_init()
@@ -169,7 +169,7 @@ impl Source {
       v8__ScriptCompiler__Source__CONSTRUCT(
         &mut buf,
         &*source_string,
-        origin.map(|x| x as *const _).unwrap_or(std::ptr::null()),
+        origin.map_or(std::ptr::null(), |x| x as *const _),
         cached_data.into_raw(), // Source constructor takes ownership.
       );
       buf.assume_init()

--- a/src/support.rs
+++ b/src/support.rs
@@ -77,8 +77,7 @@ impl<T> UniquePtr<T> {
   pub fn into_raw(self) -> *mut T {
     self
       .0
-      .map(|unique_ref| unique_ref.into_raw())
-      .unwrap_or_else(null_mut)
+      .map_or_else(null_mut, |unique_ref| unique_ref.into_raw())
   }
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -59,7 +59,7 @@ impl WasmStreaming {
   /// {exception} does not have value, the promise does not get rejected.
   #[inline(always)]
   pub fn abort(mut self, exception: Option<Local<Value>>) {
-    let exception = exception.map(|v| &*v as *const Value).unwrap_or(null());
+    let exception = exception.map_or(null(), |v| &*v as *const Value);
     unsafe { v8__WasmStreaming__Abort(&mut self.0, exception) }
   }
 

--- a/tests/test_cppgc.rs
+++ b/tests/test_cppgc.rs
@@ -233,8 +233,10 @@ fn execute_script(
     let exception_string = scope
       .stack_trace()
       .or_else(|| scope.exception())
-      .map(|value| value.to_rust_string_lossy(scope))
-      .unwrap_or_else(|| "no stack trace".into());
+      .map_or_else(
+        || "no stack trace".into(),
+        |value| value.to_rust_string_lossy(scope),
+      );
 
     panic!("{}", exception_string);
   }


### PR DESCRIPTION
auto-fixed trailing semicolons by running

```
clippy --fix --all-features --all-targets --workspace -- -W clippy::map_unwrap_or
```

See [`map_unwrap_or`](https://rust-lang.github.io/rust-clippy/master/index.html#map_unwrap_or) clippy lint.