### PR TITLE
refactor: remove dependency to once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,6 @@ dependencies = [
  "gzip-header",
  "home",
  "miniz_oxide",
- "once_cell",
  "paste",
  "rustversion",
  "trybuild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,6 @@ v8_enable_pointer_compression = []
 
 [dependencies]
 bitflags = "2.5"
-once_cell = "1.19"
 paste = "1.0"
 
 [build-dependencies]

--- a/src/V8.rs
+++ b/src/V8.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
-use once_cell::sync::Lazy;
 use std::ffi::CStr;
 use std::ffi::CString;
+use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::vec::Vec;
 
@@ -72,8 +72,8 @@ enum GlobalState {
 }
 use GlobalState::*;
 
-static GLOBAL_STATE: Lazy<Mutex<GlobalState>> =
-  Lazy::new(|| Mutex::new(Uninitialized));
+static GLOBAL_STATE: LazyLock<Mutex<GlobalState>> =
+  LazyLock::new(|| Mutex::new(Uninitialized));
 
 pub fn assert_initialized() {
   let global_state_guard = GLOBAL_STATE.lock().unwrap();

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1,5 +1,4 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
-use once_cell::sync::Lazy;
 use std::any::type_name;
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -13,6 +12,7 @@ use std::mem::MaybeUninit;
 use std::os::raw::c_char;
 use std::ptr::{addr_of, addr_of_mut};
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use v8::AccessorConfiguration;
@@ -9598,7 +9598,8 @@ fn counter_lookup_callback() {
   unsafe impl Send for Name {}
   unsafe impl Send for Count {}
 
-  static MAP: Lazy<Arc<Mutex<HashMap<Name, Count>>>> = Lazy::new(Arc::default);
+  static MAP: LazyLock<Arc<Mutex<HashMap<Name, Count>>>> =
+    LazyLock::new(Arc::default);
 
   // |name| points to a static zero-terminated C string.
   extern "C" fn callback(name: *const c_char) -> *mut i32 {


### PR DESCRIPTION
in [rust 1.80](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html) LazyLock has been stabilized.
this allows to remove the dependency on once_cell.