### PR TITLE
fix: correct ExternalOneByteString destructor memory accounting

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1235,7 +1235,7 @@ class ExternalOneByteString : public v8::String::ExternalOneByteStringResource {
   ~ExternalOneByteString() override {
     (*rustDestroy_)(data_, length_);
     isolate_->AdjustAmountOfExternalAllocatedMemory(
-        -static_cast<int64_t>(-length_));
+        -static_cast<int64_t>(length_));
   }
 
   const char* data() const override { return data_; }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8164,6 +8164,42 @@ fn external_onebyte_string() {
 }
 
 #[test]
+fn external_onebyte_string_frees_external_memory() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+
+  let before = isolate.get_heap_statistics().external_memory();
+
+  {
+    v8::scope!(let scope, isolate);
+    let context = v8::Context::new(scope, Default::default());
+    let scope = &mut v8::ContextScope::new(scope, context);
+
+    // Allocate a large external string so the memory delta is measurable.
+    let input = vec![b'x'; 1024 * 1024].into_boxed_slice();
+    let _s = v8::String::new_external_onebyte(scope, input).unwrap();
+
+    let during = scope.get_heap_statistics().external_memory();
+    assert!(
+      during >= before + 1024 * 1024,
+      "external memory should increase after allocating external string: before={before}, during={during}",
+    );
+  }
+
+  // The string is unreachable now; force GC to collect it.
+  isolate.low_memory_notification();
+
+  let after = isolate.get_heap_statistics().external_memory();
+  // After GC the external memory counter should drop back down.
+  // Before the fix, the destructor was *increasing* the counter instead of
+  // decreasing it, so `after` would be >= `during`.
+  assert!(
+    after < before + 1024 * 1024,
+    "external memory should decrease after GC frees external string: before={before}, after={after}",
+  );
+}
+
+#[test]
 fn bigint() {
   let _setup_guard: setup::SetupGuard<std::sync::RwLockReadGuard<'_, ()>> =
     setup::parallel_test();


### PR DESCRIPTION
## Summary

- Fix double-negative bug in `ExternalOneByteString` destructor (`src/binding.cc:1237-1238`) where `-static_cast<int64_t>(-length_)` was used instead of `-static_cast<int64_t>(length_)`. Since `length_` is `size_t` (unsigned), the unary minus wraps it before the cast, causing V8 to think memory is being *allocated* instead of *freed* on every external string destruction.
- Over many string allocation/deallocation cycles (e.g. large file uploads in Deno), the external memory counter accumulates until it exceeds V8's 32GB sanity check (`kMaxReasonableBytes`), triggering a fatal `CHECK` failure.
- Add test `external_onebyte_string_frees_external_memory` that verifies the external memory counter correctly decreases after GC collects an external one-byte string.

Fixes denoland/deno#32693

## Test plan

- [x] New test `external_onebyte_string_frees_external_memory` allocates a 1MB external string, verifies the external memory counter increases, forces GC, then verifies the counter drops back down
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)