### PR TITLE
Fix `InterruptCallback` signature

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -544,7 +544,7 @@ pub type GcCallbackWithData = unsafe extern "C" fn(
 );
 
 pub type InterruptCallback =
-  unsafe extern "C" fn(isolate: &mut Isolate, data: *mut c_void);
+  unsafe extern "C" fn(isolate: UnsafeRawIsolatePtr, data: *mut c_void);
 
 pub type NearHeapLimitCallback = unsafe extern "C" fn(
   data: *mut c_void,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1075,7 +1075,7 @@ fn isolate_termination_methods() {
   assert!(!handle.is_execution_terminating());
   static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
   extern "C" fn callback(
-    _isolate: &mut v8::Isolate,
+    _isolate: v8::UnsafeRawIsolatePtr,
     data: *mut std::ffi::c_void,
   ) {
     assert_eq!(data, std::ptr::null_mut());
@@ -1103,7 +1103,7 @@ fn thread_safe_handle_drop_after_isolate() {
   assert!(!handle.is_execution_terminating());
   static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
   extern "C" fn callback(
-    _isolate: &mut v8::Isolate,
+    _isolate: v8::UnsafeRawIsolatePtr,
     data: *mut std::ffi::c_void,
   ) {
     assert_eq!(data, std::ptr::null_mut());
@@ -1168,9 +1168,10 @@ fn request_interrupt_small_scripts() {
 
     static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
     extern "C" fn callback(
-      isolate: &mut v8::Isolate,
+      isolate: v8::UnsafeRawIsolatePtr,
       data: *mut std::ffi::c_void,
     ) {
+      let isolate = unsafe { v8::Isolate::ref_from_raw_isolate_ptr(&isolate) };
       assert_eq!(isolate.get_slot::<String>(), Some(&"hello".into()));
       assert_eq!(data, std::ptr::null_mut());
       CALL_COUNT.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
Before, the callback was expected to take a `&mut Isolate` as  the first arg, but the C++ version of the typedef has `Isolate*` as the first arg, corresponding to rust `*mut RealIsolate`. This meant that any attempt to access the isolate would segfault, since in GDB, it was showing this:

```
(gdb) frame 1
#1  0x00005555580104e1 in v8::isolate::Isolate::get_data_internal (self=0x7fff8c001000, slot=0)
    at /home/coolreader18/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/v8-140.2.0/src/isolate.rs:1070
1070	    unsafe { v8__Isolate__GetData(self.as_real_ptr(), slot) }
(gdb) p self
$1 = (*mut v8::isolate::Isolate) 0x7fff8c001000
(gdb) p (*self)
$2 = v8::isolate::Isolate (core::ptr::non_null::NonNull<v8::isolate::RealIsolate> {pointer: 0x0})
```

You can reproduce the segfault by checking out the first commit of this branch and running `cargo t --test test_api request_interrupt_small_scripts`.

Now, the first argument is `UnsafeRawIsolatePtr`, which matches `GcCallbackWithData`.