### PR TITLE
Add WriteUtf8V2 missing param fix

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1122,8 +1122,10 @@ int v8__String__WriteUtf8(const v8::String& self, v8::Isolate* isolate,
 }
 
 size_t v8__String__WriteUtf8_v2(const v8::String& self, v8::Isolate* isolate,
-                                char* buffer, size_t capacity, int flags) {
-  return self.WriteUtf8V2(isolate, buffer, capacity, flags);
+                                char* buffer, size_t capacity, int flags,
+                                size_t* processed_characters_return) {
+  return self.WriteUtf8V2(isolate, buffer, capacity, flags,
+                          processed_characters_return);
 }
 
 const v8::String::ExternalStringResource* v8__String__GetExternalStringResource(

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -263,10 +263,17 @@ fn test_string() {
     assert_eq!(17, local.utf8_length(scope));
     assert_eq!(reference, local.to_rust_string_lossy(scope));
     let mut vec = vec![0; 17];
+    let mut processed_characters = 0;
     assert_eq!(
       17,
-      local.write_utf8_v2(scope, &mut vec, v8::WriteFlags::empty())
+      local.write_utf8_v2(
+        scope,
+        &mut vec,
+        v8::WriteFlags::empty(),
+        Some(&mut processed_characters)
+      )
     );
+    assert_eq!(15, processed_characters);
     let mut u16_buffer = [0u16; 16];
     local.write_v2(scope, 0, &mut u16_buffer, v8::WriteFlags::empty());
     assert_eq!(


### PR DESCRIPTION
WriteUtf8V2 didn't have this parameter originally, but now it does!