### PR TITLE
Remove v8_enable_shared_ro_heap=false and v8_enable_verify_heap=false

### DIFF
--- a/.gn
+++ b/.gn
@@ -64,17 +64,6 @@ default_args = {
   v8_array_buffer_internal_field_count = 2
   v8_array_buffer_view_internal_field_count = 2
 
-  # Enabling the shared read-only heap comes with a restriction that all
-  # isolates running at the same time must be created from the same snapshot.
-  # This is problematic for Deno, which has separate "runtime" and "typescript
-  # compiler" snapshots, and sometimes uses them both at the same time.
-  v8_enable_shared_ro_heap = false
-
-  # V8 11.6 hardcoded an assumption in `mksnapshot` that shared RO heap
-  # is enabled. In our case it's disabled so without this flag we can't
-  # compile.
-  v8_enable_verify_heap = false
-
   # Enable V8 object print for debugging.
   # v8_enable_object_print = true
 


### PR DESCRIPTION
v8_enable_shared_ro_heap is no longer configurable since https://github.com/v8/v8/commit/b3054f77d65ea96ddf6e0a526abadebd91d7114e.

This also removes the justification for setting `v8_enable_verify_heap=false` so remove that too.