### PR TITLE
ci: add more pointer compression pre-builts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,18 @@ jobs:
             v8_enable_pointer_compression: false
             cargo: cargo
 
+          - os: macos-13
+            target: x86_64-apple-darwin
+            variant: debug
+            v8_enable_pointer_compression: true
+            cargo: cargo
+
+          - os: macos-13
+            target: x86_64-apple-darwin
+            variant: release
+            v8_enable_pointer_compression: true
+            cargo: cargo
+
           - os: macos-14
             target: aarch64-apple-darwin
             variant: asan
@@ -55,6 +67,18 @@ jobs:
             target: aarch64-apple-darwin
             variant: release
             v8_enable_pointer_compression: false
+            cargo: cargo
+
+          - os: macos-14
+            target: aarch64-apple-darwin
+            variant: debug
+            v8_enable_pointer_compression: true
+            cargo: cargo
+
+          - os: macos-14
+            target: aarch64-apple-darwin
+            variant: release
+            v8_enable_pointer_compression: true
             cargo: cargo
 
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,12 @@ jobs:
             v8_enable_pointer_compression: false
             cargo: cargo
 
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'windows-2022-xxl' || 'windows-2022' }}
+            target: x86_64-pc-windows-msvc
+            variant: release
+            v8_enable_pointer_compression: true
+            cargo: cargo
+
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
             target: aarch64-unknown-linux-gnu
             variant: debug
@@ -121,6 +127,18 @@ jobs:
             target: aarch64-unknown-linux-gnu
             variant: release
             v8_enable_pointer_compression: false
+            cargo: cargo
+
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
+            target: aarch64-unknown-linux-gnu
+            variant: debug
+            v8_enable_pointer_compression: true
+            cargo: cargo
+
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
+            target: aarch64-unknown-linux-gnu
+            variant: release
+            v8_enable_pointer_compression: true
             cargo: cargo
 
     env:


### PR DESCRIPTION
This PR adds "pointer compression" for more pre-builts:
* macos-13 (x86_64), macos-14 (arm64)
* windows (x86_64)
* ubuntu (linux-aarch64)