### PR TITLE
feat: add bindings for `v8::Object::SetIsUncloneable()`

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1537,6 +1537,10 @@ bool v8__Object__IsApiWrapper(const v8::Object& self) {
   return ptr_to_local(&self)->IsApiWrapper();
 }
 
+void v8__Object__SetIsUncloneable(const v8::Object& self) {
+  ptr_to_local(&self)->SetIsUncloneable();
+}
+
 const v8::Value* v8__Object__GetPrototype(const v8::Object& self) {
   return local_to_ptr(ptr_to_local(&self)->GetPrototypeV2());
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -246,6 +246,7 @@ unsafe extern "C" {
     tag: u16,
   ) -> *mut RustObj;
   fn v8__Object__IsApiWrapper(this: *const Object) -> bool;
+  fn v8__Object__SetIsUncloneable(this: *const Object);
 
   fn v8__Array__New(isolate: *mut RealIsolate, length: int) -> *const Array;
   fn v8__Array__New_with_elements(
@@ -818,6 +819,14 @@ impl Object {
   #[inline(always)]
   pub fn is_api_wrapper(&self) -> bool {
     unsafe { v8__Object__IsApiWrapper(self) }
+  }
+
+  /// Marks this object as uncloneable. If a JavaScript code tries to use
+  /// `structuredClone()` to clone this object, it will throw a
+  /// `DataCloneError`.
+  #[inline(always)]
+  pub fn set_is_uncloneable(&self) {
+    unsafe { v8__Object__SetIsUncloneable(self) }
   }
 
   /// Sets the integrity level of the object.

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2965,6 +2965,34 @@ fn object() {
 }
 
 #[test]
+fn object_set_is_uncloneable() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  {
+    v8::scope!(let scope, isolate);
+
+    let context = v8::Context::new(scope, Default::default());
+    let scope = &mut v8::ContextScope::new(scope, context);
+
+    let object = v8::Object::new(scope);
+    let global = context.global(scope);
+    let key = v8::String::new(scope, "o").unwrap().into();
+    global.set(scope, key, object.into());
+
+    // Before marking as uncloneable, structuredClone should succeed.
+    assert!(eval(scope, "structuredClone(o)").is_some());
+
+    // Mark the object as uncloneable.
+    object.set_is_uncloneable();
+
+    // After marking as uncloneable, structuredClone should throw.
+    let scope = &mut v8::TryCatch::new(scope);
+    assert!(eval(scope, "structuredClone(o)").is_none());
+    assert!(scope.has_caught());
+  }
+}
+
+#[test]
 fn map() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
## Summary
- Add C++ binding, Rust FFI declaration, safe wrapper, and test for `v8::Object::SetIsUncloneable()`
- This marks an object so that `structuredClone()` throws a `DataCloneError`
- Needed to make the `test-worker-message-mark-as-uncloneable.js` Node compatibility test pass

## Test plan
- [x] Added `object_set_is_uncloneable` test in `tests/test_api.rs` that verifies `structuredClone()` succeeds before marking and throws after marking

🤖 Generated with [Claude Code](https://claude.com/claude-code)