### PR TITLE
ci: bump 'sccache' to v0.8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,8 @@ jobs:
 
       - name: Start sccache
         env:
+          # Start sccache server instead of using `RUSTC_WRAPPER`/`SCCACHE_GHA_ENABLED` environment variable (recommended by `sccache-action`).
+          # Because it cannot compile `syn` lib correctly on windows.
           SCCACHE_DIR: ${{ github.workspace }}/target/sccache
           SCCACHE_CACHE_SIZE: 128M
           SCCACHE_IDLE_TIMEOUT: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,16 +160,26 @@ jobs:
           # ('librusty_v8.rlib', the whole 'gn_out' directory, etc.) can be
           # quite big, so we cache only those subdirectories of
           # target/{debug|release} that contain the build output for crates that
-          # come from the registry.
+          # come from the registry. By additionally saving the sccache cache
+          # directory it's still possible to build v8 fast.
           path: |-
+            target/sccache
             target/*/.*
             target/*/build
             target/*/deps
           key: cargo-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
           restore-keys: cargo-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-
 
-      - name: Sccache
+      - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.8
+
+      - name: Start sccache
+        env:
+          SCCACHE_DIR: ${{ github.workspace }}/target/sccache
+          SCCACHE_CACHE_SIZE: 128M
+          SCCACHE_IDLE_TIMEOUT: 0
+        run: |
+          sccache --start-server
 
       - name: Install Clang
         if: startsWith(matrix.config.os, 'ubuntu')
@@ -194,8 +204,7 @@ jobs:
 
       - name: Test (ASAN)
         env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
+          SCCACHE_IDLE_TIMEOUT: 0
         if: matrix.config.variant == 'asan'
         # https://github.com/rust-lang/rust/issues/87215
         run: |
@@ -207,15 +216,11 @@ jobs:
 
       - name: Test
         env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
+          SCCACHE_IDLE_TIMEOUT: 0
         if: matrix.config.variant == 'debug' || matrix.config.variant == 'release'
         run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
 
       - name: Clippy
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
         run: ${{ matrix.config.cargo }} clippy --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }} -- -D clippy::all
 
       - name: Prepare binary publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           key: cargo-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
           restore-keys: cargo-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-
 
-      - name: Sccache
+      - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.8
 
       - name: Start sccache
@@ -178,9 +178,8 @@ jobs:
           # Start sccache server instead of using `RUSTC_WRAPPER` environment variable (recommended by `sccache-action`).
           # Because it cannot compile `syn` lib correctly on windows.
           SCCACHE_DIR: ${{ github.workspace }}/target/sccache
-          SCCACHE_CACHE_SIZE: 128M
+          SCCACHE_CACHE_SIZE: 1G
           SCCACHE_IDLE_TIMEOUT: 0
-          SCCACHE_GHA_ENABLED: true
         run: |
           sccache --start-server
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,6 @@ jobs:
       LIB_EXT: ${{ contains(matrix.config.target, 'windows') && 'lib' || 'a' }}
       FEATURES_SUFFIX: ${{ matrix.config.v8_enable_pointer_compression && '_ptrcomp' || '' }}
       RUSTFLAGS: -D warnings
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: Configure git
@@ -195,6 +193,9 @@ jobs:
           clang-format-19 --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h
 
       - name: Test (ASAN)
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
         if: matrix.config.variant == 'asan'
         # https://github.com/rust-lang/rust/issues/87215
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,16 +170,28 @@ jobs:
           key: cargo-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
           restore-keys: cargo-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-
 
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.8
-
-      - name: Start sccache
+      - name: Install and start sccache
+        shell: pwsh
         env:
           SCCACHE_DIR: ${{ github.workspace }}/target/sccache
-          SCCACHE_CACHE_SIZE: 1G
+          SCCACHE_CACHE_SIZE: 256M
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
-          sccache --start-server
+          $version = "v0.8.2"
+          $platform =
+            @{ "x86_64-apple-darwin"       = "x86_64-apple-darwin"
+               "aarch64-apple-darwin"      = "aarch64-apple-darwin"
+               "x86_64-unknown-linux-gnu"  = "x86_64-unknown-linux-musl"
+               "aarch64-unknown-linux-gnu" = "aarch64-unknown-linux-musl"
+               "x86_64-pc-windows-msvc"    = "x86_64-pc-windows-msvc"
+             }['${{ matrix.config.target }}']
+          $basename = "sccache-$version-$platform"
+          $url = "https://github.com/mozilla/sccache/releases/download/$version/$basename.tar.gz"
+          cd ~
+          curl -LO $url
+          tar -xzvf "$basename.tar.gz"
+          . $basename/sccache --start-server
+          echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Clang
         if: startsWith(matrix.config.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,8 @@ jobs:
           # ('librusty_v8.rlib', the whole 'gn_out' directory, etc.) can be
           # quite big, so we cache only those subdirectories of
           # target/{debug|release} that contain the build output for crates that
-          # come from the registry. By additionally saving the sccache cache
-          # directory it's still possible to build v8 fast.
+          # come from the registry.
           path: |-
-            target/sccache
             target/*/.*
             target/*/build
             target/*/deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,6 @@ jobs:
 
       - name: Start sccache
         env:
-          # Start sccache server instead of using `RUSTC_WRAPPER` environment variable (recommended by `sccache-action`).
-          # Because it cannot compile `syn` lib correctly on windows.
           SCCACHE_DIR: ${{ github.workspace }}/target/sccache
           SCCACHE_CACHE_SIZE: 1G
           SCCACHE_IDLE_TIMEOUT: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,10 @@ jobs:
           # ('librusty_v8.rlib', the whole 'gn_out' directory, etc.) can be
           # quite big, so we cache only those subdirectories of
           # target/{debug|release} that contain the build output for crates that
-          # come from the registry.
+          # come from the registry. By additionally saving the sccache cache
+          # directory it's still possible to build v8 fast.
           path: |-
+            target/sccache
             target/*/.*
             target/*/build
             target/*/deps
@@ -170,6 +172,17 @@ jobs:
 
       - name: Sccache
         uses: mozilla-actions/sccache-action@v0.0.8
+
+      - name: Start sccache
+        env:
+          # Start sccache server instead of using `RUSTC_WRAPPER` environment variable (recommended by `sccache-action`).
+          # Because it cannot compile `syn` lib correctly on windows.
+          SCCACHE_DIR: ${{ github.workspace }}/target/sccache
+          SCCACHE_CACHE_SIZE: 128M
+          SCCACHE_IDLE_TIMEOUT: 0
+          SCCACHE_GHA_ENABLED: true
+        run: |
+          sccache --start-server
 
       - name: Install Clang
         if: startsWith(matrix.config.os, 'ubuntu')
@@ -194,8 +207,7 @@ jobs:
 
       - name: Test (ASAN)
         env:
-          RUSTC_WRAPPER: "sccache"
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_IDLE_TIMEOUT: 0
         if: matrix.config.variant == 'asan'
         # https://github.com/rust-lang/rust/issues/87215
         run: |
@@ -207,13 +219,8 @@ jobs:
 
       - name: Test
         env:
-          RUSTC_WRAPPER: "sccache"
-          SCCACHE_GHA_ENABLED: "true"
-        if: ${{ (matrix.config.variant == 'debug' || matrix.config.variant == 'release') && ! contains(matrix.config.target, 'windows') }}
-        run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
-
-      - name: Test (Without Sccache)
-        if : ${{ contains(matrix.config.target, 'windows') }}
+          SCCACHE_IDLE_TIMEOUT: 0
+        if: matrix.config.variant == 'debug' || matrix.config.variant == 'release'
         run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
 
       - name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,10 +206,16 @@ jobs:
           V8_FROM_SOURCE=true RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std nextest run --lib --bins --tests -v --cargo-verbose --cargo-verbose --target ${{ matrix.config.target }}
 
       - name: Test
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
         if: matrix.config.variant == 'debug' || matrix.config.variant == 'release'
         run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
 
       - name: Clippy
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
         run: ${{ matrix.config.cargo }} clippy --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }} -- -D clippy::all
 
       - name: Prepare binary publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,7 @@ jobs:
       - name: Test (ASAN)
         env:
           SCCACHE_IDLE_TIMEOUT: 0
+          RUSTC_WRAPPER: "sccache"
         if: matrix.config.variant == 'asan'
         # https://github.com/rust-lang/rust/issues/87215
         run: |
@@ -219,7 +220,14 @@ jobs:
       - name: Test
         env:
           SCCACHE_IDLE_TIMEOUT: 0
-        if: matrix.config.variant == 'debug' || matrix.config.variant == 'release'
+          RUSTC_WRAPPER: "sccache"
+        if: (matrix.config.variant == 'debug' || matrix.config.variant == 'release') && ! contains(matrix.config.target, 'windows')
+        run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
+
+      - name: Test
+        env:
+          SCCACHE_IDLE_TIMEOUT: 0
+        if: (matrix.config.variant == 'debug' || matrix.config.variant == 'release') && contains(matrix.config.target, 'windows')
         run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
 
       - name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,28 +160,16 @@ jobs:
           # ('librusty_v8.rlib', the whole 'gn_out' directory, etc.) can be
           # quite big, so we cache only those subdirectories of
           # target/{debug|release} that contain the build output for crates that
-          # come from the registry. By additionally saving the sccache cache
-          # directory it's still possible to build v8 fast.
+          # come from the registry.
           path: |-
-            target/sccache
             target/*/.*
             target/*/build
             target/*/deps
           key: cargo-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
           restore-keys: cargo-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-
 
-      - name: Install sccache
+      - name: Sccache
         uses: mozilla-actions/sccache-action@v0.0.8
-
-      - name: Start sccache
-        env:
-          # Start sccache server instead of using `RUSTC_WRAPPER`/`SCCACHE_GHA_ENABLED` environment variable (recommended by `sccache-action`).
-          # Because it cannot compile `syn` lib correctly on windows.
-          SCCACHE_DIR: ${{ github.workspace }}/target/sccache
-          SCCACHE_CACHE_SIZE: 128M
-          SCCACHE_IDLE_TIMEOUT: 0
-        run: |
-          sccache --start-server
 
       - name: Install Clang
         if: startsWith(matrix.config.os, 'ubuntu')
@@ -206,7 +194,8 @@ jobs:
 
       - name: Test (ASAN)
         env:
-          SCCACHE_IDLE_TIMEOUT: 0
+          RUSTC_WRAPPER: "sccache"
+          SCCACHE_GHA_ENABLED: "true"
         if: matrix.config.variant == 'asan'
         # https://github.com/rust-lang/rust/issues/87215
         run: |
@@ -218,8 +207,13 @@ jobs:
 
       - name: Test
         env:
-          SCCACHE_IDLE_TIMEOUT: 0
-        if: matrix.config.variant == 'debug' || matrix.config.variant == 'release'
+          RUSTC_WRAPPER: "sccache"
+          SCCACHE_GHA_ENABLED: "true"
+        if: ${{ (matrix.config.variant == 'debug' || matrix.config.variant == 'release') && ! contains(matrix.config.target, 'windows') }}
+        run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
+
+      - name: Test (Without Sccache)
+        if : ${{ contains(matrix.config.target, 'windows') }}
         run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
 
       - name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
         uses: dsherret/rust-toolchain-file@v1
 
       - name: Install python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11.x
           architecture: x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
       LIB_EXT: ${{ contains(matrix.config.target, 'windows') && 'lib' || 'a' }}
       FEATURES_SUFFIX: ${{ matrix.config.v8_enable_pointer_compression && '_ptrcomp' || '' }}
       RUSTFLAGS: -D warnings
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: Configure git
@@ -168,27 +170,8 @@ jobs:
           key: cargo-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
           restore-keys: cargo-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-
 
-      - name: Install and start sccache
-        shell: pwsh
-        env:
-          SCCACHE_DIR: ${{ github.workspace }}/target/sccache
-          SCCACHE_CACHE_SIZE: 128M
-          SCCACHE_IDLE_TIMEOUT: 0
-        run: |
-          $version = "0.2.12"
-          $platform =
-            @{ "macOS"   = "x86_64-apple-darwin"
-               "Linux"   = "x86_64-unknown-linux-musl"
-               "Windows" = "x86_64-pc-windows-msvc"
-             }.${{ runner.os }}
-          $basename = "sccache-$version-$platform"
-          $url = "https://github.com/mozilla/sccache/releases/download/" +
-                 "$version/$basename.tar.gz"
-          cd ~
-          curl -LO $url
-          tar -xzvf "$basename.tar.gz"
-          . $basename/sccache --start-server
-          echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Sccache
+        uses: mozilla-actions/sccache-action@v0.0.8
 
       - name: Install Clang
         if: startsWith(matrix.config.os, 'ubuntu')
@@ -212,8 +195,6 @@ jobs:
           clang-format-19 --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h
 
       - name: Test (ASAN)
-        env:
-          SCCACHE_IDLE_TIMEOUT: 0
         if: matrix.config.variant == 'asan'
         # https://github.com/rust-lang/rust/issues/87215
         run: |
@@ -224,8 +205,6 @@ jobs:
           V8_FROM_SOURCE=true RUSTFLAGS="-C opt-level=1 -Zsanitizer=address" cargo +nightly -Z build-std nextest run --lib --bins --tests -v --cargo-verbose --cargo-verbose --target ${{ matrix.config.target }}
 
       - name: Test
-        env:
-          SCCACHE_IDLE_TIMEOUT: 0
         if: matrix.config.variant == 'debug' || matrix.config.variant == 'release'
         run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,6 @@ jobs:
       - name: Test (ASAN)
         env:
           SCCACHE_IDLE_TIMEOUT: 0
-          RUSTC_WRAPPER: "sccache"
         if: matrix.config.variant == 'asan'
         # https://github.com/rust-lang/rust/issues/87215
         run: |
@@ -220,14 +219,7 @@ jobs:
       - name: Test
         env:
           SCCACHE_IDLE_TIMEOUT: 0
-          RUSTC_WRAPPER: "sccache"
-        if: (matrix.config.variant == 'debug' || matrix.config.variant == 'release') && ! contains(matrix.config.target, 'windows')
-        run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
-
-      - name: Test
-        env:
-          SCCACHE_IDLE_TIMEOUT: 0
-        if: (matrix.config.variant == 'debug' || matrix.config.variant == 'release') && contains(matrix.config.target, 'windows')
+        if: matrix.config.variant == 'debug' || matrix.config.variant == 'release'
         run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
 
       - name: Clippy


### PR DESCRIPTION
1. Bumps `sccache` to v0.8.2, it is originally from here [PR-1663](https://github.com/denoland/rusty_v8/pull/1663/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL152).
2. Bumps `setup-python` to v5.