### PR TITLE
refactor: use String& instead of std::string_view in string_util

### DIFF
--- a/src/deno_inspector/string_util.cc
+++ b/src/deno_inspector/string_util.cc
@@ -101,11 +101,11 @@ String StringUtil::fromUTF16LE(const uint16_t* data, size_t length) {
   return fromUTF16(data, length);  // Assuming host is little-endian
 }
 
-const uint8_t* StringUtil::CharactersUTF8(const std::string_view s) {
+const uint8_t* StringUtil::CharactersUTF8(const String& s) {
   return reinterpret_cast<const uint8_t*>(s.data());
 }
 
-size_t StringUtil::CharacterCount(const std::string_view s) {
+size_t StringUtil::CharacterCount(const String& s) {
   return s.length();
 }
 

--- a/src/deno_inspector/string_util.h
+++ b/src/deno_inspector/string_util.h
@@ -56,13 +56,13 @@ struct StringUtil {
   static String fromUTF16(const uint16_t* data, size_t length);
   static String fromUTF8(const uint8_t* data, size_t length);
   static String fromUTF16LE(const uint16_t* data, size_t length);
-  static const uint8_t* CharactersUTF8(const std::string_view s);
-  static size_t CharacterCount(const std::string_view s);
+  static const uint8_t* CharactersUTF8(const String& s);
+  static size_t CharacterCount(const String& s);
 
-  inline static uint8_t* CharactersLatin1(const std::string_view s) {
+  inline static uint8_t* CharactersLatin1(const String& s) {
     return nullptr;
   }
-  inline static const uint16_t* CharactersUTF16(const std::string_view s) {
+  inline static const uint16_t* CharactersUTF16(const String& s) {
     return nullptr;
   }
 };


### PR DESCRIPTION
Follow-up to #1904

Uses the protocol's `String` type alias (`std::string`) directly instead of `std::string_view` for the `CharactersUTF8`, `CharacterCount`, `CharactersLatin1`, and `CharactersUTF16` functions.

This is more consistent with the rest of the codebase and avoids the C++ `<string_view>` header dependency.