### PR TITLE
build: Notify when no pre-built archive is available for the target

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -644,7 +644,7 @@ fn build_dir() -> PathBuf {
     .to_path_buf()
 }
 
-/// Checks if the target is available as a pre-built archive from the rusty_v8 GitLab.
+/// Checks if the target is available as a pre-built archive from the rusty_v8 GitHub. 
 /// Should only be called when `RUSTY_V8_MIRROR` is unset.
 fn is_target_prebuilt(target: &str) -> bool {
   const PREBUILT_TARGETS: [&str; 6] = [

--- a/build.rs
+++ b/build.rs
@@ -596,7 +596,6 @@ fn static_lib_url() -> String {
   let target = env::var("TARGET").unwrap();
   let profile = prebuilt_profile();
   let features = prebuilt_features_suffix();
-
   format!(
     "{base}/v{version}/{}.gz",
     static_lib_name(&format!("{features}_{profile}_{target}")),
@@ -683,11 +682,6 @@ fn download_file(url: &str, filename: &Path) {
       .arg(
         "const [url, path] = Deno.args; \
          const resp = await fetch(url); \
-         if (resp.status === 404) { \
-           console.error(`Failed to download prebuilt V8 archive from ${url}`); \
-           console.error(`If no prebuilt archive is available for your target, compile V8 from source by setting V8_FROM_SOURCE=1`); \
-           Deno.exit(1); \
-         } \
          if (!resp.ok) Deno.exit(1); \
          const file = await Deno.open(path, { write: true, create: true }); \
          await resp.body.pipeTo(file.writable);",
@@ -742,8 +736,9 @@ fn download_file(url: &str, filename: &Path) {
   if !status.success() {
     panic!(
       "Failed to download V8 prebuilt archive from {url}\n\
-     If no prebuilt archive is available for your target, \
-     compile V8 from source by setting V8_FROM_SOURCE=1"
+     This is usually because no prebuilt archive is published for your target, \
+     in which case you should compile V8 from source by setting V8_FROM_SOURCE=1. \
+     It can also indicate a network connectivity problem."
     );
   }
   assert!(tmpfile.exists());

--- a/build.rs
+++ b/build.rs
@@ -598,7 +598,9 @@ fn static_lib_url() -> String {
   let features = prebuilt_features_suffix();
 
   if base == default_base && !is_target_prebuilt(&target) {
-    panic!("The target {target} is not a first class target and no pre-built archive is provided. Compile v8 from source with V8_FROM_SOURCE=1")
+    panic!(
+      "The target {target} is not a first class target and no pre-built archive is provided. Compile v8 from source with V8_FROM_SOURCE=1"
+    )
   }
 
   format!(
@@ -651,7 +653,7 @@ fn is_target_prebuilt(target: &str) -> bool {
     "aarch64-unknown-linux",
     "x86_64-apple-darwin",
     "x86_64-pc-windows-msvc",
-    "x86_64-unknown-linux-gnu"
+    "x86_64-unknown-linux-gnu",
   ];
   PREBUILT_TARGETS.contains(&target)
 }

--- a/build.rs
+++ b/build.rs
@@ -597,9 +597,11 @@ fn static_lib_url() -> String {
   let profile = prebuilt_profile();
   let features = prebuilt_features_suffix();
 
-  if base == default_base && !is_target_prebuilt(&target) {
+  if env::var("RUSTY_V8_MIRROR").is_err()
+    && !is_target_prebuilt(&target, profile)
+  {
     panic!(
-      "The target {target} is not a first class target and no pre-built archive is provided. Compile v8 from source with V8_FROM_SOURCE=1"
+      "The target '{target}' is not a first class target and no pre-built archive is provided. Compile v8 from source with V8_FROM_SOURCE=1"
     )
   }
 
@@ -646,15 +648,21 @@ fn build_dir() -> PathBuf {
 
 /// Checks if the target is available as a pre-built archive from the rusty_v8 GitHub.
 /// Should only be called when `RUSTY_V8_MIRROR` is unset.
-fn is_target_prebuilt(target: &str) -> bool {
+fn is_target_prebuilt(target: &str, profile: &str) -> bool {
   const PREBUILT_TARGETS: [&str; 6] = [
     "aarch64-apple-darwin",
     "aarch64-pc-windows-msvc",
-    "aarch64-unknown-linux",
+    "aarch64-unknown-linux-gnu",
     "x86_64-apple-darwin",
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-gnu",
   ];
+
+  // No pre-built archives for Windows on debug builds.
+  if target.contains("windows") && profile != "release" {
+    return false;
+  }
+
   PREBUILT_TARGETS.contains(&target)
 }
 

--- a/build.rs
+++ b/build.rs
@@ -596,6 +596,11 @@ fn static_lib_url() -> String {
   let target = env::var("TARGET").unwrap();
   let profile = prebuilt_profile();
   let features = prebuilt_features_suffix();
+
+  if base == default_base && !is_target_prebuilt(&target) {
+    panic!("The target {target} is not a first class target and no pre-built archive is provided. Compile v8 from source with V8_FROM_SOURCE=1")
+  }
+
   format!(
     "{base}/v{version}/{}.gz",
     static_lib_name(&format!("{features}_{profile}_{target}")),
@@ -635,6 +640,20 @@ fn build_dir() -> PathBuf {
     .parent()
     .unwrap()
     .to_path_buf()
+}
+
+/// Checks if the target is available as a pre-built archive from the rusty_v8 GitLab.
+/// Should only be called when `RUSTY_V8_MIRROR` is unset.
+fn is_target_prebuilt(target: &str) -> bool {
+  const PREBUILT_TARGETS: [&str; 6] = [
+    "aarch64-apple-darwin",
+    "aarch64-pc-windows-msvc",
+    "aarch64-unknown-linux",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu"
+  ];
+  PREBUILT_TARGETS.contains(&target)
 }
 
 fn replace_non_alphanumeric(url: &str) -> String {

--- a/build.rs
+++ b/build.rs
@@ -597,14 +597,6 @@ fn static_lib_url() -> String {
   let profile = prebuilt_profile();
   let features = prebuilt_features_suffix();
 
-  if env::var("RUSTY_V8_MIRROR").is_err()
-    && !is_target_prebuilt(&target, profile)
-  {
-    panic!(
-      "The target '{target}' is not a first class target and no pre-built archive is provided. Compile v8 from source with V8_FROM_SOURCE=1"
-    )
-  }
-
   format!(
     "{base}/v{version}/{}.gz",
     static_lib_name(&format!("{features}_{profile}_{target}")),
@@ -644,26 +636,6 @@ fn build_dir() -> PathBuf {
     .parent()
     .unwrap()
     .to_path_buf()
-}
-
-/// Checks if the target is available as a pre-built archive from the rusty_v8 GitHub.
-/// Should only be called when `RUSTY_V8_MIRROR` is unset.
-fn is_target_prebuilt(target: &str, profile: &str) -> bool {
-  const PREBUILT_TARGETS: [&str; 6] = [
-    "aarch64-apple-darwin",
-    "aarch64-pc-windows-msvc",
-    "aarch64-unknown-linux-gnu",
-    "x86_64-apple-darwin",
-    "x86_64-pc-windows-msvc",
-    "x86_64-unknown-linux-gnu",
-  ];
-
-  // No pre-built archives for Windows on debug builds.
-  if target.contains("windows") && profile != "release" {
-    return false;
-  }
-
-  PREBUILT_TARGETS.contains(&target)
 }
 
 fn replace_non_alphanumeric(url: &str) -> String {
@@ -711,6 +683,11 @@ fn download_file(url: &str, filename: &Path) {
       .arg(
         "const [url, path] = Deno.args; \
          const resp = await fetch(url); \
+         if (resp.status === 404) { \
+           console.error(`Failed to download prebuilt V8 archive from ${url}`); \
+           console.error(`If no prebuilt archive is available for your target, compile V8 from source by setting V8_FROM_SOURCE=1`); \
+           Deno.exit(1); \
+         } \
          if (!resp.ok) Deno.exit(1); \
          const file = await Deno.open(path, { write: true, create: true }); \
          await resp.body.pipeTo(file.writable);",
@@ -762,7 +739,13 @@ fn download_file(url: &str, filename: &Path) {
   };
 
   // Assert DL was successful
-  assert!(status.success());
+  if !status.success() {
+    panic!(
+      "Failed to download V8 prebuilt archive from {url}\n\
+     If no prebuilt archive is available for your target, \
+     compile V8 from source by setting V8_FROM_SOURCE=1"
+    );
+  }
   assert!(tmpfile.exists());
 
   // Write checksum (i.e url) & move file

--- a/build.rs
+++ b/build.rs
@@ -644,7 +644,7 @@ fn build_dir() -> PathBuf {
     .to_path_buf()
 }
 
-/// Checks if the target is available as a pre-built archive from the rusty_v8 GitHub. 
+/// Checks if the target is available as a pre-built archive from the rusty_v8 GitHub.
 /// Should only be called when `RUSTY_V8_MIRROR` is unset.
 fn is_target_prebuilt(target: &str) -> bool {
   const PREBUILT_TARGETS: [&str; 6] = [


### PR DESCRIPTION
This PR adds a panic into `build.rs` when a v8 build is started with a target that v8 does not provide a pre-built archive for and `RUSTY_V8_MIRROR` is unset (i.e. the script downloads the archive from this GitHub repo). In this case, the panic message advises to rebuild v8 with `V8_FROM_SOURCE=1`.

I currently use a hardcoded list of targets for this, but if you have a better solution, please suggest so :)

I am also a bit unsure if the placement of the code is appropriate, as the build script is quite expansive, so feel free to also suggest improvements there.

Implements the feature discussed in #1877