### PR TITLE
cppgc cleanup

### DIFF
--- a/examples/cppgc-object.rs
+++ b/examples/cppgc-object.rs
@@ -7,7 +7,7 @@ struct Wrappable {
 }
 
 unsafe impl v8::cppgc::GarbageCollected for Wrappable {
-  fn trace(&self, _visitor: &v8::cppgc::Visitor) {
+  fn trace(&self, _visitor: &mut v8::cppgc::Visitor) {
     println!("Wrappable::trace() {}", self.id);
     self
       .trace_count

--- a/examples/cppgc.rs
+++ b/examples/cppgc.rs
@@ -34,7 +34,7 @@ impl Rope {
 }
 
 unsafe impl v8::cppgc::GarbageCollected for Rope {
-  fn trace(&self, visitor: &v8::cppgc::Visitor) {
+  fn trace(&self, visitor: &mut v8::cppgc::Visitor) {
     visitor.trace(&self.next);
   }
 

--- a/tests/test_cppgc.rs
+++ b/tests/test_cppgc.rs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 the Deno authors. All rights reserved. MIT license.
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use v8::cppgc::{GarbageCollected, GcCell, Member, Ptr, Traced, Visitor};
 
@@ -69,7 +70,7 @@ macro_rules! test {
       }
 
       unsafe impl GarbageCollected for Wrap {
-        fn trace(&self, visitor: &Visitor) {
+        fn trace(&self, visitor: &mut Visitor) {
           TRACE_COUNT.fetch_add(1, Ordering::SeqCst);
           visitor.trace(&self.value);
         }
@@ -243,16 +244,17 @@ fn cppgc_cell() {
   }
 
   unsafe impl GarbageCollected for Wrap {
-    fn trace(&self, visitor: &Visitor) {
+    fn trace(&self, visitor: &mut Visitor) {
       visitor.trace(&self.inner);
     }
+
     fn get_name(&self) -> &'static std::ffi::CStr {
       c"GcCellWrap"
     }
   }
 
   impl Traced for Inner {
-    fn trace(&self, visitor: &Visitor) {
+    fn trace(&self, visitor: &mut Visitor) {
       visitor.trace(&self.other);
     }
   }


### PR DESCRIPTION
- make Visitor a mutable reference
- remove deprecated function
- make visitor calls consistent