### PR TITLE
Call Platform::NotifyIsolateShutdown before disposing isolate

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2959,6 +2959,11 @@ void v8__Platform__RunIdleTasks(v8::Platform* platform, v8::Isolate* isolate,
   v8::platform::RunIdleTasks(platform, isolate, idle_time_in_seconds);
 }
 
+void v8__Platform__NotifyIsolateShutdown(v8::Platform* platform,
+                                         v8::Isolate* isolate) {
+  v8::platform::NotifyIsolateShutdown(platform, isolate);
+}
+
 void v8__Platform__DELETE(v8::Platform* self) { delete self; }
 
 two_pointers_t std__shared_ptr__v8__Platform__CONVERT__std__unique_ptr(

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -12,10 +12,12 @@ use crate::Local;
 use crate::Message;
 use crate::Module;
 use crate::Object;
+use crate::Platform;
 use crate::Promise;
 use crate::PromiseResolver;
 use crate::StartupData;
 use crate::String;
+use crate::V8::get_current_platform;
 use crate::Value;
 use crate::binding::v8__HeapSpaceStatistics;
 use crate::binding::v8__HeapStatistics;
@@ -1882,6 +1884,7 @@ impl Drop for OwnedIsolate {
       self.dispose_scope_root();
       self.exit();
       self.dispose_annex();
+      Platform::notify_isolate_shutdown(&get_current_platform(), self);
       self.dispose();
     }
   }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -35,6 +35,11 @@ unsafe extern "C" {
     idle_time_in_seconds: f64,
   );
 
+  fn v8__Platform__NotifyIsolateShutdown(
+    platform: *mut Platform,
+    isolate: *mut Isolate,
+  );
+
   fn std__shared_ptr__v8__Platform__CONVERT__std__unique_ptr(
     unique_ptr: UniquePtr<Platform>,
   ) -> SharedPtrBase<Platform>;
@@ -209,6 +214,24 @@ impl Platform {
         &**platform as *const Self as *mut _,
         isolate,
         idle_time_in_seconds,
+      );
+    }
+  }
+
+  /// Notifies the given platform about the Isolate getting deleted soon. Has to
+  /// be called for all Isolates which are deleted - unless we're shutting down
+  /// the platform.
+  ///
+  /// The |platform| has to be created using |NewDefaultPlatform|.
+  #[inline(always)]
+  pub(crate) unsafe fn notify_isolate_shutdown(
+    platform: &SharedRef<Self>,
+    isolate: &mut Isolate,
+  ) {
+    unsafe {
+      v8__Platform__NotifyIsolateShutdown(
+        &**platform as *const Self as *mut _,
+        isolate,
       );
     }
   }


### PR DESCRIPTION
Without this, the isolate's ForegroundTaskRunner (stored in the platform) leaks.