### PR TITLE
fix: add auto derivation and repr(C) to `MemoryPressureLevel`

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -86,6 +86,8 @@ pub enum MicrotasksPolicy {
 /// of higher latency due to garbage collection pauses.
 /// Critical hints V8 to free memory as soon as possible. Garbage collection
 /// pauses at this level will be large.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
 pub enum MemoryPressureLevel {
   None = 0,
   Moderate = 1,


### PR DESCRIPTION
This adds `#[derive(Debug, Clone, Copy, PartialEq, Eq)]` and `#[repr(C)]` to the `MemoryPressureLevel` enum to ensure consistent memory layout and enable common trait implementations.