### PR TITLE
Remove use of internal V8 apis

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -59,7 +59,6 @@ unsafe extern "C" {
     deleter: BackingStoreDeleterCallback,
     deleter_data: *mut c_void,
   ) -> *mut BackingStore;
-  fn v8__BackingStore__EmptyBackingStore(shared: bool) -> *mut BackingStore;
 
   fn v8__BackingStore__Data(this: *const BackingStore) -> *mut c_void;
   fn v8__BackingStore__ByteLength(this: *const BackingStore) -> usize;
@@ -450,16 +449,6 @@ impl ArrayBuffer {
     .unwrap()
   }
 
-  /// Create a new, empty ArrayBuffer.
-  #[inline(always)]
-  pub fn empty<'s>(scope: &mut HandleScope<'s>) -> Local<'s, ArrayBuffer> {
-    // SAFETY: This is a v8-provided empty backing store
-    let backing_store = unsafe {
-      UniqueRef::from_raw(v8__BackingStore__EmptyBackingStore(false))
-    };
-    Self::with_backing_store(scope, &backing_store.make_shared())
-  }
-
   /// Data length in bytes.
   #[inline(always)]
   pub fn byte_length(&self) -> usize {
@@ -593,11 +582,6 @@ impl ArrayBuffer {
     T: sealed::Rawable,
   {
     let len = bytes.byte_len();
-    if len == 0 {
-      return unsafe {
-        UniqueRef::from_raw(v8__BackingStore__EmptyBackingStore(false))
-      };
-    }
 
     let (ptr, slice) = T::into_raw(bytes);
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -4,34 +4,24 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
-#include <iostream>
-#include <memory>
+#include <thread>
 
 #include "cppgc/allocation.h"
+#include "cppgc/persistent.h"
 #include "cppgc/platform.h"
+#include "libplatform/libplatform.h"
 #include "support.h"
 #include "unicode/locid.h"
 #include "v8-callbacks.h"
-#include "v8/include/cppgc/persistent.h"
-#include "v8/include/libplatform/libplatform.h"
-#include "v8/include/v8-cppgc.h"
-#include "v8/include/v8-fast-api-calls.h"
-#include "v8/include/v8-inspector.h"
-#include "v8/include/v8-internal.h"
-#include "v8/include/v8-platform.h"
-#include "v8/include/v8-profiler.h"
-#include "v8/include/v8.h"
-#include "v8/src/api/api-inl.h"
-#include "v8/src/api/api.h"
-#include "v8/src/base/debug/stack_trace.h"
-#include "v8/src/base/sys-info.h"
-#include "v8/src/execution/isolate-utils-inl.h"
-#include "v8/src/execution/isolate-utils.h"
+#include "v8-cppgc.h"
+#include "v8-fast-api-calls.h"
+#include "v8-inspector.h"
+#include "v8-internal.h"
+#include "v8-platform.h"
+#include "v8-profiler.h"
+#include "v8.h"
 #include "v8/src/flags/flags.h"
 #include "v8/src/libplatform/default-platform.h"
-#include "v8/src/objects/objects-inl.h"
-#include "v8/src/objects/objects.h"
-#include "v8/src/objects/smi.h"
 
 using namespace support;
 
@@ -125,9 +115,6 @@ static_assert(sizeof(v8::Isolate::DisallowJavascriptExecutionScope) == 12,
 #endif
 
 extern "C" {
-const extern int v8__internal__Internals__kIsolateEmbedderDataOffset =
-    v8::internal::Internals::kIsolateEmbedderDataOffset;
-
 void v8__V8__SetFlagsFromCommandLine(int* argc, char** argv,
                                      const char* usage) {
   namespace i = v8::internal;
@@ -202,6 +189,14 @@ const v8::Context* v8__Isolate__GetEnteredOrMicrotaskContext(
 
 uint32_t v8__Isolate__GetNumberOfDataSlots(v8::Isolate* isolate) {
   return isolate->GetNumberOfDataSlots();
+}
+
+void* v8__Isolate__GetData(v8::Isolate* isolate, uint32_t slot) {
+  return isolate->GetData(slot);
+}
+
+void v8__Isolate__SetData(v8::Isolate* isolate, uint32_t slot, void* data) {
+  isolate->SetData(slot, data);
 }
 
 const v8::Data* v8__Isolate__GetDataFromSnapshotOnce(v8::Isolate* isolate,
@@ -577,17 +572,17 @@ bool v8__Data__EQ(const v8::Data& self, const v8::Data& other) {
 }
 
 bool v8__Data__IsBigInt(const v8::Data& self) {
-  return IsBigInt(*v8::Utils::OpenHandle(&self));
+  return self.IsValue() && reinterpret_cast<const v8::Value&>(self).IsBigInt();
 }
 
 bool v8__Data__IsBoolean(const v8::Data& self) {
-  return IsBoolean(*v8::Utils::OpenHandle(&self));
+  return self.IsValue() && reinterpret_cast<const v8::Value&>(self).IsBoolean();
 }
 
 bool v8__Data__IsContext(const v8::Data& self) { return self.IsContext(); }
 
 bool v8__Data__IsFixedArray(const v8::Data& self) {
-  return IsFixedArray(*v8::Utils::OpenHandle(&self));
+  return self.IsFixedArray();
 }
 
 bool v8__Data__IsFunctionTemplate(const v8::Data& self) {
@@ -597,15 +592,15 @@ bool v8__Data__IsFunctionTemplate(const v8::Data& self) {
 bool v8__Data__IsModule(const v8::Data& self) { return self.IsModule(); }
 
 bool v8__Data__IsModuleRequest(const v8::Data& self) {
-  return IsModuleRequest(*v8::Utils::OpenHandle(&self));
+  return self.IsModuleRequest();
 }
 
 bool v8__Data__IsName(const v8::Data& self) {
-  return IsName(*v8::Utils::OpenHandle(&self));
+  return self.IsValue() && reinterpret_cast<const v8::Value&>(self).IsName();
 }
 
 bool v8__Data__IsNumber(const v8::Data& self) {
-  return IsNumber(*v8::Utils::OpenHandle(&self));
+  return self.IsValue() && reinterpret_cast<const v8::Value&>(self).IsNumber();
 }
 
 bool v8__Data__IsObjectTemplate(const v8::Data& self) {
@@ -613,17 +608,18 @@ bool v8__Data__IsObjectTemplate(const v8::Data& self) {
 }
 
 bool v8__Data__IsPrimitive(const v8::Data& self) {
-  return IsPrimitive(*v8::Utils::OpenHandle(&self)) && !self.IsPrivate();
+  return self.IsValue() &&
+         reinterpret_cast<const v8::Value&>(self).IsPrimitive();
 }
 
 bool v8__Data__IsPrivate(const v8::Data& self) { return self.IsPrivate(); }
 
 bool v8__Data__IsString(const v8::Data& self) {
-  return IsString(*v8::Utils::OpenHandle(&self));
+  return self.IsValue() && reinterpret_cast<const v8::Value&>(self).IsString();
 }
 
 bool v8__Data__IsSymbol(const v8::Data& self) {
-  return IsPublicSymbol(*v8::Utils::OpenHandle(&self));
+  return self.IsValue() && reinterpret_cast<const v8::Value&>(self).IsSymbol();
 }
 
 bool v8__Data__IsValue(const v8::Data& self) { return self.IsValue(); }
@@ -896,6 +892,8 @@ const v8::String* v8__Value__TypeOf(v8::Value& self, v8::Isolate* isolate) {
   return local_to_ptr(self.TypeOf(isolate));
 }
 
+uint32_t v8__Value__GetHash(v8::Value& self) { return self.GetHash(); }
+
 const v8::Primitive* v8__Null(v8::Isolate* isolate) {
   return local_to_ptr(v8::Null(isolate));
 }
@@ -952,12 +950,6 @@ v8::BackingStore* v8__ArrayBuffer__NewBackingStore__with_data(
 
 two_pointers_t v8__ArrayBuffer__GetBackingStore(const v8::ArrayBuffer& self) {
   return make_pod<two_pointers_t>(ptr_to_local(&self)->GetBackingStore());
-}
-
-v8::BackingStore* v8__BackingStore__EmptyBackingStore(bool shared) {
-  std::unique_ptr<i::BackingStoreBase> u = i::BackingStore::EmptyBackingStore(
-      shared ? i::SharedFlag::kShared : i::SharedFlag::kNotShared);
-  return static_cast<v8::BackingStore*>(u.release());
 }
 
 bool v8__BackingStore__IsResizableByUserJavaScript(
@@ -2359,10 +2351,10 @@ const v8::Object* v8__PropertyCallbackInfo__Holder(
   return local_to_ptr(self.HolderV2());
 }
 
-v8::internal::Address* v8__PropertyCallbackInfo__GetReturnValue(
+uintptr_t* v8__PropertyCallbackInfo__GetReturnValue(
     const v8::PropertyCallbackInfo<v8::Value>& self) {
   v8::ReturnValue<v8::Value> rv = self.GetReturnValue();
-  return *reinterpret_cast<v8::internal::Address**>(&rv);
+  return *reinterpret_cast<uintptr_t**>(&rv);
 }
 
 bool v8__PropertyCallbackInfo__ShouldThrowOnError(
@@ -2875,8 +2867,6 @@ class UnprotectedDefaultPlatform : public v8::platform::DefaultPlatform {
   using PriorityMode = v8::platform::PriorityMode;
   using TracingController = v8::TracingController;
 
-  static constexpr int kMaxThreadPoolSize = 16;
-
  public:
   explicit UnprotectedDefaultPlatform(
       int thread_pool_size, IdleTaskSupport idle_task_support,
@@ -2886,28 +2876,8 @@ class UnprotectedDefaultPlatform : public v8::platform::DefaultPlatform {
                                       std::move(tracing_controller),
                                       priority_mode) {}
 
-  static std::unique_ptr<v8::Platform> New(
-      int thread_pool_size, IdleTaskSupport idle_task_support,
-      InProcessStackDumping in_process_stack_dumping,
-      std::unique_ptr<TracingController> tracing_controller = {},
-      PriorityMode priority_mode = PriorityMode::kDontApply) {
-    // This implementation is semantically equivalent to the implementation of
-    // `v8::platform::NewDefaultPlatform()`.
-    DCHECK_GE(thread_pool_size, 0);
-    if (thread_pool_size < 1) {
-      thread_pool_size =
-          std::max(v8::base::SysInfo::NumberOfProcessors() - 1, 1);
-    }
-    thread_pool_size = std::min(thread_pool_size, kMaxThreadPoolSize);
-    if (in_process_stack_dumping == InProcessStackDumping::kEnabled) {
-      v8::base::debug::EnableInProcessStackDumping();
-    }
-    return std::make_unique<UnprotectedDefaultPlatform>(
-        thread_pool_size, idle_task_support, std::move(tracing_controller),
-        priority_mode);
-  }
-
   v8::ThreadIsolatedAllocator* GetThreadIsolatedAllocator() override {
+    // DefaultThreadIsolatedAllocator is PKU protected
     return nullptr;
   }
 };
@@ -2924,11 +2894,14 @@ v8::Platform* v8__Platform__NewDefaultPlatform(int thread_pool_size,
 
 v8::Platform* v8__Platform__NewUnprotectedDefaultPlatform(
     int thread_pool_size, bool idle_task_support) {
-  return UnprotectedDefaultPlatform::New(
-             thread_pool_size,
-             idle_task_support ? v8::platform::IdleTaskSupport::kEnabled
-                               : v8::platform::IdleTaskSupport::kDisabled,
-             v8::platform::InProcessStackDumping::kDisabled, nullptr)
+  if (thread_pool_size < 1) {
+    thread_pool_size = std::thread::hardware_concurrency();
+  }
+  thread_pool_size = std::max(std::min(thread_pool_size, 16), 1);
+  return std::make_unique<UnprotectedDefaultPlatform>(
+             thread_pool_size, idle_task_support
+                                   ? v8::platform::IdleTaskSupport::kEnabled
+                                   : v8::platform::IdleTaskSupport::kDisabled)
       .release();
 }
 
@@ -3418,28 +3391,6 @@ void v8__HeapProfiler__TakeHeapSnapshot(v8::Isolate* isolate,
   // in node-heapdump for the last 8 years and I think there is a pretty
   // good chance it'll keep working for 8 more.
   const_cast<v8::HeapSnapshot*>(snapshot)->Delete();
-}
-
-v8::Isolate* v8__internal__GetIsolateFromHeapObject(const v8::Data& data) {
-  namespace i = v8::internal;
-  i::Tagged<i::Object> object(reinterpret_cast<const i::Address&>(data));
-  i::Isolate* isolate;
-  return IsHeapObject(object) &&
-                 i::GetIsolateFromHeapObject(object.GetHeapObject(), &isolate)
-             ? reinterpret_cast<v8::Isolate*>(isolate)
-             : nullptr;
-}
-
-int v8__Value__GetHash(const v8::Value& data) {
-  namespace i = v8::internal;
-  i::Tagged<i::Object> object(reinterpret_cast<const i::Address&>(data));
-  i::Isolate* isolate;
-  int hash = IsHeapObject(object) && i::GetIsolateFromHeapObject(
-                                         object.GetHeapObject(), &isolate)
-                 ? i::Object::GetOrCreateHash(object, isolate).value()
-                 : i::Smi::ToInt(i::Object::GetHash(object));
-  assert(hash != 0);
-  return hash;
 }
 
 void v8__HeapStatistics__CONSTRUCT(uninit_t<v8::HeapStatistics>* buf) {

--- a/src/shared_array_buffer.rs
+++ b/src/shared_array_buffer.rs
@@ -35,7 +35,6 @@ unsafe extern "C" {
     deleter: BackingStoreDeleterCallback,
     deleter_data: *mut c_void,
   ) -> *mut BackingStore;
-  fn v8__BackingStore__EmptyBackingStore(shared: bool) -> *mut BackingStore;
 }
 
 impl SharedArrayBuffer {
@@ -72,17 +71,6 @@ impl SharedArrayBuffer {
       })
     }
     .unwrap()
-  }
-
-  /// Create a new, empty SharedArrayBuffer.
-  #[inline(always)]
-  pub fn empty<'s>(
-    scope: &mut HandleScope<'s>,
-  ) -> Local<'s, SharedArrayBuffer> {
-    // SAFETY: This is a v8-provided empty backing store
-    let backing_store =
-      unsafe { UniqueRef::from_raw(v8__BackingStore__EmptyBackingStore(true)) };
-    Self::with_backing_store(scope, &backing_store.make_shared())
   }
 
   /// Data length in bytes.
@@ -173,11 +161,6 @@ impl SharedArrayBuffer {
     T: crate::array_buffer::sealed::Rawable,
   {
     let len = bytes.byte_len();
-    if len == 0 {
-      return unsafe {
-        UniqueRef::from_raw(v8__BackingStore__EmptyBackingStore(false))
-      };
-    }
 
     let (ptr, slice) = T::into_raw(bytes);
 

--- a/src/support.h
+++ b/src/support.h
@@ -9,29 +9,9 @@
 #include <type_traits>
 #include <utility>
 
-#include "v8/include/cppgc/name-provider.h"
-#include "v8/include/v8-cppgc.h"
-#include "v8/include/v8.h"
-
-// Work around a bug in the V8 headers.
-//
-// The following template is defined in v8-internal.h. It has a subtle bug that
-// indirectly makes it impossible to convert `v8::Data` handles to themselves.
-// Some methods do that impliclity so they don't compile without this hack; one
-// example is `Local<Data> MaybeLocal::FromMaybe(Local<Data> default_value)`.
-//
-// Spot the bug :)
-//
-// ```
-// template <class T>
-// V8_INLINE void PerformCastCheck(T* data) {
-//   CastCheck<std::is_base_of<Data, T>::value &&
-//             !std::is_same<Data, std::remove_cv<T>>::value>::Perform(data);
-// }
-// ```
-template <>
-template <>
-inline void v8::internal::CastCheck<true>::Perform<v8::Data>(v8::Data* data) {}
+#include "cppgc/name-provider.h"
+#include "v8-cppgc.h"
+#include "v8.h"
 
 // Check assumptions made in binding code.
 static_assert(sizeof(bool) == sizeof(uint8_t), "");

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroI32;
-
 use crate::BigInt;
 use crate::Boolean;
 use crate::Context;
@@ -14,7 +12,6 @@ use crate::String;
 use crate::Uint32;
 use crate::Value;
 use crate::support::Maybe;
-use crate::support::int;
 
 unsafe extern "C" {
   fn v8__Value__IsUndefined(this: *const Value) -> bool;
@@ -142,7 +139,7 @@ unsafe extern "C" {
   );
   fn v8__Value__BooleanValue(this: *const Value, isolate: *mut Isolate)
   -> bool;
-  fn v8__Value__GetHash(this: *const Value) -> int;
+  fn v8__Value__GetHash(this: *const Value) -> u32;
   fn v8__Value__TypeOf(
     this: *const Value,
     isolate: *mut Isolate,
@@ -704,14 +701,13 @@ impl Value {
     unsafe { v8__Value__BooleanValue(self, scope.get_isolate_ptr()) }
   }
 
-  /// Returns the V8 hash value for this value. The current implementation
-  /// uses a hidden property to store the identity hash on some object types.
-  ///
-  /// The return value will never be 0. Also, it is not guaranteed to be
-  /// unique.
+  /// Get the hash of this value. The hash is not guaranteed to be
+  /// unique. For |Object| and |Name| instances the result is equal to
+  /// |GetIdentityHash|. Hashes are not guaranteed to be stable across
+  /// different isolates or processes.
   #[inline(always)]
-  pub fn get_hash(&self) -> NonZeroI32 {
-    unsafe { NonZeroI32::new_unchecked(v8__Value__GetHash(self)) }
+  pub fn get_hash(&self) -> u32 {
+    unsafe { v8__Value__GetHash(self) }
   }
 
   #[inline(always)]


### PR DESCRIPTION
Remove use of internal V8 APIs. some could be removed as-is, others will require changes coming in 13.5. Ultimately this includes some breaking changes as well, so waiting for 13.5 is ok.