### PR TITLE
feat: add copy_contents_uninit to `ArrayBufferView`

### DIFF
--- a/src/array_buffer_view.rs
+++ b/src/array_buffer_view.rs
@@ -8,6 +8,7 @@ use crate::scope::PinScope;
 use crate::support::int;
 use std::convert::TryInto;
 use std::ffi::c_void;
+use std::mem::MaybeUninit;
 
 unsafe extern "C" {
   fn v8__ArrayBufferView__Buffer(
@@ -84,6 +85,21 @@ impl ArrayBufferView {
   /// Returns the number of bytes actually written.
   #[inline(always)]
   pub fn copy_contents(&self, dest: &mut [u8]) -> usize {
+    unsafe {
+      v8__ArrayBufferView__CopyContents(
+        self,
+        dest.as_mut_ptr() as *mut c_void,
+        dest.len().try_into().unwrap(),
+      )
+    }
+  }
+
+  /// Copy the contents of the ArrayBufferView's buffer to an embedder defined
+  /// memory without additional overhead that calling ArrayBufferView::Buffer
+  /// might incur.
+  /// Returns the number of bytes actually written.
+  #[inline(always)]
+  pub fn copy_contents_uninit(&self, dest: &mut [MaybeUninit<u8>]) -> usize {
     unsafe {
       v8__ArrayBufferView__CopyContents(
         self,


### PR DESCRIPTION
So that you don't have to zero out the buffer