### PR TITLE
fix: space_name is static

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -2031,7 +2031,7 @@ impl HeapStatistics {
 pub struct HeapSpaceStatistics(v8__HeapSpaceStatistics);
 
 impl HeapSpaceStatistics {
-  pub fn space_name(&self) -> &CStr {
+  pub fn space_name(&self) -> &'static CStr {
     unsafe { CStr::from_ptr(self.0.space_name_) }
   }
 


### PR DESCRIPTION
this value is very difficult to use for metrics if the lifetime is not static.