### PR TITLE
feat: expose `total_allocated_bytes` in `HeapStatistics`

### DIFF
--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -2227,6 +2227,14 @@ impl HeapStatistics {
     self.0.number_of_detached_contexts_
   }
 
+  /// Returns the total number of bytes allocated since the Isolate was created.
+  /// This includes all heap objects allocated in any space (new, old, code,
+  /// etc.).
+  #[inline(always)]
+  pub fn total_allocated_bytes(&self) -> u64 {
+    self.0.total_allocated_bytes_
+  }
+
   /// Returns a 0/1 boolean, which signifies whether the V8 overwrite heap
   /// garbage with a bit pattern.
   #[inline(always)]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -7790,6 +7790,7 @@ fn heap_statistics() {
   assert_ne!(s.used_global_handles_size(), 0);
   assert_ne!(s.total_global_handles_size(), 0);
   assert_ne!(s.number_of_native_contexts(), 0);
+  assert!(s.total_allocated_bytes() > 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Expose `HeapStatistics::total_allocated_bytes()` which returns the total number of bytes allocated since the Isolate was created (V8's `uint64_t total_allocated_bytes_` field)
- Add test assertion in `heap_statistics` test

## Test plan
- [x] `cargo test heap_statistics` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)