### PR TITLE
Add v8 sandbox

### DIFF
--- a/.gn
+++ b/.gn
@@ -33,12 +33,9 @@ default_args = {
 
   v8_embedder_string = "-rusty"
 
-  v8_enable_sandbox = false
   v8_enable_javascript_promise_hooks = true
   v8_promise_internal_field_count = 1
   v8_use_external_startup_data = false
-
-  v8_enable_pointer_compression = false
 
   v8_imminent_deprecation_warnings = false
 
@@ -64,17 +61,6 @@ default_args = {
   # Historically these always had 2 slots. Keep for compat.
   v8_array_buffer_internal_field_count = 2
   v8_array_buffer_view_internal_field_count = 2
-
-  # Enabling the shared read-only heap comes with a restriction that all
-  # isolates running at the same time must be created from the same snapshot.
-  # This is problematic for Deno, which has separate "runtime" and "typescript
-  # compiler" snapshots, and sometimes uses them both at the same time.
-  v8_enable_shared_ro_heap = false
-
-  # V8 11.6 hardcoded an assumption in `mksnapshot` that shared RO heap
-  # is enabled. In our case it's disabled so without this flag we can't
-  # compile.
-  v8_enable_verify_heap = false
 
   # Enable V8 object print for debugging.
   # v8_enable_object_print = true

--- a/src/V8.rs
+++ b/src/V8.rs
@@ -27,6 +27,7 @@ unsafe extern "C" {
   fn v8__V8__Dispose() -> bool;
   fn v8__V8__DisposePlatform();
   fn v8__V8__SetFatalErrorHandler(that: V8FatalErrorCallback);
+  fn v8__V8__IsSandboxEnabled() -> bool;
 }
 
 pub type V8FatalErrorCallback = unsafe extern "C" fn(
@@ -82,6 +83,11 @@ enum GlobalState {
 use GlobalState::*;
 
 static GLOBAL_STATE: Mutex<GlobalState> = Mutex::new(Uninitialized);
+
+/// Returns true if V8 is sandboxed.
+pub fn is_sandboxed() -> bool {
+  unsafe { v8__V8__IsSandboxEnabled() }
+}
 
 pub fn assert_initialized() {
   let global_state_guard = GLOBAL_STATE.lock().unwrap();

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -121,6 +121,12 @@ static_assert(sizeof(v8::Isolate::DisallowJavascriptExecutionScope) == 12,
               "DisallowJavascriptExecutionScope size mismatch");
 #endif
 
+// Note: this currently uses an internal API to determine if the v8 sandbox is
+// enabled in the testsuite etc.
+extern "C" bool v8__V8__IsSandboxEnabled() {
+  return v8::internal::SandboxIsEnabled();
+}
+
 extern "C" {
 void v8__V8__SetFlagsFromCommandLine(int* argc, char** argv,
                                      const char* usage) {
@@ -978,6 +984,21 @@ v8::BackingStore* v8__ArrayBuffer__NewBackingStore__with_data(
     void* deleter_data) {
   std::unique_ptr<v8::BackingStore> u = v8::ArrayBuffer::NewBackingStore(
       data, byte_length, deleter, deleter_data);
+  return u.release();
+}
+
+v8::BackingStore* v8__ArrayBuffer__NewBackingStore__with_data_sandboxed(
+    v8::Isolate* isolate, void* data, size_t byte_length) {
+  std::unique_ptr<v8::BackingStore> u =
+      v8::ArrayBuffer::NewBackingStore(isolate, byte_length);
+  if (u == nullptr) {
+    return nullptr;  // Allocation failed
+  }
+  if (byte_length == 0) {
+    // Nothing to copy
+    return u.release();
+  }
+  memcpy(u->Data(), data, byte_length);
   return u.release();
 }
 
@@ -2748,6 +2769,24 @@ v8::BackingStore* v8__SharedArrayBuffer__NewBackingStore__with_data(
     void* deleter_data) {
   std::unique_ptr<v8::BackingStore> u = v8::SharedArrayBuffer::NewBackingStore(
       data, byte_length, deleter, deleter_data);
+  return u.release();
+}
+
+v8::BackingStore* v8__SharedArrayBuffer__NewBackingStore__with_data_sandboxed(
+    v8::Isolate* isolate, void* data, size_t byte_length) {
+  std::unique_ptr<v8::BackingStore> u =
+      v8::SharedArrayBuffer::NewBackingStore(isolate, byte_length);
+  if (u == nullptr) {
+    return nullptr;  // Allocation failed
+  }
+  // If byte_length is 0, then just release without doing memcpy
+  //
+  // The user may not have passed a valid data pointer in such a case,
+  // making the memcpy potentially UB
+  if (byte_length == 0) {
+    return u.release();
+  }
+  memcpy(u->Data(), data, byte_length);
   return u.release();
 }
 

--- a/tests/test_sandbox_use.rs
+++ b/tests/test_sandbox_use.rs
@@ -1,0 +1,14 @@
+#[cfg(test)]
+mod test_sandbox_use {
+  #[test]
+  #[cfg(feature = "v8_enable_pointer_compression")]
+  fn test_sandbox_on() {
+    assert!(v8::V8::is_sandboxed());
+  }
+
+  #[test]
+  #[cfg(not(feature = "v8_enable_pointer_compression"))]
+  fn test_sandbox_off() {
+    assert!(!v8::V8::is_sandboxed());
+  }
+}

--- a/tests/test_simple_external.rs
+++ b/tests/test_simple_external.rs
@@ -1,0 +1,45 @@
+#[cfg(test)]
+mod test_simple_external {
+  #[test]
+  fn test() {
+    v8::V8::set_flags_from_string(
+      "--no_freeze_flags_after_init --expose_gc --harmony-shadow-realm --allow_natives_syntax --turbo_fast_api_calls --js-source-phase-imports",
+    );
+    v8::V8::initialize_platform(
+      v8::new_default_platform(0, false).make_shared(),
+    );
+    v8::V8::initialize();
+    let isolate = &mut v8::Isolate::new(Default::default());
+    v8::scope!(let scope, isolate);
+
+    let ex1_value =
+      Box::into_raw(Box::new(1234567usize)) as *mut std::ffi::c_void;
+    let ex1_handle_a = v8::External::new(scope, ex1_value);
+    assert_eq!(ex1_handle_a.value(), ex1_value);
+
+    let b_value =
+      Box::into_raw(Box::new(2334567usize)) as *mut std::ffi::c_void;
+    let ex1_handle_b = v8::External::new(scope, b_value);
+    assert_eq!(ex1_handle_b.value(), b_value);
+
+    let ex2_value =
+      Box::into_raw(Box::new(2334567usize)) as *mut std::ffi::c_void;
+    let ex3_value = Box::into_raw(Box::new(-2isize)) as *mut std::ffi::c_void;
+
+    let ex2_handle_a = v8::External::new(scope, ex2_value);
+    let ex3_handle_a = v8::External::new(scope, ex3_value);
+
+    assert!(ex1_handle_a != ex2_handle_a);
+    assert!(ex2_handle_a != ex3_handle_a);
+    assert!(ex3_handle_a != ex1_handle_a);
+
+    assert_ne!(ex2_value, ex3_value);
+    assert_eq!(ex2_handle_a.value(), ex2_value);
+    assert_eq!(ex3_handle_a.value(), ex3_value);
+
+    drop(unsafe { Box::from_raw(ex1_value as *mut usize) });
+    drop(unsafe { Box::from_raw(b_value as *mut usize) });
+    drop(unsafe { Box::from_raw(ex2_value as *mut usize) });
+    drop(unsafe { Box::from_raw(ex3_value as *mut isize) });
+  }
+}


### PR DESCRIPTION
This PR adds support for the v8 sandbox to rusty v8 (which is something critical to my use case of running untrusted user code). Sandbox is enabled along with pointer compression via ``v8_enable_pointer_compression``. Note that due to limitations of the sandbox, enabling sandbox will cause the following API-wide changes:

- ``(Shared)ArrayBuffer::new_backing_store_from_vec/boxed_slice`` will create a copy of the data inside the v8 sandbox (possible future change: Add a ``new_backing_store_from_bytes(&[u8])`` as we anyways need to make a copy). v8 sandbox requires all arraybuffer backing stores to be v8 allocated within the isolates sandbox
- ``(Shared)ArrayBuffer::new_backing_store_from_ptr`` will not be available as it doesn't work with the v8 sandbox requirement of all backing stores needing to be allocated within isolate sandbox
- ``new_rust_allocator`` will not work as a consequence of the above. Backing stores are now fully v8 managed and rust managed ones can't (at least I haven't found a public API yet) allocate their own data within the sandbox.
- The pointer to ``v8::External`` will now required to be a real heap-allocated pointer (this was always the case really, you should not be casting random numbers and passing to v8::External::new anyways). This is because v8's EPT needs to store the external tag which doesn't seem to work if the pointer isnt heap allocated when v8 sandbox is enabled