### PR TITLE
Inline some obvious candidates (ops, small functions)

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -374,6 +374,7 @@ impl Deref for BackingStore {
   type Target = [Cell<u8>];
 
   /// Returns a [u8] slice refencing the data in the backing store.
+  #[inline]
   fn deref(&self) -> &Self::Target {
     // We use a dangling pointer if `self.data()` returns None because it's UB
     // to create even an empty slice from a null pointer.
@@ -387,26 +388,32 @@ impl Deref for BackingStore {
 }
 
 impl Drop for BackingStore {
+  #[inline]
   fn drop(&mut self) {
     unsafe { v8__BackingStore__DELETE(self) };
   }
 }
 
 impl Shared for BackingStore {
+  #[inline]
   fn clone(ptr: &SharedPtrBase<Self>) -> SharedPtrBase<Self> {
     unsafe { std__shared_ptr__v8__BackingStore__COPY(ptr) }
   }
+  #[inline]
   fn from_unique_ptr(unique_ptr: UniquePtr<Self>) -> SharedPtrBase<Self> {
     unsafe {
       std__shared_ptr__v8__BackingStore__CONVERT__std__unique_ptr(unique_ptr)
     }
   }
+  #[inline]
   fn get(ptr: &SharedPtrBase<Self>) -> *const Self {
     unsafe { std__shared_ptr__v8__BackingStore__get(ptr) }
   }
+  #[inline]
   fn reset(ptr: &mut SharedPtrBase<Self>) {
     unsafe { std__shared_ptr__v8__BackingStore__reset(ptr) }
   }
+  #[inline]
   fn use_count(ptr: &SharedPtrBase<Self>) -> long {
     unsafe { std__shared_ptr__v8__BackingStore__use_count(ptr) }
   }

--- a/src/data.rs
+++ b/src/data.rs
@@ -133,6 +133,7 @@ macro_rules! impl_deref {
   { $target:ident for $type:ident } => {
     impl Deref for $type {
       type Target = $target;
+      #[inline]
       fn deref(&self) -> &Self::Target {
         unsafe { &*(self as *const _ as *const Self::Target) }
       }
@@ -143,6 +144,7 @@ macro_rules! impl_deref {
 macro_rules! impl_from {
   { $source:ident for $type:ident } => {
     impl<'s> From<Local<'s, $source>> for Local<'s, $type> {
+      #[inline]
       fn from(l: Local<'s, $source>) -> Self {
         unsafe { transmute(l) }
       }
@@ -154,9 +156,11 @@ macro_rules! impl_try_from {
   { $source:ident for $target:ident if $value:pat => $check:expr } => {
     impl<'s> TryFrom<Local<'s, $source>> for Local<'s, $target> {
       type Error = DataError;
+      #[inline]
       fn try_from(l: Local<'s, $source>) -> Result<Self, Self::Error> {
         // Not dead: `cast()` is sometimes used in the $check expression.
         #[allow(dead_code)]
+        #[inline(always)]
         fn cast<T>(l: Local<$source>) -> Local<T> {
           unsafe { transmute::<Local<$source>, Local<T>>(l) }
         }
@@ -190,6 +194,7 @@ macro_rules! impl_hash {
 macro_rules! impl_partial_eq {
   { $rhs:ident for $type:ident use identity } => {
     impl<'s> PartialEq<$rhs> for $type {
+      #[inline]
       fn eq(&self, other: &$rhs) -> bool {
         let a = self as *const _ as *const Data;
         let b = other as *const _ as *const Data;
@@ -199,6 +204,7 @@ macro_rules! impl_partial_eq {
   };
   { $rhs:ident for $type:ident use strict_equals } => {
     impl<'s> PartialEq<$rhs> for $type {
+      #[inline]
       fn eq(&self, other: &$rhs) -> bool {
         let a = self as *const _ as *const Value;
         let b = other as *const _ as *const Value;
@@ -209,6 +215,7 @@ macro_rules! impl_partial_eq {
 
   { $rhs:ident for $type:ident use same_value_zero } => {
     impl<'s> PartialEq<$rhs> for $type {
+      #[inline]
       fn eq(&self, other: &$rhs) -> bool {
         let a = self as *const _ as *const Value;
         let b = other as *const _ as *const Value;

--- a/src/object.rs
+++ b/src/object.rs
@@ -694,6 +694,7 @@ impl Object {
       .into()
   }
 
+  #[inline]
   pub fn delete_index(
     &self,
     scope: &mut HandleScope,
@@ -933,6 +934,7 @@ impl Object {
 
   /// Implements Object.getOwnPropertyDescriptor(O, P), see
   /// https://tc39.es/ecma262/#sec-object.getownpropertydescriptor.
+  #[inline]
   pub fn get_own_property_descriptor<'s>(
     &self,
     scope: &mut HandleScope<'s>,
@@ -956,6 +958,7 @@ impl Object {
   ///
   /// Also returns a boolean, indicating whether the returned array contains
   /// key & values (for example when the value is Set.entries()).
+  #[inline]
   pub fn preview_entries<'s>(
     &self,
     scope: &mut HandleScope<'s>,

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -823,12 +823,14 @@ macro_rules! impl_deref {
   (<$($params:tt),+> $src_type:ty as $tgt_type:ty) => {
     impl<$($params),*> Deref for $src_type {
       type Target = $tgt_type;
+      #[inline]
       fn deref(&self) -> &Self::Target {
         self.as_ref()
       }
     }
 
     impl<$($params),*> DerefMut for $src_type {
+      #[inline]
       fn deref_mut(&mut self) -> &mut Self::Target {
         self.as_mut()
       }
@@ -1014,12 +1016,14 @@ mod param {
   }
 
   impl NewHandleScopeWithContext<'_> for Isolate {
+    #[inline]
     fn get_isolate_mut(&mut self) -> &mut Isolate {
       self
     }
   }
 
   impl NewHandleScopeWithContext<'_> for OwnedIsolate {
+    #[inline]
     fn get_isolate_mut(&mut self) -> &mut Isolate {
       &mut *self
     }
@@ -1189,6 +1193,7 @@ mod param {
     type NewScope: Scope;
     const NEEDS_SCOPE: bool = false;
 
+    #[inline]
     fn get_context(&self) -> Option<Local<'s, Context>> {
       None
     }
@@ -1218,6 +1223,7 @@ mod param {
   impl<'s> NewCallbackScope<'s> for Local<'s, Context> {
     type NewScope = CallbackScope<'s>;
 
+    #[inline]
     fn get_context(&self) -> Option<Local<'s, Context>> {
       Some(*self)
     }
@@ -1247,48 +1253,56 @@ mod getter {
   }
 
   impl<'s> GetIsolate<'s> for &'s mut Isolate {
+    #[inline]
     unsafe fn get_isolate_mut(self) -> &'s mut Isolate {
       self
     }
   }
 
   impl<'s> GetIsolate<'s> for &'s mut OwnedIsolate {
+    #[inline]
     unsafe fn get_isolate_mut(self) -> &'s mut Isolate {
       &mut *self
     }
   }
 
   impl<'s> GetIsolate<'s> for &'s FunctionCallbackInfo {
+    #[inline]
     unsafe fn get_isolate_mut(self) -> &'s mut Isolate {
       unsafe { &mut *self.get_isolate_ptr() }
     }
   }
 
   impl<'s, T> GetIsolate<'s> for &'s PropertyCallbackInfo<T> {
+    #[inline]
     unsafe fn get_isolate_mut(self) -> &'s mut Isolate {
       unsafe { &mut *self.get_isolate_ptr() }
     }
   }
 
   impl<'s> GetIsolate<'s> for &'s FastApiCallbackOptions<'s> {
+    #[inline]
     unsafe fn get_isolate_mut(self) -> &'s mut Isolate {
       unsafe { &mut *self.isolate }
     }
   }
 
   impl<'s> GetIsolate<'s> for Local<'s, Context> {
+    #[inline]
     unsafe fn get_isolate_mut(self) -> &'s mut Isolate {
       unsafe { &mut *raw::v8__Context__GetIsolate(&*self) }
     }
   }
 
   impl<'s> GetIsolate<'s> for Local<'s, Message> {
+    #[inline]
     unsafe fn get_isolate_mut(self) -> &'s mut Isolate {
       unsafe { &mut *raw::v8__Message__GetIsolate(&*self) }
     }
   }
 
   impl<'s, T: Into<Local<'s, Object>>> GetIsolate<'s> for T {
+    #[inline]
     unsafe fn get_isolate_mut(self) -> &'s mut Isolate {
       let object: Local<Object> = self.into();
       unsafe { &mut *raw::v8__Object__GetIsolate(&*object) }
@@ -1296,6 +1310,7 @@ mod getter {
   }
 
   impl<'s> GetIsolate<'s> for &'s PromiseRejectMessage<'s> {
+    #[inline]
     unsafe fn get_isolate_mut(self) -> &'s mut Isolate {
       let object: Local<Object> = self.get_promise().into();
       unsafe { &mut *raw::v8__Object__GetIsolate(&*object) }
@@ -1313,12 +1328,14 @@ mod getter {
   }
 
   impl GetScopeData for Isolate {
+    #[inline]
     fn get_scope_data_mut(&mut self) -> &mut data::ScopeData {
       data::ScopeData::get_root_mut(self)
     }
   }
 
   impl GetScopeData for OwnedIsolate {
+    #[inline]
     fn get_scope_data_mut(&mut self) -> &mut data::ScopeData {
       data::ScopeData::get_root_mut(self)
     }
@@ -2103,6 +2120,7 @@ mod raw {
     ///
     /// This function is marked unsafe because the caller must ensure that the
     /// returned value isn't dropped before `init()` has been called.
+    #[inline]
     pub unsafe fn uninit() -> Self {
       Self(unsafe { MaybeUninit::uninit().assume_init() })
     }
@@ -2111,6 +2129,7 @@ mod raw {
     /// once, no more and no less, after creating a
     /// `DisallowJavascriptExecutionScope` value with
     /// `DisallowJavascriptExecutionScope::uninit()`.
+    #[inline]
     pub unsafe fn init(
       &mut self,
       isolate: NonNull<Isolate>,
@@ -2143,6 +2162,7 @@ mod raw {
     ///
     /// This function is marked unsafe because the caller must ensure that the
     /// returned value isn't dropped before `init()` has been called.
+    #[inline]
     pub unsafe fn uninit() -> Self {
       Self(unsafe { MaybeUninit::uninit().assume_init() })
     }
@@ -2151,6 +2171,7 @@ mod raw {
     /// once, no more and no less, after creating an
     /// `AllowJavascriptExecutionScope` value with
     /// `AllowJavascriptExecutionScope::uninit()`.
+    #[inline]
     pub unsafe fn init(&mut self, isolate: NonNull<Isolate>) {
       unsafe {
         let buf = NonNull::from(self).cast();

--- a/src/string.rs
+++ b/src/string.rs
@@ -182,17 +182,20 @@ impl ExternalOneByteStringResource {
   /// Returns a pointer to the data owned by this resource.
   /// This pointer is valid as long as the resource is alive.
   /// The data is guaranteed to be Latin-1.
+  #[inline]
   pub fn data(&self) -> *const char {
     unsafe { v8__ExternalOneByteStringResource__data(self) }
   }
 
   /// Returns the length of the data owned by this resource.
+  #[inline]
   pub fn length(&self) -> usize {
     unsafe { v8__ExternalOneByteStringResource__length(self) }
   }
 
   /// Returns the data owned by this resource as a string slice.
   /// The data is guaranteed to be Latin-1.
+  #[inline]
   pub fn as_bytes(&self) -> &[u8] {
     let len = self.length();
     if len == 0 {
@@ -870,6 +873,7 @@ impl String {
   /// Get the ExternalStringResource for an external string.
   ///
   /// Returns None if is_external() doesn't return true.
+  #[inline]
   pub fn get_external_string_resource(
     &self,
   ) -> Option<NonNull<ExternalStringResource>> {
@@ -879,6 +883,7 @@ impl String {
   /// Get the ExternalOneByteStringResource for an external one-byte string.
   ///
   /// Returns None if is_external_onebyte() doesn't return true.
+  #[inline]
   pub fn get_external_onebyte_string_resource(
     &self,
   ) -> Option<NonNull<ExternalOneByteStringResource>> {
@@ -1121,6 +1126,7 @@ impl String {
   }
 }
 
+#[inline]
 pub unsafe extern "C" fn free_rust_external_onebyte(s: *mut char, len: usize) {
   unsafe {
     let slice = std::slice::from_raw_parts_mut(s, len);


### PR DESCRIPTION
While benchmarking `facet-v8`, some surprising `rusty_v8` functions showed up that I would have expected to be either compiled out or be direct calls to the C ABI shim - even with LTO enabled.

I went and added `#[inline]` to a bunch of functions that looked like they should have it - particularly `v8::HandleScope::deref/_mut()`, which seemed to affect inlining heuristics nicely, giving a small perf boost.