### PR TITLE
feat: add get_contents_raw_parts

### DIFF
--- a/src/array_buffer_view.rs
+++ b/src/array_buffer_view.rs
@@ -101,11 +101,11 @@ impl ArrayBufferView {
       let span = v8__ArrayBufferView__GetContents(
         self,
         memory_span_t {
-          data: storage.as_mut_ptr() as _,
+          data: storage.as_mut_ptr(),
           size: storage.len(),
         },
       );
-      (span.data as _, span.size)
+      (span.data, span.size)
     }
   }
 

--- a/src/array_buffer_view.rs
+++ b/src/array_buffer_view.rs
@@ -87,11 +87,16 @@ impl ArrayBufferView {
     }
   }
 
+  /// Returns the contents of the ArrayBufferView's buffer as a MemorySpan. If
+  /// the contents are on the V8 heap, they get copied into `storage`. Otherwise
+  /// a view into the off-heap backing store is returned. The provided storage
+  /// should be at least as large as the maximum on-heap size of a TypedArray,
+  /// which is available as `v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP`.
   #[inline(always)]
-  pub fn get_contents<'s, 'a>(&'s self, storage: &'a mut [u8]) -> &'a [u8]
-  where
-    's: 'a,
-  {
+  pub unsafe fn get_contents_raw_parts(
+    &self,
+    storage: &mut [u8],
+  ) -> (*mut u8, usize) {
     unsafe {
       let span = v8__ArrayBufferView__GetContents(
         self,
@@ -100,7 +105,23 @@ impl ArrayBufferView {
           size: storage.len(),
         },
       );
-      std::slice::from_raw_parts(span.data as _, span.size)
+      (span.data as _, span.size)
+    }
+  }
+
+  /// Returns the contents of the ArrayBufferView's buffer as a MemorySpan. If
+  /// the contents are on the V8 heap, they get copied into `storage`. Otherwise
+  /// a view into the off-heap backing store is returned. The provided storage
+  /// should be at least as large as the maximum on-heap size of a TypedArray,
+  /// which is available as `v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP`.
+  #[inline(always)]
+  pub fn get_contents<'s, 'a>(&'s self, storage: &'a mut [u8]) -> &'a [u8]
+  where
+    's: 'a,
+  {
+    unsafe {
+      let (data, size) = self.get_contents_raw_parts(storage);
+      std::slice::from_raw_parts(data, size)
     }
   }
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1887,8 +1887,7 @@ size_t v8__ArrayBufferView__CopyContents(const v8::ArrayBufferView& self,
 
 memory_span_t v8__ArrayBufferView__GetContents(const v8::ArrayBufferView& self,
                                                memory_span_t rstorage) {
-  v8::MemorySpan<uint8_t> storage{static_cast<uint8_t*>(rstorage.data),
-                                  rstorage.size};
+  v8::MemorySpan<uint8_t> storage{rstorage.data, rstorage.size};
   v8::MemorySpan<uint8_t> span = ptr_to_local(&self)->GetContents(storage);
   return {span.data(), span.size()};
 }

--- a/src/support.h
+++ b/src/support.h
@@ -179,7 +179,7 @@ struct three_pointers_t {
 }  // namespace support
 
 struct memory_span_t {
-  void* data;
+  uint8_t* data;
   size_t size;
 };
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -1017,7 +1017,7 @@ impl ObjectTemplate {
       let getter = getter.map_or_else(std::ptr::null, |v| &*v);
       let setter = setter.map_or_else(std::ptr::null, |v| &*v);
       v8__ObjectTemplate__SetAccessorProperty(
-        self, &*key, &*getter, &*setter, attr,
+        self, &*key, getter, setter, attr,
       );
     }
   }


### PR DESCRIPTION
This needs to provide some form of mutable API. Returns a raw pointer due to rust aliasing rules, and marked unsafe since you have to manually ensure the view is rooted the entire time you are using that raw pointer.