### PR TITLE
cppgc: Fix doctest

### DIFF
--- a/src/cppgc.rs
+++ b/src/cppgc.rs
@@ -182,12 +182,12 @@ pub unsafe fn shutdown_process() {
 ///
 /// struct Foo { foo: Member<Foo> }
 ///
-/// impl GarbageCollected for Foo {
+/// unsafe impl GarbageCollected for Foo {
 ///   fn trace(&self, visitor: &Visitor) {
 ///     visitor.trace(&self.foo);
 ///   }
 ///
-///   fn get_name(&self) -> &'static CStr {
+///   fn get_name(&self) -> &'static std::ffi::CStr {
 ///     c"Foo"
 ///   }
 /// }


### PR DESCRIPTION
Followup to #1802 

This fixes plain `cargo test`, which for some reason isn't what CI runs. :)