### PR TITLE
fix(build): link proper cxx std libraries on windows-gnu{,llvm}

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -751,6 +751,7 @@ fn print_link_flags() {
       } else if target.contains("apple")
         || target.contains("freebsd")
         || target.contains("openbsd")
+        || target.contains("gnullvm")
       {
         println!("cargo:rustc-link-lib=dylib=c++");
       } else if target.contains("android") {
@@ -760,6 +761,7 @@ fn print_link_flags() {
       }
     }
   }
+  let target = env::var("TARGET").unwrap();
   let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
   let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
 
@@ -776,6 +778,12 @@ fn print_link_flags() {
     } else {
       println!("cargo:rustc-link-lib=dylib=msvcprt");
     }
+  } else if target.ends_with("windows-gnu") {
+    // Clang-based toolchains don't use separate atomic library
+    println!("cargo:rustc-link-lib=atomic")
+  } else if target.ends_with("windows-gnullvm") {
+    // Clang usually works with Win32 threads, so we need to link pthread explicitly
+    println!("cargo:rustc-link-lib=pthread")
   }
 }
 


### PR DESCRIPTION
`*-pc-windows-gnullvm` targets use Clang toolchain, so the std library for it is libc++, pthread is needed to be explicitly linked too.

`*-pc-windows-gnu` build also depends on `libatomic`