### PR TITLE
feat: add enable-i18n-support build for mobile device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,9 @@ exclude = [
 opt-level = 1
 
 [features]
-default = ["use_custom_libcxx"]
+default = ["use_custom_libcxx", "v8_enable_i18n_support"]
 use_custom_libcxx = []
+v8_enable_i18n_support = []
 v8_enable_pointer_compression = []
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -207,6 +207,10 @@ fn build_v8(is_asan: bool) {
     env::var("CARGO_FEATURE_USE_CUSTOM_LIBCXX").is_ok()
   ));
   gn_args.push(format!(
+    "v8_enable_i18n_support={}",
+    env::var("CARGO_FEATURE_V8_ENABLE_I18N_SUPPORT").is_ok()
+  ));
+  gn_args.push(format!(
     "v8_enable_pointer_compression={}",
     env::var("CARGO_FEATURE_V8_ENABLE_POINTER_COMPRESSION").is_ok()
   ));

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -11,7 +11,6 @@
 #include "cppgc/platform.h"
 #include "libplatform/libplatform.h"
 #include "support.h"
-#include "unicode/locid.h"
 #include "v8-callbacks.h"
 #include "v8-cppgc.h"
 #include "v8-fast-api-calls.h"
@@ -22,6 +21,10 @@
 #include "v8.h"
 #include "v8/src/flags/flags.h"
 #include "v8/src/libplatform/default-platform.h"
+
+#ifdef V8_INTL_SUPPORT
+#include "unicode/locid.h"
+#endif  // V8_INTL_SUPPORT
 
 using namespace support;
 
@@ -3784,6 +3787,7 @@ void v8__CompiledWasmModule__DELETE(v8::CompiledWasmModule* self) {
 
 // icu
 
+#ifdef V8_INTL_SUPPORT
 extern "C" {
 
 size_t icu_get_default_locale(char* output, size_t output_len) {
@@ -3802,6 +3806,7 @@ void icu_set_default_locale(const char* locale) {
 }
 
 }  // extern "C"
+#endif  // V8_INTL_SUPPORT
 
 // v8::PropertyDescriptor
 


### PR DESCRIPTION
Enabling compilation with v8_enable_i18n_support=false can significantly reduce the library size，this is very useful for some mobile devices.