### PR TITLE
fix: add simdutf builds for Windows targets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,13 @@ jobs:
             simdutf: true
             cargo: cargo
 
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'windows-2022-xxl' || 'windows-2022' }}
+            target: x86_64-pc-windows-msvc
+            variant: release # Note: we do not support windows debug builds.
+            v8_enable_pointer_compression: false
+            simdutf: true
+            cargo: cargo
+
     env:
       V8_FROM_SOURCE: true
       CARGO_VARIANT_FLAG: ${{ matrix.config.variant == 'release' && '--release' || '' }}
@@ -505,6 +512,99 @@ jobs:
             target/src_binding_release_aarch64-pc-windows-msvc.rs
           retention-days: 1
 
+  build-windows-arm64-simdutf:
+    name: release aarch64-pc-windows-msvc simdutf
+    runs-on: ${{ github.repository == 'denoland/rusty_v8' && 'windows-2022-xxl' || 'windows-2022' }}
+    timeout-minutes: 180
+    env:
+      CARGO_VARIANT_FLAG: --release
+      V8_FROM_SOURCE: true
+      CCACHE: ccache
+      LIB_NAME: rusty_v8
+      LIB_EXT: lib
+      FEATURES_SUFFIX: '_simdutf'
+    steps:
+      - name: Configure git
+        run: git config --global core.symlinks true
+
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+          submodules: recursive
+
+      - uses: dsherret/rust-toolchain-file@v1
+
+      - name: Install Windows ARM64 target
+        run: rustup target add aarch64-pc-windows-msvc
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Write git_submodule_status.txt
+        run: git submodule status --recursive > git_submodule_status.txt
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |-
+            target/sccache
+            target/aarch64-pc-windows-msvc/release/gn_out
+          key: cargo1-aarch64-pc-windows-msvc-release-simdutf-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
+          restore-keys: cargo1-aarch64-pc-windows-msvc-release-simdutf-
+
+      - name: Install and start sccache
+        shell: pwsh
+        env:
+          SCCACHE_DIR: ${{ github.workspace }}/target/sccache
+          SCCACHE_CACHE_SIZE: 256M
+          SCCACHE_IDLE_TIMEOUT: 0
+        run: |
+          $version = "v0.8.2"
+          $platform = "x86_64-pc-windows-msvc"
+          $basename = "sccache-$version-$platform"
+          $url = "https://github.com/mozilla/sccache/releases/download/$version/$basename.tar.gz"
+          cd ~
+          curl -LO $url
+          tar -xzvf "$basename.tar.gz"
+          . $basename/sccache --start-server
+          echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install Clang
+        run: python3 tools/clang/scripts/update.py
+
+      - name: Build (cross-compile, no tests)
+        env:
+          SCCACHE_IDLE_TIMEOUT: 0
+        run: cargo build --all-targets --locked --target aarch64-pc-windows-msvc --release --features simdutf
+
+      - name: Clippy
+        run: cargo clippy --all-targets --locked --target aarch64-pc-windows-msvc --release --features simdutf -- -D clippy::all
+
+      - name: Prepare binary publish
+        run: |
+          gzip -9c target/aarch64-pc-windows-msvc/release/gn_out/obj/rusty_v8.lib > target/rusty_v8_simdutf_release_aarch64-pc-windows-msvc.lib.gz
+          ls -l target/rusty_v8_simdutf_release_aarch64-pc-windows-msvc.lib.gz
+
+          cp target/aarch64-pc-windows-msvc/release/gn_out/src_binding.rs target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
+          ls -l target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
+
+      - name: Binary publish
+        uses: softprops/action-gh-release@v0.1.15
+        if: github.repository == 'denoland/rusty_v8' && startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            target/rusty_v8_simdutf_release_aarch64-pc-windows-msvc.lib.gz
+            target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
+
+      - name: Upload CI artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
+          path: target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
+
   test-windows-arm64:
     name: test aarch64-pc-windows-msvc
     needs: build-windows-arm64
@@ -537,7 +637,7 @@ jobs:
         run: cargo nextest run -v --all-targets --locked --target aarch64-pc-windows-msvc --release --no-fail-fast
 
   publish:
-    needs: [build, build-windows-arm64]
+    needs: [build, build-windows-arm64, build-windows-arm64-simdutf]
     runs-on: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
     if: github.repository == 'denoland/rusty_v8' && startsWith(github.ref, 'refs/tags/')
     steps:


### PR DESCRIPTION
## Summary
- The simdutf bindings added in #1928 were missing Windows builds, so prebuilt libraries were not published for Windows users
- Adds `x86_64-pc-windows-msvc` with `simdutf: true` to the build matrix (release only)
- Adds a new `build-windows-arm64-simdutf` job for `aarch64-pc-windows-msvc` with simdutf enabled
- Updates `publish` job to depend on the new Windows ARM64 simdutf build

## Test plan
- [ ] CI passes for new `x86_64-pc-windows-msvc` simdutf matrix entry
- [ ] CI passes for new `build-windows-arm64-simdutf` job
- [ ] Prebuilt binaries are correctly named with `_simdutf` suffix
- [ ] Publish job correctly waits for all builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)