### PR TITLE
Expose `ModifyCodeGenerationFromStrings` callback

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -335,6 +335,12 @@ void v8__Isolate__SetUseCounterCallback(
   isolate->SetUseCounterCallback(callback);
 }
 
+void v8__Isolate__SetModifyCodeGenerationFromStringsCallback(
+    v8::Isolate* isolate,
+    v8::ModifyCodeGenerationFromStringsCallback2 callback) {
+  isolate->SetModifyCodeGenerationFromStringsCallback(callback);
+}
+
 bool v8__Isolate__AddMessageListener(v8::Isolate* isolate,
                                      v8::MessageCallback callback) {
   return isolate->AddMessageListener(callback);

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -577,7 +577,10 @@ pub type OomErrorCallback =
   unsafe extern "C" fn(location: *const char, details: &OomDetails);
 
 /// The outcome of a [`ModifyCodeGenerationFromStringsCallback`].
-#[repr(C)]
+///
+/// Note that this is not the type V8 sees; it is translated into an internal
+/// `#[repr(C)]` equivalent before crossing the FFI boundary, so its layout
+/// carries no ABI guarantees.
 pub struct ModifyCodeGenerationFromStringsResult<'s> {
   /// If true, proceed with the code generation. Otherwise, block it.
   pub codegen_allowed: bool,
@@ -590,12 +593,21 @@ pub struct ModifyCodeGenerationFromStringsResult<'s> {
 /// the `Function` constructor. The callback decides whether the code generation
 /// is allowed, and may substitute the source that is about to be compiled.
 ///
-/// V8 only consults this callback for contexts that have code generation from
-/// strings disabled, see [`Context::set_allow_generation_from_strings`].
+/// V8 skips this callback only when the context allows code generation from
+/// strings *and* the source is already a string. So it is consulted either
+/// when the context has code generation disabled (see
+/// [`Context::set_allow_generation_from_strings`]) or when the source is
+/// something other than a string, whichever comes first.
 ///
 /// `source` is the value that was handed to `eval`/`Function`; it is not
-/// necessarily a string. `is_code_like` is true when that value is an object
-/// that the host marked as "code like".
+/// necessarily a string. When it isn't, returning `codegen_allowed: true`
+/// without a `modified_source` leaves V8 with nothing it knows how to compile,
+/// and the source object is handed back to the caller unchanged; supply a
+/// `modified_source` to have it compiled instead.
+///
+/// `is_code_like` is true when that value is an object that the host marked as
+/// "code like" via `v8::ObjectTemplate::SetCodeLike()`, which rusty_v8 does not
+/// currently expose.
 pub type ModifyCodeGenerationFromStringsCallback =
   for<'s, 'i> fn(
     scope: &mut PinScope<'s, 'i>,
@@ -613,6 +625,15 @@ struct RawModifyCodeGenerationFromStringsResult {
   modified_source: *mut String,
 }
 
+// Unlike `PrepareStackTraceCallback` and the shadow realm callback below, this
+// one needs no `#[cfg(target_os = "windows")]` sret shim. Those return a bare
+// `MaybeLocal`, which is 8 bytes: MSVC returns it through a hidden pointer
+// because it has user-declared constructors, while Rust returns it in a
+// register, so the two disagree. `ModifyCodeGenerationFromStringsResult` is 16
+// bytes, which is over the register-return threshold on every ABI we target, so
+// MSVC and rustc independently agree on the hidden-pointer form. On System V
+// and AArch64 it is trivially copyable and fits in two registers, and both
+// sides agree there too.
 type RawModifyCodeGenerationFromStringsCallback =
   for<'s> unsafe extern "C" fn(
     context: Local<'s, Context>,
@@ -1812,14 +1833,17 @@ impl Isolate {
   /// execute code using `eval` or the `Function` constructor.
   ///
   /// The callback can decide whether to allow code generation and, if so,
-  /// modify the source code beforehand. It is only consulted for contexts that
-  /// have code generation from strings disabled, see
-  /// [`Context::set_allow_generation_from_strings`].
+  /// modify the source code beforehand. V8 skips it only when the context
+  /// allows code generation from strings (see
+  /// [`Context::set_allow_generation_from_strings`]) *and* the source is
+  /// already a string; see [`ModifyCodeGenerationFromStringsCallback`] for the
+  /// exact conditions.
+  ///
+  /// Calling this again replaces the previously installed callback.
   pub fn set_modify_code_generation_from_strings_callback(
     &mut self,
     callback: ModifyCodeGenerationFromStringsCallback,
   ) {
-    #[inline]
     unsafe extern "C" fn rust_modify_code_generation_callback<'s>(
       context: Local<'s, Context>,
       source: Local<'s, Value>,
@@ -1832,6 +1856,12 @@ impl Isolate {
         .get_slot::<ModifyCodeGenerationFromStringsCallback>()
         .unwrap();
       let result = callback(&mut scope, source, is_code_like);
+      // `modified_source` outlives `scope` even though the raw handle slot is
+      // read here and only handed to V8 once `scope` has been dropped. A
+      // `CallbackScope` built from a `Local<Context>` has `NEEDS_SCOPE ==
+      // false`, so it opens no `HandleScope` of its own and handles created by
+      // the callback belong to whichever scope V8 had active when it called
+      // us. If that ever changes, this needs an `EscapableHandleScope`.
       RawModifyCodeGenerationFromStringsResult {
         codegen_allowed: result.codegen_allowed,
         modified_source: result

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -576,6 +576,50 @@ pub struct OomDetails {
 pub type OomErrorCallback =
   unsafe extern "C" fn(location: *const char, details: &OomDetails);
 
+/// The outcome of a [`ModifyCodeGenerationFromStringsCallback`].
+#[repr(C)]
+pub struct ModifyCodeGenerationFromStringsResult<'s> {
+  /// If true, proceed with the code generation. Otherwise, block it.
+  pub codegen_allowed: bool,
+  /// Compile this source instead of the original one, if present. This field
+  /// is only considered when `codegen_allowed` is true.
+  pub modified_source: Option<Local<'s, String>>,
+}
+
+/// Called when JavaScript dynamically generates code, i.e. through `eval` or
+/// the `Function` constructor. The callback decides whether the code generation
+/// is allowed, and may substitute the source that is about to be compiled.
+///
+/// V8 only consults this callback for contexts that have code generation from
+/// strings disabled, see [`Context::set_allow_generation_from_strings`].
+///
+/// `source` is the value that was handed to `eval`/`Function`; it is not
+/// necessarily a string. `is_code_like` is true when that value is an object
+/// that the host marked as "code like".
+pub type ModifyCodeGenerationFromStringsCallback =
+  for<'s, 'i> fn(
+    scope: &mut PinScope<'s, 'i>,
+    source: Local<'s, Value>,
+    is_code_like: bool,
+  ) -> ModifyCodeGenerationFromStringsResult<'s>;
+
+// The layout that V8 actually sees. It matches
+// `v8::ModifyCodeGenerationFromStringsResult`, with the `MaybeLocal<String>`
+// spelled as a nullable raw pointer so that the `improper_ctypes` lints — which
+// don't recognize the niche in `Option<Local<T>>` — are satisfied.
+#[repr(C)]
+struct RawModifyCodeGenerationFromStringsResult {
+  codegen_allowed: bool,
+  modified_source: *mut String,
+}
+
+type RawModifyCodeGenerationFromStringsCallback =
+  for<'s> unsafe extern "C" fn(
+    context: Local<'s, Context>,
+    source: Local<'s, Value>,
+    is_code_like: bool,
+  ) -> RawModifyCodeGenerationFromStringsResult;
+
 // Windows x64 ABI: MaybeLocal<Value> returned on the stack.
 #[cfg(target_os = "windows")]
 pub type PrepareStackTraceCallback<'s> =
@@ -748,6 +792,10 @@ unsafe extern "C" {
   fn v8__Isolate__SetUseCounterCallback(
     isolate: *mut RealIsolate,
     callback: UseCounterCallback,
+  );
+  fn v8__Isolate__SetModifyCodeGenerationFromStringsCallback(
+    isolate: *mut RealIsolate,
+    callback: RawModifyCodeGenerationFromStringsCallback,
   );
   fn v8__Isolate__RequestInterrupt(
     isolate: *const RealIsolate,
@@ -1757,6 +1805,49 @@ impl Isolate {
   ) {
     unsafe {
       v8__Isolate__RemoveGCEpilogueCallback(self.as_real_ptr(), callback, data)
+    }
+  }
+
+  /// This specifies the callback called by V8 when JS is trying to dynamically
+  /// execute code using `eval` or the `Function` constructor.
+  ///
+  /// The callback can decide whether to allow code generation and, if so,
+  /// modify the source code beforehand. It is only consulted for contexts that
+  /// have code generation from strings disabled, see
+  /// [`Context::set_allow_generation_from_strings`].
+  pub fn set_modify_code_generation_from_strings_callback(
+    &mut self,
+    callback: ModifyCodeGenerationFromStringsCallback,
+  ) {
+    #[inline]
+    unsafe extern "C" fn rust_modify_code_generation_callback<'s>(
+      context: Local<'s, Context>,
+      source: Local<'s, Value>,
+      is_code_like: bool,
+    ) -> RawModifyCodeGenerationFromStringsResult {
+      let scope = pin!(unsafe { CallbackScope::new(context) });
+      let mut scope = scope.init();
+      let callback = *scope
+        .as_ref()
+        .get_slot::<ModifyCodeGenerationFromStringsCallback>()
+        .unwrap();
+      let result = callback(&mut scope, source, is_code_like);
+      RawModifyCodeGenerationFromStringsResult {
+        codegen_allowed: result.codegen_allowed,
+        modified_source: result
+          .modified_source
+          .map_or_else(null_mut, |s| s.as_non_null().as_ptr()),
+      }
+    }
+
+    let slot_didnt_exist_before = self.set_slot(callback);
+    if slot_didnt_exist_before {
+      unsafe {
+        v8__Isolate__SetModifyCodeGenerationFromStringsCallback(
+          self.as_real_ptr(),
+          rust_modify_code_generation_callback,
+        );
+      }
     }
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,8 @@ pub use isolate::MemoryPressureLevel;
 pub use isolate::MessageCallback;
 pub use isolate::MessageErrorLevel;
 pub use isolate::MicrotasksPolicy;
+pub use isolate::ModifyCodeGenerationFromStringsCallback;
+pub use isolate::ModifyCodeGenerationFromStringsResult;
 pub use isolate::ModuleImportPhase;
 pub use isolate::NearHeapLimitCallback;
 pub use isolate::OomDetails;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -13722,6 +13722,56 @@ fn code_generation_from_strings_callback() {
   let result: Option<v8::Local<'_, v8::Value>> = eval(scope, "eval('1 + 1')");
   assert_eq!(result.unwrap().number_value(scope).unwrap(), 42.0);
   assert_eq!(COUNT.load(Ordering::Relaxed), 3);
+
+  // `modified_source` is only considered when `codegen_allowed` is true, so
+  // blocking still wins even though the callback hands back a replacement.
+  CODEGEN_ALLOWED.store(false, Ordering::Relaxed);
+  {
+    let tc = pin!(v8::TryCatch::new(scope));
+    let tc = &mut tc.init();
+    eval(tc, "eval('1 + 1')");
+    assert_eq!(
+      tc.message().unwrap().get(tc).to_rust_string_lossy(tc),
+      "Uncaught EvalError: Code generation from strings disallowed for this context"
+    );
+    assert_eq!(COUNT.load(Ordering::Relaxed), 4);
+  }
+}
+
+#[test]
+fn code_generation_from_strings_callback_non_string_source() {
+  static COUNT: AtomicUsize = AtomicUsize::new(0);
+
+  fn callback<'s, 'i>(
+    scope: &mut v8::PinScope<'s, 'i>,
+    source: v8::Local<'s, v8::Value>,
+    is_code_like: bool,
+  ) -> v8::ModifyCodeGenerationFromStringsResult<'s> {
+    COUNT.fetch_add(1, Ordering::Relaxed);
+    // `is_code_like` is only true for objects marked via
+    // `v8::ObjectTemplate::SetCodeLike()`, which rusty_v8 doesn't expose.
+    assert!(!is_code_like);
+    assert!(!source.is_string());
+    v8::ModifyCodeGenerationFromStringsResult {
+      codegen_allowed: true,
+      modified_source: Some(v8::String::new(scope, "40 + 2").unwrap()),
+    }
+  }
+
+  let _setup_guard = setup::parallel_test();
+  let mut isolate = v8::Isolate::new(Default::default());
+  isolate.set_modify_code_generation_from_strings_callback(callback);
+  let scope = pin!(v8::HandleScope::new(&mut isolate));
+  let mut scope = scope.init();
+  let context = v8::Context::new(&scope, Default::default());
+  let scope = &mut v8::ContextScope::new(&mut scope, context);
+
+  // Note that code generation from strings is left *enabled* here. V8 still
+  // consults the callback, because the source is not a string, and the
+  // callback is what turns it into something compilable.
+  let result: Option<v8::Local<'_, v8::Value>> = eval(scope, "eval({})");
+  assert_eq!(result.unwrap().number_value(scope).unwrap(), 42.0);
+  assert_eq!(COUNT.load(Ordering::Relaxed), 1);
 }
 
 #[test]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -13663,6 +13663,68 @@ fn use_counter_callback() {
 }
 
 #[test]
+fn code_generation_from_strings_callback() {
+  static CODEGEN_ALLOWED: AtomicBool = AtomicBool::new(false);
+  static MODIFY_SOURCE: AtomicBool = AtomicBool::new(false);
+  static COUNT: AtomicUsize = AtomicUsize::new(0);
+
+  fn callback<'s, 'i>(
+    scope: &mut v8::PinScope<'s, 'i>,
+    source: v8::Local<'s, v8::Value>,
+    is_code_like: bool,
+  ) -> v8::ModifyCodeGenerationFromStringsResult<'s> {
+    COUNT.fetch_add(1, Ordering::Relaxed);
+    assert!(!is_code_like);
+    assert_eq!(source.to_rust_string_lossy(scope), "1 + 1");
+    let modified_source = if MODIFY_SOURCE.load(Ordering::Relaxed) {
+      Some(v8::String::new(scope, "40 + 2").unwrap())
+    } else {
+      None
+    };
+    v8::ModifyCodeGenerationFromStringsResult {
+      codegen_allowed: CODEGEN_ALLOWED.load(Ordering::Relaxed),
+      modified_source,
+    }
+  }
+
+  let _setup_guard = setup::parallel_test();
+  let mut isolate = v8::Isolate::new(Default::default());
+  isolate.set_modify_code_generation_from_strings_callback(callback);
+  let scope = pin!(v8::HandleScope::new(&mut isolate));
+  let mut scope = scope.init();
+  let context = v8::Context::new(&scope, Default::default());
+  // Must be set to false, otherwise code generation is unconditionally allowed
+  // and the callback is never consulted.
+  context.set_allow_generation_from_strings(false);
+
+  let scope = &mut v8::ContextScope::new(&mut scope, context);
+
+  // Code generation should be disallowed.
+  {
+    let tc = pin!(v8::TryCatch::new(scope));
+    let tc = &mut tc.init();
+    eval(tc, "eval('1 + 1')");
+    assert_eq!(
+      tc.message().unwrap().get(tc).to_rust_string_lossy(tc),
+      "Uncaught EvalError: Code generation from strings disallowed for this context"
+    );
+    assert_eq!(COUNT.load(Ordering::Relaxed), 1);
+  }
+
+  // Enable code generation.
+  CODEGEN_ALLOWED.store(true, Ordering::Relaxed);
+  let result: Option<v8::Local<'_, v8::Value>> = eval(scope, "eval('1 + 1')");
+  assert_eq!(result.unwrap().number_value(scope).unwrap(), 2.0);
+  assert_eq!(COUNT.load(Ordering::Relaxed), 2);
+
+  // Replace the source that is about to be compiled.
+  MODIFY_SOURCE.store(true, Ordering::Relaxed);
+  let result: Option<v8::Local<'_, v8::Value>> = eval(scope, "eval('1 + 1')");
+  assert_eq!(result.unwrap().number_value(scope).unwrap(), 42.0);
+  assert_eq!(COUNT.load(Ordering::Relaxed), 3);
+}
+
+#[test]
 fn test_eternals() {
   let _setup_guard = setup::parallel_test();
   let eternal1 = v8::Eternal::empty();


### PR DESCRIPTION
Implements https://github.com/denoland/rusty_v8/issues/1716. Most of the code was taken from https://github.com/denoland/rusty_v8/pull/435 and adapted to work with the current V8 version (credits for the original PR go to @NeoLegends).

The approach implemented in this PR is somewhat limited (but does match the feature set of the previous PR):
- There's no `HandleScope` available in the callback, so it doesn't seem to be possible to read or modify the source code
- The attribute `#[allow(improper_ctypes_definitions)]` must be added to the callback function for it to not be (as far as I know, incorrectly) flagged with a warning