### PR TITLE
Add Context::{get,set}_embedder_data

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2056,6 +2056,16 @@ void v8__Context__SetAlignedPointerInEmbedderData(v8::Context& self, int index,
   ptr_to_local(&self)->SetAlignedPointerInEmbedderData(index, value);
 }
 
+const v8::Value* v8__Context__GetEmbedderData(const v8::Context& self,
+                                              int index) {
+  return local_to_ptr(ptr_to_local(&self)->GetEmbedderData(index));
+}
+
+void v8__Context__SetEmbedderData(v8::Context& self, int index,
+                                  const v8::Value* value) {
+  ptr_to_local(&self)->SetEmbedderData(index, ptr_to_local(value));
+}
+
 const v8::Data* v8__Context__GetDataFromSnapshotOnce(v8::Context& self,
                                                      size_t index) {
   return maybe_local_to_ptr(

--- a/src/context.rs
+++ b/src/context.rs
@@ -39,6 +39,15 @@ unsafe extern "C" {
     index: int,
     value: *mut c_void,
   );
+  fn v8__Context__GetEmbedderData(
+    this: *const Context,
+    index: int,
+  ) -> *const Value;
+  fn v8__Context__SetEmbedderData(
+    this: *const Context,
+    index: int,
+    value: *const Value,
+  );
   fn v8__Context__FromSnapshot(
     isolate: *mut Isolate,
     context_snapshot_index: usize,
@@ -301,6 +310,27 @@ impl Context {
         );
       };
     }
+  }
+
+  /// Sets the embedder data with the given index, growing the data as needed.
+  ///
+  /// Note that index 0 currently has a special meaning for Chrome's debugger.
+  #[inline(always)]
+  pub fn set_embedder_data(&self, slot: i32, data: Local<'_, Value>) {
+    unsafe {
+      v8__Context__SetEmbedderData(self, slot, &*data);
+    }
+  }
+
+  /// Gets the embedder data with the given index, which must have been set by
+  /// a previous call to SetEmbedderData with the same index.
+  #[inline(always)]
+  pub fn get_embedder_data<'s>(
+    &self,
+    scope: &mut HandleScope<'s, ()>,
+    slot: i32,
+  ) -> Option<Local<'s, Value>> {
+    unsafe { scope.cast_local(|_| v8__Context__GetEmbedderData(self, slot)) }
   }
 
   #[inline(always)]


### PR DESCRIPTION
Similar to `set_aligned_pointer_in_embedder_data` but lets you set `Value`s rather than pointers.