### PR TITLE
Expose `FunctionTemplate::SetAccessorProperty`

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2404,6 +2404,15 @@ void v8__FunctionTemplate__SetClassName(const v8::FunctionTemplate& self,
   ptr_to_local(&self)->SetClassName(ptr_to_local(&name));
 }
 
+void v8__FunctionTemplate__SetAccessorProperty(const v8::FunctionTemplate& self,
+                                               const v8::Name& key,
+                                               v8::FunctionTemplate& getter,
+                                               v8::FunctionTemplate& setter,
+                                               v8::PropertyAttribute attr) {
+  ptr_to_local(&self)->SetAccessorProperty(
+      ptr_to_local(&key), ptr_to_local(&getter), ptr_to_local(&setter), attr);
+}
+
 void v8__FunctionTemplate__Inherit(const v8::FunctionTemplate& self,
                                    const v8::FunctionTemplate& parent) {
   ptr_to_local(&self)->Inherit(ptr_to_local(&parent));

--- a/src/template.rs
+++ b/src/template.rs
@@ -81,6 +81,13 @@ unsafe extern "C" {
     this: *const FunctionTemplate,
     name: *const String,
   );
+  fn v8__FunctionTemplate__SetAccessorProperty(
+    this: *const FunctionTemplate,
+    key: *const Name,
+    getter: *const FunctionTemplate,
+    setter: *const FunctionTemplate,
+    attr: PropertyAttribute,
+  );
   fn v8__FunctionTemplate__Inherit(
     this: *const FunctionTemplate,
     parent: *const FunctionTemplate,
@@ -830,6 +837,31 @@ impl FunctionTemplate {
   #[inline(always)]
   pub fn remove_prototype(&self) {
     unsafe { v8__FunctionTemplate__RemovePrototype(self) };
+  }
+
+  /// Sets an [accessor property](https://tc39.es/ecma262/#sec-property-attributes)
+  /// on the function template (i.e. a static accessor on the constructor).
+  ///
+  /// # Panics
+  ///
+  /// Panics if both `getter` and `setter` are `None`.
+  #[inline(always)]
+  pub fn set_accessor_property(
+    &self,
+    key: Local<Name>,
+    getter: Option<Local<FunctionTemplate>>,
+    setter: Option<Local<FunctionTemplate>>,
+    attr: PropertyAttribute,
+  ) {
+    assert!(getter.is_some() || setter.is_some());
+
+    unsafe {
+      let getter = getter.map_or_else(std::ptr::null, |v| &*v);
+      let setter = setter.map_or_else(std::ptr::null, |v| &*v);
+      v8__FunctionTemplate__SetAccessorProperty(
+        self, &*key, getter, setter, attr,
+      );
+    }
   }
 }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1833,6 +1833,79 @@ fn function_template_intrinsic_data_property() {
 }
 
 #[test]
+fn function_template_set_accessor_property() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  v8::scope!(let scope, isolate);
+
+  let context = v8::Context::new(scope, Default::default());
+  let scope = &mut v8::ContextScope::new(scope, context);
+
+  {
+    let getter = v8::FunctionTemplate::new(scope, fortytwo_callback);
+
+    fn setter_callback(
+      _scope: &mut v8::PinScope,
+      _args: v8::FunctionCallbackArguments,
+      _rv: v8::ReturnValue<v8::Value>,
+    ) {
+    }
+
+    let setter = v8::FunctionTemplate::new(scope, setter_callback);
+
+    fn constructor_callback(
+      _scope: &mut v8::PinScope,
+      _args: v8::FunctionCallbackArguments,
+      _rv: v8::ReturnValue<v8::Value>,
+    ) {
+    }
+
+    let tmpl = v8::FunctionTemplate::new(scope, constructor_callback);
+    let class_name = v8::String::new(scope, "MyClass").unwrap();
+    tmpl.set_class_name(class_name);
+
+    // Getter
+    let key1 = v8::String::new(scope, "key1").unwrap();
+    tmpl.set_accessor_property(
+      key1.into(),
+      Some(getter),
+      None,
+      v8::PropertyAttribute::default(),
+    );
+
+    // Getter + setter
+    let key2 = v8::String::new(scope, "key2").unwrap();
+    tmpl.set_accessor_property(
+      key2.into(),
+      Some(getter),
+      Some(setter),
+      v8::PropertyAttribute::default(),
+    );
+
+    let name = v8::String::new(scope, "MyClass").unwrap();
+    let constructor = tmpl.get_function(scope).unwrap();
+    scope.get_current_context().global(scope).set(
+      scope,
+      name.into(),
+      constructor.into(),
+    );
+
+    let int = v8::Integer::new(scope, 42);
+    assert!(
+      eval(scope, "MyClass.key1")
+        .unwrap()
+        .strict_equals(int.into())
+    );
+    assert!(
+      eval(scope, "MyClass.key2")
+        .unwrap()
+        .strict_equals(int.into())
+    );
+    eval(scope, "MyClass.key2 = 99");
+  }
+}
+
+#[test]
 fn instance_template_with_internal_field() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
`ObjectTemplate::SetAccessorProperty` is already exposed for setting instance accessors on object templates. This PR exposes `FunctionTemplate::SetAccessorProperty` so that static accessors can be set on the constructor function.

Required for denoland/deno#32951