### PR TITLE
clean up Allocated apis

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2844,7 +2844,15 @@ void v8__SnapshotCreator__DESTRUCT(v8::SnapshotCreator* self) {
   self->~SnapshotCreator();
 }
 
-void v8__StartupData__DESTRUCT(v8::StartupData* self) { delete[] self->data; }
+bool v8__StartupData__CanBeRehashed(const v8::StartupData& self) {
+  return self.CanBeRehashed();
+}
+
+bool v8__StartupData__IsValid(const v8::StartupData& self) {
+  return self.IsValid();
+}
+
+void v8__StartupData__data__DELETE(const char* data) { delete[] data; }
 
 v8::Isolate* v8__SnapshotCreator__GetIsolate(const v8::SnapshotCreator& self) {
   // `v8::SnapshotCreator::GetIsolate()` is not declared as a const method, but

--- a/src/external_references.rs
+++ b/src/external_references.rs
@@ -14,7 +14,6 @@ use crate::NamedQueryCallback;
 use crate::NamedSetterCallback;
 use crate::PropertyEnumeratorCallback;
 use crate::fast_api::CFunctionInfo;
-use crate::support::intptr_t;
 use std::ffi::c_void;
 use std::fmt::Debug;
 
@@ -44,39 +43,8 @@ impl Debug for ExternalReference<'_> {
   }
 }
 
-#[derive(Debug, Clone)]
-pub struct ExternalReferences {
-  null_terminated: Vec<intptr_t>,
-}
-
-unsafe impl Sync for ExternalReferences {}
-
-impl ExternalReferences {
-  #[inline(always)]
-  pub fn new(refs: &[ExternalReference]) -> Self {
-    let null_terminated = refs
-      .iter()
-      .map(|&r| unsafe { std::mem::transmute(r) })
-      .chain(std::iter::once(0)) // Add null terminator.
-      .collect::<Vec<intptr_t>>();
-    Self { null_terminated }
-  }
-
-  #[inline(always)]
-  pub fn as_ptr(&self) -> *const intptr_t {
-    self.null_terminated.as_ptr()
-  }
-}
-
-impl std::ops::Deref for ExternalReferences {
-  type Target = [intptr_t];
-  fn deref(&self) -> &Self::Target {
-    &self.null_terminated
-  }
-}
-
-impl std::borrow::Borrow<[intptr_t]> for ExternalReferences {
-  fn borrow(&self) -> &[intptr_t] {
-    self
+impl PartialEq for ExternalReference<'_> {
+  fn eq(&self, other: &Self) -> bool {
+    unsafe { self.pointer.eq(&other.pointer) }
   }
 }

--- a/src/external_references.rs
+++ b/src/external_references.rs
@@ -18,32 +18,32 @@ use std::ffi::c_void;
 use std::fmt::Debug;
 
 #[derive(Clone, Copy)]
-pub union ExternalReference<'s> {
+pub union ExternalReference {
   pub function: FunctionCallback,
-  pub named_getter: NamedGetterCallback<'s>,
-  pub named_setter: NamedSetterCallback<'s>,
-  pub named_definer: NamedDefinerCallback<'s>,
-  pub named_deleter: NamedDeleterCallback<'s>,
-  pub named_query: NamedQueryCallback<'s>,
-  pub indexed_getter: IndexedGetterCallback<'s>,
-  pub indexed_setter: IndexedSetterCallback<'s>,
-  pub indexed_definer: IndexedDefinerCallback<'s>,
-  pub indexed_deleter: IndexedDeleterCallback<'s>,
-  pub indexed_query: IndexedQueryCallback<'s>,
-  pub enumerator: PropertyEnumeratorCallback<'s>,
+  pub named_getter: NamedGetterCallback,
+  pub named_setter: NamedSetterCallback,
+  pub named_definer: NamedDefinerCallback,
+  pub named_deleter: NamedDeleterCallback,
+  pub named_query: NamedQueryCallback,
+  pub indexed_getter: IndexedGetterCallback,
+  pub indexed_setter: IndexedSetterCallback,
+  pub indexed_definer: IndexedDefinerCallback,
+  pub indexed_deleter: IndexedDeleterCallback,
+  pub indexed_query: IndexedQueryCallback,
+  pub enumerator: PropertyEnumeratorCallback,
   pub message: MessageCallback,
   pub pointer: *mut c_void,
   pub type_info: *const CFunctionInfo,
 }
 
-impl Debug for ExternalReference<'_> {
+impl Debug for ExternalReference {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     // SAFETY: All union fields are the same size
     unsafe { (self.pointer).fmt(f) }
   }
 }
 
-impl PartialEq for ExternalReference<'_> {
+impl PartialEq for ExternalReference {
   fn eq(&self, other: &Self) -> bool {
     unsafe { self.pointer.eq(&other.pointer) }
   }

--- a/src/function.rs
+++ b/src/function.rs
@@ -14,6 +14,7 @@ use crate::Local;
 use crate::Name;
 use crate::Object;
 use crate::PropertyDescriptor;
+use crate::SealedLocal;
 use crate::Signature;
 use crate::String;
 use crate::UniqueRef;
@@ -515,10 +516,10 @@ where
   }
 }
 
-pub(crate) type NamedGetterCallbackForAccessor<'s> =
-  unsafe extern "C" fn(Local<'s, Name>, *const PropertyCallbackInfo<Value>);
+pub(crate) type NamedGetterCallbackForAccessor =
+  unsafe extern "C" fn(SealedLocal<Name>, *const PropertyCallbackInfo<Value>);
 
-impl<F> MapFnFrom<F> for NamedGetterCallbackForAccessor<'_>
+impl<F> MapFnFrom<F> for NamedGetterCallbackForAccessor
 where
   F: UnitType
     + for<'s> Fn(
@@ -529,9 +530,11 @@ where
     ),
 {
   fn mapping() -> Self {
-    let f = |key: Local<Name>, info: *const PropertyCallbackInfo<Value>| {
+    let f = |key: SealedLocal<Name>,
+             info: *const PropertyCallbackInfo<Value>| {
       let info = unsafe { &*info };
       let scope = &mut unsafe { CallbackScope::new(info) };
+      let key = unsafe { scope.unseal(key) };
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
       (F::get())(scope, key, args, rv);
@@ -540,12 +543,12 @@ where
   }
 }
 
-pub(crate) type NamedGetterCallback<'s> = unsafe extern "C" fn(
-  Local<'s, Name>,
+pub(crate) type NamedGetterCallback = unsafe extern "C" fn(
+  SealedLocal<Name>,
   *const PropertyCallbackInfo<Value>,
 ) -> Intercepted;
 
-impl<F> MapFnFrom<F> for NamedGetterCallback<'_>
+impl<F> MapFnFrom<F> for NamedGetterCallback
 where
   F: UnitType
     + for<'s> Fn(
@@ -556,9 +559,11 @@ where
     ) -> Intercepted,
 {
   fn mapping() -> Self {
-    let f = |key: Local<Name>, info: *const PropertyCallbackInfo<Value>| {
+    let f = |key: SealedLocal<Name>,
+             info: *const PropertyCallbackInfo<Value>| {
       let info = unsafe { &*info };
       let scope = &mut unsafe { CallbackScope::new(info) };
+      let key = unsafe { scope.unseal(key) };
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
       (F::get())(scope, key, args, rv)
@@ -567,12 +572,12 @@ where
   }
 }
 
-pub(crate) type NamedQueryCallback<'s> = unsafe extern "C" fn(
-  Local<'s, Name>,
+pub(crate) type NamedQueryCallback = unsafe extern "C" fn(
+  SealedLocal<Name>,
   *const PropertyCallbackInfo<Integer>,
 ) -> Intercepted;
 
-impl<F> MapFnFrom<F> for NamedQueryCallback<'_>
+impl<F> MapFnFrom<F> for NamedQueryCallback
 where
   F: UnitType
     + for<'s> Fn(
@@ -583,9 +588,11 @@ where
     ) -> Intercepted,
 {
   fn mapping() -> Self {
-    let f = |key: Local<Name>, info: *const PropertyCallbackInfo<Integer>| {
+    let f = |key: SealedLocal<Name>,
+             info: *const PropertyCallbackInfo<Integer>| {
       let info = unsafe { &*info };
       let scope = &mut unsafe { CallbackScope::new(info) };
+      let key = unsafe { scope.unseal(key) };
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
       (F::get())(scope, key, args, rv)
@@ -594,13 +601,13 @@ where
   }
 }
 
-pub(crate) type NamedSetterCallbackForAccessor<'s> = unsafe extern "C" fn(
-  Local<'s, Name>,
-  Local<'s, Value>,
+pub(crate) type NamedSetterCallbackForAccessor = unsafe extern "C" fn(
+  SealedLocal<Name>,
+  SealedLocal<Value>,
   *const PropertyCallbackInfo<()>,
 );
 
-impl<F> MapFnFrom<F> for NamedSetterCallbackForAccessor<'_>
+impl<F> MapFnFrom<F> for NamedSetterCallbackForAccessor
 where
   F: UnitType
     + for<'s> Fn(
@@ -612,11 +619,13 @@ where
     ),
 {
   fn mapping() -> Self {
-    let f = |key: Local<Name>,
-             value: Local<Value>,
+    let f = |key: SealedLocal<Name>,
+             value: SealedLocal<Value>,
              info: *const PropertyCallbackInfo<()>| {
       let info = unsafe { &*info };
       let scope = &mut unsafe { CallbackScope::new(info) };
+      let key = unsafe { scope.unseal(key) };
+      let value = unsafe { scope.unseal(value) };
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
       (F::get())(scope, key, value, args, rv);
@@ -625,13 +634,13 @@ where
   }
 }
 
-pub(crate) type NamedSetterCallback<'s> = unsafe extern "C" fn(
-  Local<'s, Name>,
-  Local<'s, Value>,
+pub(crate) type NamedSetterCallback = unsafe extern "C" fn(
+  SealedLocal<Name>,
+  SealedLocal<Value>,
   *const PropertyCallbackInfo<()>,
 ) -> Intercepted;
 
-impl<F> MapFnFrom<F> for NamedSetterCallback<'_>
+impl<F> MapFnFrom<F> for NamedSetterCallback
 where
   F: UnitType
     + for<'s> Fn(
@@ -643,11 +652,13 @@ where
     ) -> Intercepted,
 {
   fn mapping() -> Self {
-    let f = |key: Local<Name>,
-             value: Local<Value>,
+    let f = |key: SealedLocal<Name>,
+             value: SealedLocal<Value>,
              info: *const PropertyCallbackInfo<()>| {
       let info = unsafe { &*info };
       let scope = &mut unsafe { CallbackScope::new(info) };
+      let key = unsafe { scope.unseal(key) };
+      let value = unsafe { scope.unseal(value) };
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
       (F::get())(scope, key, value, args, rv)
@@ -657,10 +668,10 @@ where
 }
 
 // Should return an Array in Return Value
-pub(crate) type PropertyEnumeratorCallback<'s> =
+pub(crate) type PropertyEnumeratorCallback =
   unsafe extern "C" fn(*const PropertyCallbackInfo<Array>);
 
-impl<F> MapFnFrom<F> for PropertyEnumeratorCallback<'_>
+impl<F> MapFnFrom<F> for PropertyEnumeratorCallback
 where
   F: UnitType
     + for<'s> Fn(
@@ -681,13 +692,13 @@ where
   }
 }
 
-pub(crate) type NamedDefinerCallback<'s> = unsafe extern "C" fn(
-  Local<'s, Name>,
+pub(crate) type NamedDefinerCallback = unsafe extern "C" fn(
+  SealedLocal<Name>,
   *const PropertyDescriptor,
   *const PropertyCallbackInfo<()>,
 ) -> Intercepted;
 
-impl<F> MapFnFrom<F> for NamedDefinerCallback<'_>
+impl<F> MapFnFrom<F> for NamedDefinerCallback
 where
   F: UnitType
     + for<'s> Fn(
@@ -699,11 +710,12 @@ where
     ) -> Intercepted,
 {
   fn mapping() -> Self {
-    let f = |key: Local<Name>,
+    let f = |key: SealedLocal<Name>,
              desc: *const PropertyDescriptor,
              info: *const PropertyCallbackInfo<()>| {
       let info = unsafe { &*info };
       let scope = &mut unsafe { CallbackScope::new(info) };
+      let key = unsafe { scope.unseal(key) };
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let desc = unsafe { &*desc };
       let rv = ReturnValue::from_property_callback_info(info);
@@ -713,12 +725,12 @@ where
   }
 }
 
-pub(crate) type NamedDeleterCallback<'s> = unsafe extern "C" fn(
-  Local<'s, Name>,
+pub(crate) type NamedDeleterCallback = unsafe extern "C" fn(
+  SealedLocal<Name>,
   *const PropertyCallbackInfo<Boolean>,
 ) -> Intercepted;
 
-impl<F> MapFnFrom<F> for NamedDeleterCallback<'_>
+impl<F> MapFnFrom<F> for NamedDeleterCallback
 where
   F: UnitType
     + for<'s> Fn(
@@ -729,9 +741,11 @@ where
     ) -> Intercepted,
 {
   fn mapping() -> Self {
-    let f = |key: Local<Name>, info: *const PropertyCallbackInfo<Boolean>| {
+    let f = |key: SealedLocal<Name>,
+             info: *const PropertyCallbackInfo<Boolean>| {
       let info = unsafe { &*info };
       let scope = &mut unsafe { CallbackScope::new(info) };
+      let key = unsafe { scope.unseal(key) };
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
       (F::get())(scope, key, args, rv)
@@ -740,10 +754,10 @@ where
   }
 }
 
-pub(crate) type IndexedGetterCallback<'s> =
+pub(crate) type IndexedGetterCallback =
   unsafe extern "C" fn(u32, *const PropertyCallbackInfo<Value>) -> Intercepted;
 
-impl<F> MapFnFrom<F> for IndexedGetterCallback<'_>
+impl<F> MapFnFrom<F> for IndexedGetterCallback
 where
   F: UnitType
     + for<'s> Fn(
@@ -765,12 +779,12 @@ where
   }
 }
 
-pub(crate) type IndexedQueryCallback<'s> = unsafe extern "C" fn(
+pub(crate) type IndexedQueryCallback = unsafe extern "C" fn(
   u32,
   *const PropertyCallbackInfo<Integer>,
 ) -> Intercepted;
 
-impl<F> MapFnFrom<F> for IndexedQueryCallback<'_>
+impl<F> MapFnFrom<F> for IndexedQueryCallback
 where
   F: UnitType
     + for<'s> Fn(
@@ -792,14 +806,13 @@ where
   }
 }
 
-pub(crate) type IndexedSetterCallback<'s> = unsafe extern "C" fn(
+pub(crate) type IndexedSetterCallback = unsafe extern "C" fn(
   u32,
-  Local<'s, Value>,
+  SealedLocal<Value>,
   *const PropertyCallbackInfo<()>,
-)
-  -> Intercepted;
+) -> Intercepted;
 
-impl<F> MapFnFrom<F> for IndexedSetterCallback<'_>
+impl<F> MapFnFrom<F> for IndexedSetterCallback
 where
   F: UnitType
     + for<'s> Fn(
@@ -812,10 +825,11 @@ where
 {
   fn mapping() -> Self {
     let f = |index: u32,
-             value: Local<Value>,
+             value: SealedLocal<Value>,
              info: *const PropertyCallbackInfo<()>| {
       let info = unsafe { &*info };
       let scope = &mut unsafe { CallbackScope::new(info) };
+      let value = unsafe { scope.unseal(value) };
       let args = PropertyCallbackArguments::from_property_callback_info(info);
       let rv = ReturnValue::from_property_callback_info(info);
       (F::get())(scope, index, value, args, rv)
@@ -824,14 +838,13 @@ where
   }
 }
 
-pub(crate) type IndexedDefinerCallback<'s> =
-  unsafe extern "C" fn(
-    u32,
-    *const PropertyDescriptor,
-    *const PropertyCallbackInfo<()>,
-  ) -> Intercepted;
+pub(crate) type IndexedDefinerCallback = unsafe extern "C" fn(
+  u32,
+  *const PropertyDescriptor,
+  *const PropertyCallbackInfo<()>,
+) -> Intercepted;
 
-impl<F> MapFnFrom<F> for IndexedDefinerCallback<'_>
+impl<F> MapFnFrom<F> for IndexedDefinerCallback
 where
   F: UnitType
     + for<'s> Fn(
@@ -857,13 +870,12 @@ where
   }
 }
 
-pub(crate) type IndexedDeleterCallback<'s> =
-  unsafe extern "C" fn(
-    u32,
-    *const PropertyCallbackInfo<Boolean>,
-  ) -> Intercepted;
+pub(crate) type IndexedDeleterCallback = unsafe extern "C" fn(
+  u32,
+  *const PropertyCallbackInfo<Boolean>,
+) -> Intercepted;
 
-impl<F> MapFnFrom<F> for IndexedDeleterCallback<'_>
+impl<F> MapFnFrom<F> for IndexedDeleterCallback
 where
   F: UnitType
     + for<'s> Fn(

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1176,3 +1176,10 @@ impl<T> Drop for Eternal<T> {
     }
   }
 }
+
+/// A Local<T> passed from V8 without an inherent scope.
+/// The value must be "unsealed" with Scope::unseal to bind
+/// it to a lifetime.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct SealedLocal<T>(pub(crate) NonNull<T>);

--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -211,7 +211,7 @@ struct CreateParamAllocations {
   // preferred format. We have to heap allocate this because we need to put a
   // stable pointer to it in `CreateParams`.
   snapshot_blob_header: Option<Box<RawStartupData>>,
-  external_references: Option<Cow<'static, [ExternalReference<'static>]>>,
+  external_references: Option<Cow<'static, [ExternalReference]>>,
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@ pub use array_buffer::*;
 pub use data::*;
 pub use exception::*;
 pub use external_references::ExternalReference;
-pub use external_references::ExternalReferences;
 pub use function::*;
 pub use gc::*;
 pub use get_property_names_args_builder::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub use handle::Eternal;
 pub use handle::Global;
 pub use handle::Handle;
 pub use handle::Local;
+pub use handle::SealedLocal;
 pub use handle::TracedReference;
 pub use handle::Weak;
 pub use isolate::GarbageCollectionType;

--- a/src/object.rs
+++ b/src/object.rs
@@ -537,7 +537,7 @@ impl Object {
     &self,
     scope: &mut HandleScope,
     name: Local<Name>,
-    getter: impl for<'s> MapFnTo<AccessorNameGetterCallback<'s>>,
+    getter: impl MapFnTo<AccessorNameGetterCallback>,
   ) -> Option<bool> {
     self.set_accessor_with_configuration(
       scope,
@@ -551,8 +551,8 @@ impl Object {
     &self,
     scope: &mut HandleScope,
     name: Local<Name>,
-    getter: impl for<'s> MapFnTo<AccessorNameGetterCallback<'s>>,
-    setter: impl for<'s> MapFnTo<AccessorNameSetterCallback<'s>>,
+    getter: impl MapFnTo<AccessorNameGetterCallback>,
+    setter: impl MapFnTo<AccessorNameSetterCallback>,
   ) -> Option<bool> {
     self.set_accessor_with_configuration(
       scope,

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -114,6 +114,7 @@ use crate::Object;
 use crate::OwnedIsolate;
 use crate::Primitive;
 use crate::PromiseRejectMessage;
+use crate::SealedLocal;
 use crate::Value;
 use crate::fast_api::FastApiCallbackOptions;
 use crate::function::FunctionCallbackInfo;
@@ -256,6 +257,16 @@ impl<'s> HandleScope<'s, ()> {
   #[inline(always)]
   pub(crate) fn get_isolate_ptr(&self) -> *mut Isolate {
     data::ScopeData::get(self).get_isolate_ptr()
+  }
+
+  /// Open a handle passed from V8 in the current scope.
+  ///
+  /// # Safety
+  ///
+  /// The handle must be rooted in this scope.
+  #[inline(always)]
+  pub unsafe fn unseal<T>(&self, v: SealedLocal<T>) -> Local<'s, T> {
+    unsafe { Local::from_non_null(v.0) }
   }
 }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -3,16 +3,13 @@ use crate::Data;
 use crate::Isolate;
 use crate::Local;
 use crate::OwnedIsolate;
-use crate::external_references::ExternalReferences;
+use crate::external_references::ExternalReference;
 use crate::isolate_create_params::raw;
-use crate::support::Allocated;
 use crate::support::char;
 use crate::support::int;
 
-use std::borrow::Borrow;
-use std::convert::TryFrom;
+use std::borrow::Cow;
 use std::mem::MaybeUninit;
-use std::ops::Deref;
 
 unsafe extern "C" {
   fn v8__SnapshotCreator__CONSTRUCT(
@@ -26,7 +23,7 @@ unsafe extern "C" {
   fn v8__SnapshotCreator__CreateBlob(
     this: *mut SnapshotCreator,
     function_code_handling: FunctionCodeHandling,
-  ) -> StartupData;
+  ) -> RawStartupData;
   fn v8__SnapshotCreator__SetDefaultContext(
     this: *mut SnapshotCreator,
     context: *const Context,
@@ -44,42 +41,60 @@ unsafe extern "C" {
     context: *const Context,
     data: *const Data,
   ) -> usize;
-  fn v8__StartupData__DESTRUCT(this: *mut StartupData);
+  fn v8__StartupData__CanBeRehashed(this: *const RawStartupData) -> bool;
+  fn v8__StartupData__IsValid(this: *const RawStartupData) -> bool;
+  fn v8__StartupData__data__DELETE(this: *const char);
 }
 
-// TODO(piscisaureus): merge this struct with
-// `isolate_create_params::raw::StartupData`.
 #[repr(C)]
 #[derive(Debug)]
+pub(crate) struct RawStartupData {
+  pub(crate) data: *const char,
+  pub(crate) raw_size: int,
+}
+
+#[derive(Clone, Debug)]
 pub struct StartupData {
-  data: *const char,
-  raw_size: int,
+  data: Cow<'static, [u8]>,
 }
 
-impl Drop for StartupData {
-  fn drop(&mut self) {
-    unsafe { v8__StartupData__DESTRUCT(self) }
+impl StartupData {
+  /// Whether the data created can be rehashed and and the hash seed can be
+  /// recomputed when deserialized.
+  /// Only valid for StartupData returned by SnapshotCreator::CreateBlob().
+  pub fn can_be_rehashed(self) -> bool {
+    let tmp = RawStartupData {
+      data: self.data.as_ptr() as _,
+      raw_size: self.data.len() as _,
+    };
+    unsafe { v8__StartupData__CanBeRehashed(&tmp) }
+  }
+
+  /// Allows embedders to verify whether the data is valid for the current
+  /// V8 instance.
+  pub fn is_valid(&self) -> bool {
+    let tmp = RawStartupData {
+      data: self.data.as_ptr() as _,
+      raw_size: self.data.len() as _,
+    };
+    unsafe { v8__StartupData__IsValid(&tmp) }
   }
 }
 
-impl Deref for StartupData {
+impl std::ops::Deref for StartupData {
   type Target = [u8];
+
   fn deref(&self) -> &Self::Target {
-    let data = self.data;
-    let len = usize::try_from(self.raw_size).unwrap();
-    unsafe { std::slice::from_raw_parts(data as _, len) }
+    &self.data
   }
 }
 
-impl AsRef<[u8]> for StartupData {
-  fn as_ref(&self) -> &[u8] {
-    self
-  }
-}
-
-impl Borrow<[u8]> for StartupData {
-  fn borrow(&self) -> &[u8] {
-    self
+impl<T> From<T> for StartupData
+where
+  T: Into<Cow<'static, [u8]>>,
+{
+  fn from(value: T) -> Self {
+    Self { data: value.into() }
   }
 }
 
@@ -101,10 +116,10 @@ impl SnapshotCreator {
   #[inline(always)]
   #[allow(clippy::new_ret_no_self)]
   pub(crate) fn new(
-    external_references: Option<&'static ExternalReferences>,
+    external_references: Option<Cow<'static, [ExternalReference]>>,
     params: Option<crate::CreateParams>,
   ) -> OwnedIsolate {
-    Self::new_impl(external_references, None::<&[u8]>, params)
+    Self::new_impl(external_references, None, params)
   }
 
   /// Create an isolate, and set it up for serialization.
@@ -112,8 +127,8 @@ impl SnapshotCreator {
   #[inline(always)]
   #[allow(clippy::new_ret_no_self)]
   pub(crate) fn from_existing_snapshot(
-    existing_snapshot_blob: impl Allocated<[u8]>,
-    external_references: Option<&'static ExternalReferences>,
+    existing_snapshot_blob: StartupData,
+    external_references: Option<Cow<'static, [ExternalReference]>>,
     params: Option<crate::CreateParams>,
   ) -> OwnedIsolate {
     Self::new_impl(external_references, Some(existing_snapshot_blob), params)
@@ -124,15 +139,15 @@ impl SnapshotCreator {
   #[inline(always)]
   #[allow(clippy::new_ret_no_self)]
   fn new_impl(
-    external_references: Option<&'static ExternalReferences>,
-    existing_snapshot_blob: Option<impl Allocated<[u8]>>,
+    external_references: Option<Cow<'static, [ExternalReference]>>,
+    existing_snapshot_blob: Option<StartupData>,
     params: Option<crate::CreateParams>,
   ) -> OwnedIsolate {
     let mut snapshot_creator: MaybeUninit<Self> = MaybeUninit::uninit();
 
     let mut params = params.unwrap_or_default();
     if let Some(external_refs) = external_references {
-      params = params.external_references(&**external_refs);
+      params = params.external_references(external_refs);
     }
     if let Some(snapshot_blob) = existing_snapshot_blob {
       params = params.snapshot_blob(snapshot_blob);
@@ -221,7 +236,19 @@ impl SnapshotCreator {
       None
     } else {
       debug_assert!(blob.raw_size > 0);
-      Some(blob)
+
+      let data = Cow::from(
+        unsafe {
+          std::slice::from_raw_parts(blob.data as _, blob.raw_size as _)
+        }
+        .to_owned(),
+      );
+
+      unsafe {
+        v8__StartupData__data__DELETE(blob.data);
+      }
+
+      Some(StartupData { data })
     }
   }
 }

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,26 +1,21 @@
-use std::any::Any;
 use std::any::type_name;
 use std::borrow::Borrow;
 use std::borrow::BorrowMut;
 use std::convert::AsMut;
 use std::convert::AsRef;
 use std::convert::TryFrom;
-use std::convert::identity;
-use std::fmt::{self, Debug, Formatter};
+use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::mem::align_of;
 use std::mem::forget;
 use std::mem::needs_drop;
 use std::mem::size_of;
 use std::mem::take;
-use std::mem::transmute_copy;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::ptr::NonNull;
 use std::ptr::drop_in_place;
 use std::ptr::null_mut;
-use std::rc::Rc;
-use std::sync::Arc;
 use std::thread::yield_now;
 use std::time::Duration;
 use std::time::Instant;
@@ -366,105 +361,6 @@ fn assert_shared_ptr_use_count_eq<T: Shared>(
   );
 }
 
-/// A trait for values with static lifetimes that are allocated at a fixed
-/// address in memory. Practically speaking, that means they're either a
-/// `&'static` reference, or they're heap-allocated in a `Arc`, `Box`, `Rc`,
-/// `UniqueRef`, `SharedRef` or `Vec`.
-pub trait Allocated<T: ?Sized>:
-  Deref<Target = T> + Borrow<T> + 'static
-{
-}
-impl<A, T: ?Sized> Allocated<T> for A where
-  A: Deref<Target = T> + Borrow<T> + 'static
-{
-}
-
-pub(crate) enum Allocation<T: ?Sized + 'static> {
-  Static(&'static T),
-  Arc(Arc<T>),
-  Box(Box<T>),
-  Rc(Rc<T>),
-  UniqueRef(UniqueRef<T>),
-  Other(Box<dyn Borrow<T> + 'static>),
-  // Note: it would be nice to add `SharedRef` to this list, but it
-  // requires the `T: Shared` bound, and it's unfortunately not possible
-  // to set bounds on individual enum variants.
-}
-
-impl<T: ?Sized + 'static> Allocation<T> {
-  unsafe fn transmute_wrap<Abstract, Concrete>(
-    value: Abstract,
-    wrap: fn(Concrete) -> Self,
-  ) -> Self {
-    assert_eq!(size_of::<Abstract>(), size_of::<Concrete>());
-    let wrapped = wrap(unsafe { transmute_copy(&value) });
-    forget(value);
-    wrapped
-  }
-
-  fn try_wrap<Abstract: 'static, Concrete: 'static>(
-    value: Abstract,
-    wrap: fn(Concrete) -> Self,
-  ) -> Result<Self, Abstract> {
-    if <dyn Any>::is::<Concrete>(&value) {
-      Ok(unsafe { Self::transmute_wrap(value, wrap) })
-    } else {
-      Err(value)
-    }
-  }
-
-  pub fn of<Abstract: Deref<Target = T> + Borrow<T> + 'static>(
-    a: Abstract,
-  ) -> Self {
-    Self::try_wrap(a, identity)
-      .or_else(|a| Self::try_wrap(a, Self::Static))
-      .or_else(|a| Self::try_wrap(a, Self::Arc))
-      .or_else(|a| Self::try_wrap(a, Self::Box))
-      .or_else(|a| Self::try_wrap(a, Self::Rc))
-      .or_else(|a| Self::try_wrap(a, Self::UniqueRef))
-      .unwrap_or_else(|a| Self::Other(Box::from(a)))
-  }
-}
-
-impl<T: Debug + ?Sized> Debug for Allocation<T> {
-  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-    match self {
-      Allocation::Arc(r) => f.debug_tuple("Arc").field(&r).finish(),
-      Allocation::Box(b) => f.debug_tuple("Box").field(&b).finish(),
-      Allocation::Other(_) => f.debug_tuple("Other").finish(),
-      Allocation::Rc(r) => f.debug_tuple("Rc").field(&r).finish(),
-      Allocation::Static(s) => f.debug_tuple("Static").field(&s).finish(),
-      Allocation::UniqueRef(u) => f.debug_tuple("UniqueRef").field(&u).finish(),
-    }
-  }
-}
-
-impl<T: ?Sized> Deref for Allocation<T> {
-  type Target = T;
-  fn deref(&self) -> &Self::Target {
-    match self {
-      Self::Static(v) => v.borrow(),
-      Self::Arc(v) => v.borrow(),
-      Self::Box(v) => v.borrow(),
-      Self::Rc(v) => v.borrow(),
-      Self::UniqueRef(v) => v.borrow(),
-      Self::Other(v) => (**v).borrow(),
-    }
-  }
-}
-
-impl<T: ?Sized> AsRef<T> for Allocation<T> {
-  fn as_ref(&self) -> &T {
-    self
-  }
-}
-
-impl<T: ?Sized> Borrow<T> for Allocation<T> {
-  fn borrow(&self) -> &T {
-    self
-  }
-}
-
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq)]
 pub enum MaybeBool {
@@ -729,8 +625,6 @@ where
 mod tests {
   use super::*;
   use std::ptr::null;
-  use std::sync::atomic::AtomicBool;
-  use std::sync::atomic::Ordering;
 
   #[derive(Eq, PartialEq)]
   struct MockSharedObj {
@@ -830,97 +724,5 @@ mod tests {
   fn shared_ref_use_count_assertion_failed() {
     let shared_ref = SharedRef(MockSharedObj::SHARED_PTR_BASE_B);
     shared_ref.assert_use_count_eq(7);
-  }
-
-  static TEST_OBJ_DROPPED: AtomicBool = AtomicBool::new(false);
-
-  struct TestObj {
-    pub id: u32,
-  }
-
-  impl Drop for TestObj {
-    fn drop(&mut self) {
-      assert!(!TEST_OBJ_DROPPED.swap(true, Ordering::SeqCst));
-    }
-  }
-
-  struct TestObjRef(TestObj);
-
-  impl Deref for TestObjRef {
-    type Target = TestObj;
-
-    fn deref(&self) -> &TestObj {
-      &self.0
-    }
-  }
-
-  impl Borrow<TestObj> for TestObjRef {
-    fn borrow(&self) -> &TestObj {
-      self
-    }
-  }
-
-  #[test]
-  fn allocation() {
-    // Static.
-    static STATIC_OBJ: TestObj = TestObj { id: 1 };
-    let owner = Allocation::of(&STATIC_OBJ);
-    match owner {
-      Allocation::Static(_) => assert_eq!(owner.id, 1),
-      _ => panic!(),
-    }
-    drop(owner);
-    assert!(!TEST_OBJ_DROPPED.load(Ordering::SeqCst));
-
-    // Arc.
-    let owner = Allocation::of(Arc::new(TestObj { id: 2 }));
-    match owner {
-      Allocation::Arc(_) => assert_eq!(owner.id, 2),
-      _ => panic!(),
-    }
-    drop(owner);
-    assert!(TEST_OBJ_DROPPED.swap(false, Ordering::SeqCst));
-
-    // Box.
-    let owner = Allocation::of(Box::new(TestObj { id: 3 }));
-    match owner {
-      Allocation::Box(_) => assert_eq!(owner.id, 3),
-      _ => panic!(),
-    }
-    drop(owner);
-    assert!(TEST_OBJ_DROPPED.swap(false, Ordering::SeqCst));
-
-    // Rc.
-    let owner = Allocation::of(Rc::new(TestObj { id: 4 }));
-    match owner {
-      Allocation::Rc(_) => assert_eq!(owner.id, 4),
-      _ => panic!(),
-    }
-    drop(owner);
-    assert!(TEST_OBJ_DROPPED.swap(false, Ordering::SeqCst));
-
-    // Other.
-    let owner = Allocation::of(TestObjRef(TestObj { id: 5 }));
-    match owner {
-      Allocation::Other(_) => assert_eq!(owner.id, 5),
-      _ => panic!(),
-    }
-    drop(owner);
-    assert!(TEST_OBJ_DROPPED.swap(false, Ordering::SeqCst));
-
-    // Contents of Vec should not be moved.
-    let vec = vec![1u8, 2, 3, 5, 8, 13, 21];
-    let vec_element_ptrs =
-      vec.iter().map(|i| i as *const u8).collect::<Vec<_>>();
-    let owner = Allocation::of(vec);
-    match owner {
-      Allocation::Other(_) => {}
-      _ => panic!(),
-    }
-    owner
-      .iter()
-      .map(|i| i as *const u8)
-      .zip(vec_element_ptrs)
-      .for_each(|(p1, p2)| assert_eq!(p1, p2));
   }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -154,10 +154,10 @@ pub enum Intercepted {
   Yes,
 }
 
-pub type AccessorNameGetterCallback<'s> = NamedGetterCallbackForAccessor<'s>;
+pub type AccessorNameGetterCallback = NamedGetterCallbackForAccessor;
 
 /// Note: [ReturnValue] is ignored for accessors.
-pub type AccessorNameSetterCallback<'s> = NamedSetterCallbackForAccessor<'s>;
+pub type AccessorNameSetterCallback = NamedSetterCallbackForAccessor;
 
 /// Interceptor for get requests on an object.
 ///
@@ -166,7 +166,7 @@ pub type AccessorNameSetterCallback<'s> = NamedSetterCallbackForAccessor<'s>;
 /// not produce side effects.
 ///
 /// See also [ObjectTemplate::set_handler].
-pub type NamedPropertyGetterCallback<'s> = NamedGetterCallback<'s>;
+pub type NamedPropertyGetterCallback = NamedGetterCallback;
 
 /// Interceptor for set requests on an object.
 ///
@@ -178,7 +178,7 @@ pub type NamedPropertyGetterCallback<'s> = NamedGetterCallback<'s>;
 /// effects.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type NamedPropertySetterCallback<'s> = NamedSetterCallback<'s>;
+pub type NamedPropertySetterCallback = NamedSetterCallback;
 
 /// Intercepts all requests that query the attributes of the property, e.g.,
 /// getOwnPropertyDescriptor(), propertyIsEnumerable(), and defineProperty().
@@ -192,7 +192,7 @@ pub type NamedPropertySetterCallback<'s> = NamedSetterCallback<'s>;
 /// this interceptor depending on the state of the object.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type NamedPropertyQueryCallback<'s> = NamedQueryCallback<'s>;
+pub type NamedPropertyQueryCallback = NamedQueryCallback;
 
 /// Interceptor for delete requests on an object.
 ///
@@ -209,14 +209,14 @@ pub type NamedPropertyQueryCallback<'s> = NamedQueryCallback<'s>;
 /// in strict mode.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type NamedPropertyDeleterCallback<'s> = NamedDeleterCallback<'s>;
+pub type NamedPropertyDeleterCallback = NamedDeleterCallback;
 
 /// Returns an array containing the names of the properties the named property getter intercepts.
 ///
 /// Note: The values in the array must be of type v8::Name.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type NamedPropertyEnumeratorCallback<'s> = PropertyEnumeratorCallback<'s>;
+pub type NamedPropertyEnumeratorCallback = PropertyEnumeratorCallback;
 
 /// Interceptor for defineProperty requests on an object.
 ///
@@ -228,7 +228,7 @@ pub type NamedPropertyEnumeratorCallback<'s> = PropertyEnumeratorCallback<'s>;
 /// effects.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type NamedPropertyDefinerCallback<'s> = NamedDefinerCallback<'s>;
+pub type NamedPropertyDefinerCallback = NamedDefinerCallback;
 
 /// Interceptor for getOwnPropertyDescriptor requests on an object.
 ///
@@ -241,38 +241,38 @@ pub type NamedPropertyDefinerCallback<'s> = NamedDefinerCallback<'s>;
 /// true, i.e., indicate that the property was found.
 ///
 /// See also [ObjectTemplate::set_named_property_handler].
-pub type NamedPropertyDescriptorCallback<'s> = NamedGetterCallback<'s>;
+pub type NamedPropertyDescriptorCallback = NamedGetterCallback;
 
 /// See [GenericNamedPropertyGetterCallback].
-pub type IndexedPropertyGetterCallback<'s> = IndexedGetterCallback<'s>;
+pub type IndexedPropertyGetterCallback = IndexedGetterCallback;
 
 /// See [GenericNamedPropertySetterCallback].
-pub type IndexedPropertySetterCallback<'s> = IndexedSetterCallback<'s>;
+pub type IndexedPropertySetterCallback = IndexedSetterCallback;
 
 /// See [GenericNamedPropertyQueryCallback].
-pub type IndexedPropertyQueryCallback<'s> = IndexedQueryCallback<'s>;
+pub type IndexedPropertyQueryCallback = IndexedQueryCallback;
 
 /// See [GenericNamedPropertyDeleterCallback].
-pub type IndexedPropertyDeleterCallback<'s> = IndexedDeleterCallback<'s>;
+pub type IndexedPropertyDeleterCallback = IndexedDeleterCallback;
 
 /// See [GenericNamedPropertyEnumeratorCallback].
-pub type IndexedPropertyEnumeratorCallback<'s> = PropertyEnumeratorCallback<'s>;
+pub type IndexedPropertyEnumeratorCallback = PropertyEnumeratorCallback;
 
 /// See [GenericNamedPropertyDefinerCallback].
-pub type IndexedPropertyDefinerCallback<'s> = IndexedDefinerCallback<'s>;
+pub type IndexedPropertyDefinerCallback = IndexedDefinerCallback;
 
 /// See [GenericNamedPropertyDescriptorCallback].
-pub type IndexedPropertyDescriptorCallback<'s> = IndexedGetterCallback<'s>;
+pub type IndexedPropertyDescriptorCallback = IndexedGetterCallback;
 
 pub struct AccessorConfiguration<'s> {
-  pub(crate) getter: AccessorNameGetterCallback<'s>,
-  pub(crate) setter: Option<AccessorNameSetterCallback<'s>>,
+  pub(crate) getter: AccessorNameGetterCallback,
+  pub(crate) setter: Option<AccessorNameSetterCallback>,
   pub(crate) data: Option<Local<'s, Value>>,
   pub(crate) property_attribute: PropertyAttribute,
 }
 
 impl<'s> AccessorConfiguration<'s> {
-  pub fn new(getter: impl MapFnTo<AccessorNameGetterCallback<'s>>) -> Self {
+  pub fn new(getter: impl MapFnTo<AccessorNameGetterCallback>) -> Self {
     Self {
       getter: getter.map_fn_to(),
       setter: None,
@@ -283,7 +283,7 @@ impl<'s> AccessorConfiguration<'s> {
 
   pub fn setter(
     mut self,
-    setter: impl MapFnTo<AccessorNameSetterCallback<'s>>,
+    setter: impl MapFnTo<AccessorNameSetterCallback>,
   ) -> Self {
     self.setter = Some(setter.map_fn_to());
     self
@@ -306,13 +306,13 @@ impl<'s> AccessorConfiguration<'s> {
 
 #[derive(Default)]
 pub struct NamedPropertyHandlerConfiguration<'s> {
-  pub(crate) getter: Option<NamedPropertyGetterCallback<'s>>,
-  pub(crate) setter: Option<NamedPropertySetterCallback<'s>>,
-  pub(crate) query: Option<NamedPropertyQueryCallback<'s>>,
-  pub(crate) deleter: Option<NamedPropertyDeleterCallback<'s>>,
-  pub(crate) enumerator: Option<NamedPropertyEnumeratorCallback<'s>>,
-  pub(crate) definer: Option<NamedPropertyDefinerCallback<'s>>,
-  pub(crate) descriptor: Option<NamedPropertyDescriptorCallback<'s>>,
+  pub(crate) getter: Option<NamedPropertyGetterCallback>,
+  pub(crate) setter: Option<NamedPropertySetterCallback>,
+  pub(crate) query: Option<NamedPropertyQueryCallback>,
+  pub(crate) deleter: Option<NamedPropertyDeleterCallback>,
+  pub(crate) enumerator: Option<NamedPropertyEnumeratorCallback>,
+  pub(crate) definer: Option<NamedPropertyDefinerCallback>,
+  pub(crate) descriptor: Option<NamedPropertyDescriptorCallback>,
   pub(crate) data: Option<Local<'s, Value>>,
   pub(crate) flags: PropertyHandlerFlags,
 }
@@ -345,62 +345,59 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn getter(
     mut self,
-    getter: impl MapFnTo<NamedPropertyGetterCallback<'s>>,
+    getter: impl MapFnTo<NamedPropertyGetterCallback>,
   ) -> Self {
     self.getter = Some(getter.map_fn_to());
     self
   }
 
-  pub fn getter_raw(mut self, getter: NamedPropertyGetterCallback<'s>) -> Self {
+  pub fn getter_raw(mut self, getter: NamedPropertyGetterCallback) -> Self {
     self.getter = Some(getter);
     self
   }
 
   pub fn setter(
     mut self,
-    setter: impl MapFnTo<NamedPropertySetterCallback<'s>>,
+    setter: impl MapFnTo<NamedPropertySetterCallback>,
   ) -> Self {
     self.setter = Some(setter.map_fn_to());
     self
   }
 
-  pub fn setter_raw(mut self, setter: NamedPropertySetterCallback<'s>) -> Self {
+  pub fn setter_raw(mut self, setter: NamedPropertySetterCallback) -> Self {
     self.setter = Some(setter);
     self
   }
 
   pub fn query(
     mut self,
-    query: impl MapFnTo<NamedPropertyQueryCallback<'s>>,
+    query: impl MapFnTo<NamedPropertyQueryCallback>,
   ) -> Self {
     self.query = Some(query.map_fn_to());
     self
   }
 
-  pub fn query_raw(mut self, query: NamedPropertyQueryCallback<'s>) -> Self {
+  pub fn query_raw(mut self, query: NamedPropertyQueryCallback) -> Self {
     self.query = Some(query);
     self
   }
 
   pub fn deleter(
     mut self,
-    deleter: impl MapFnTo<NamedPropertyDeleterCallback<'s>>,
+    deleter: impl MapFnTo<NamedPropertyDeleterCallback>,
   ) -> Self {
     self.deleter = Some(deleter.map_fn_to());
     self
   }
 
-  pub fn deleter_raw(
-    mut self,
-    deleter: NamedPropertyDeleterCallback<'s>,
-  ) -> Self {
+  pub fn deleter_raw(mut self, deleter: NamedPropertyDeleterCallback) -> Self {
     self.deleter = Some(deleter);
     self
   }
 
   pub fn enumerator(
     mut self,
-    enumerator: impl MapFnTo<NamedPropertyEnumeratorCallback<'s>>,
+    enumerator: impl MapFnTo<NamedPropertyEnumeratorCallback>,
   ) -> Self {
     self.enumerator = Some(enumerator.map_fn_to());
     self
@@ -408,7 +405,7 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn enumerator_raw(
     mut self,
-    enumerator: NamedPropertyEnumeratorCallback<'s>,
+    enumerator: NamedPropertyEnumeratorCallback,
   ) -> Self {
     self.enumerator = Some(enumerator);
     self
@@ -416,23 +413,20 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn definer(
     mut self,
-    definer: impl MapFnTo<NamedPropertyDefinerCallback<'s>>,
+    definer: impl MapFnTo<NamedPropertyDefinerCallback>,
   ) -> Self {
     self.definer = Some(definer.map_fn_to());
     self
   }
 
-  pub fn definer_raw(
-    mut self,
-    definer: NamedPropertyDefinerCallback<'s>,
-  ) -> Self {
+  pub fn definer_raw(mut self, definer: NamedPropertyDefinerCallback) -> Self {
     self.definer = Some(definer);
     self
   }
 
   pub fn descriptor(
     mut self,
-    descriptor: impl MapFnTo<NamedPropertyDescriptorCallback<'s>>,
+    descriptor: impl MapFnTo<NamedPropertyDescriptorCallback>,
   ) -> Self {
     self.descriptor = Some(descriptor.map_fn_to());
     self
@@ -440,7 +434,7 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
   pub fn descriptor_raw(
     mut self,
-    descriptor: NamedPropertyDescriptorCallback<'s>,
+    descriptor: NamedPropertyDescriptorCallback,
   ) -> Self {
     self.descriptor = Some(descriptor);
     self
@@ -461,13 +455,13 @@ impl<'s> NamedPropertyHandlerConfiguration<'s> {
 
 #[derive(Default)]
 pub struct IndexedPropertyHandlerConfiguration<'s> {
-  pub(crate) getter: Option<IndexedPropertyGetterCallback<'s>>,
-  pub(crate) setter: Option<IndexedPropertySetterCallback<'s>>,
-  pub(crate) query: Option<IndexedPropertyQueryCallback<'s>>,
-  pub(crate) deleter: Option<IndexedPropertyDeleterCallback<'s>>,
-  pub(crate) enumerator: Option<IndexedPropertyEnumeratorCallback<'s>>,
-  pub(crate) definer: Option<IndexedPropertyDefinerCallback<'s>>,
-  pub(crate) descriptor: Option<IndexedPropertyDescriptorCallback<'s>>,
+  pub(crate) getter: Option<IndexedPropertyGetterCallback>,
+  pub(crate) setter: Option<IndexedPropertySetterCallback>,
+  pub(crate) query: Option<IndexedPropertyQueryCallback>,
+  pub(crate) deleter: Option<IndexedPropertyDeleterCallback>,
+  pub(crate) enumerator: Option<IndexedPropertyEnumeratorCallback>,
+  pub(crate) definer: Option<IndexedPropertyDefinerCallback>,
+  pub(crate) descriptor: Option<IndexedPropertyDescriptorCallback>,
   pub(crate) data: Option<Local<'s, Value>>,
   pub(crate) flags: PropertyHandlerFlags,
 }
@@ -500,52 +494,46 @@ impl<'s> IndexedPropertyHandlerConfiguration<'s> {
 
   pub fn getter(
     mut self,
-    getter: impl MapFnTo<IndexedPropertyGetterCallback<'s>>,
+    getter: impl MapFnTo<IndexedPropertyGetterCallback>,
   ) -> Self {
     self.getter = Some(getter.map_fn_to());
     self
   }
 
-  pub fn getter_raw(
-    mut self,
-    getter: IndexedPropertyGetterCallback<'s>,
-  ) -> Self {
+  pub fn getter_raw(mut self, getter: IndexedPropertyGetterCallback) -> Self {
     self.getter = Some(getter);
     self
   }
 
   pub fn setter(
     mut self,
-    setter: impl MapFnTo<IndexedPropertySetterCallback<'s>>,
+    setter: impl MapFnTo<IndexedPropertySetterCallback>,
   ) -> Self {
     self.setter = Some(setter.map_fn_to());
     self
   }
 
-  pub fn setter_raw(
-    mut self,
-    setter: IndexedPropertySetterCallback<'s>,
-  ) -> Self {
+  pub fn setter_raw(mut self, setter: IndexedPropertySetterCallback) -> Self {
     self.setter = Some(setter);
     self
   }
 
   pub fn query(
     mut self,
-    query: impl MapFnTo<IndexedPropertyQueryCallback<'s>>,
+    query: impl MapFnTo<IndexedPropertyQueryCallback>,
   ) -> Self {
     self.query = Some(query.map_fn_to());
     self
   }
 
-  pub fn query_raw(mut self, query: IndexedPropertyQueryCallback<'s>) -> Self {
+  pub fn query_raw(mut self, query: IndexedPropertyQueryCallback) -> Self {
     self.query = Some(query);
     self
   }
 
   pub fn deleter(
     mut self,
-    deleter: impl MapFnTo<IndexedPropertyDeleterCallback<'s>>,
+    deleter: impl MapFnTo<IndexedPropertyDeleterCallback>,
   ) -> Self {
     self.deleter = Some(deleter.map_fn_to());
     self
@@ -553,7 +541,7 @@ impl<'s> IndexedPropertyHandlerConfiguration<'s> {
 
   pub fn deleter_raw(
     mut self,
-    deleter: IndexedPropertyDeleterCallback<'s>,
+    deleter: IndexedPropertyDeleterCallback,
   ) -> Self {
     self.deleter = Some(deleter);
     self
@@ -561,7 +549,7 @@ impl<'s> IndexedPropertyHandlerConfiguration<'s> {
 
   pub fn enumerator(
     mut self,
-    enumerator: impl MapFnTo<IndexedPropertyEnumeratorCallback<'s>>,
+    enumerator: impl MapFnTo<IndexedPropertyEnumeratorCallback>,
   ) -> Self {
     self.enumerator = Some(enumerator.map_fn_to());
     self
@@ -569,7 +557,7 @@ impl<'s> IndexedPropertyHandlerConfiguration<'s> {
 
   pub fn enumerator_raw(
     mut self,
-    enumerator: IndexedPropertyEnumeratorCallback<'s>,
+    enumerator: IndexedPropertyEnumeratorCallback,
   ) -> Self {
     self.enumerator = Some(enumerator);
     self
@@ -577,7 +565,7 @@ impl<'s> IndexedPropertyHandlerConfiguration<'s> {
 
   pub fn definer(
     mut self,
-    definer: impl MapFnTo<IndexedPropertyDefinerCallback<'s>>,
+    definer: impl MapFnTo<IndexedPropertyDefinerCallback>,
   ) -> Self {
     self.definer = Some(definer.map_fn_to());
     self
@@ -585,7 +573,7 @@ impl<'s> IndexedPropertyHandlerConfiguration<'s> {
 
   pub fn definer_raw(
     mut self,
-    definer: IndexedPropertyDefinerCallback<'s>,
+    definer: IndexedPropertyDefinerCallback,
   ) -> Self {
     self.definer = Some(definer);
     self
@@ -593,7 +581,7 @@ impl<'s> IndexedPropertyHandlerConfiguration<'s> {
 
   pub fn descriptor(
     mut self,
-    descriptor: impl MapFnTo<IndexedPropertyDescriptorCallback<'s>>,
+    descriptor: impl MapFnTo<IndexedPropertyDescriptorCallback>,
   ) -> Self {
     self.descriptor = Some(descriptor.map_fn_to());
     self
@@ -601,7 +589,7 @@ impl<'s> IndexedPropertyHandlerConfiguration<'s> {
 
   pub fn descriptor_raw(
     mut self,
-    descriptor: IndexedPropertyDescriptorCallback<'s>,
+    descriptor: IndexedPropertyDescriptorCallback,
   ) -> Self {
     self.descriptor = Some(descriptor);
     self
@@ -917,7 +905,7 @@ impl ObjectTemplate {
   pub fn set_accessor(
     &self,
     key: Local<Name>,
-    getter: impl for<'s> MapFnTo<AccessorNameGetterCallback<'s>>,
+    getter: impl MapFnTo<AccessorNameGetterCallback>,
   ) {
     self
       .set_accessor_with_configuration(key, AccessorConfiguration::new(getter));
@@ -927,8 +915,8 @@ impl ObjectTemplate {
   pub fn set_accessor_with_setter(
     &self,
     key: Local<Name>,
-    getter: impl for<'s> MapFnTo<AccessorNameGetterCallback<'s>>,
-    setter: impl for<'s> MapFnTo<AccessorNameSetterCallback<'s>>,
+    getter: impl MapFnTo<AccessorNameGetterCallback>,
+    setter: impl MapFnTo<AccessorNameSetterCallback>,
   ) {
     self.set_accessor_with_configuration(
       key,

--- a/tests/test_external_deserialize.rs
+++ b/tests/test_external_deserialize.rs
@@ -17,20 +17,18 @@ fn external_deserialize() {
   v8::V8::initialize();
 
   let blob = {
-    let external_references = v8::ExternalReferences::new(&[
+    let external_references = [
       v8::ExternalReference {
         function: callback.map_fn_to(),
       },
       v8::ExternalReference { pointer: 1 as _ },
-    ]);
+      v8::ExternalReference {
+        pointer: std::ptr::null_mut(),
+      },
+    ];
 
     let mut isolate = v8::Isolate::snapshot_creator(
-      Some(unsafe {
-        std::mem::transmute::<
-          &v8::ExternalReferences,
-          &'static v8::ExternalReferences,
-        >(&external_references)
-      }),
+      Some(external_references.to_vec().into()),
       Some(v8::CreateParams::default()),
     );
 
@@ -55,30 +53,36 @@ fn external_deserialize() {
   };
 
   {
-    let external_references = v8::ExternalReferences::new(&[
+    let external_references = [
       v8::ExternalReference {
         function: callback.map_fn_to(),
       },
       v8::ExternalReference { pointer: 2 as _ },
-    ]);
+      v8::ExternalReference {
+        pointer: std::ptr::null_mut(),
+      },
+    ];
 
     let mut _isolate_a = v8::Isolate::new(
       v8::CreateParams::default()
-        .snapshot_blob(blob.to_vec())
-        .external_references(external_references),
+        .snapshot_blob(blob.clone())
+        .external_references(external_references.to_vec().into()),
     );
 
-    let external_references = v8::ExternalReferences::new(&[
+    let external_references = [
       v8::ExternalReference {
         function: callback.map_fn_to(),
       },
       v8::ExternalReference { pointer: 3 as _ },
-    ]);
+      v8::ExternalReference {
+        pointer: std::ptr::null_mut(),
+      },
+    ];
 
     let mut isolate_b = v8::Isolate::new(
       v8::CreateParams::default()
         .snapshot_blob(blob)
-        .external_references(external_references),
+        .external_references(external_references.to_vec().into()),
     );
 
     {


### PR DESCRIPTION
Simpify apis for isolate-owned data (startup snapshot and external references). Notably this finally makes it possible to use external references without `transmute`. function callbacks are also refactored to get rid of the incorrect lifetime they contained, which leaked into ExternalReference.