### PR TITLE
Include `build/rust/known-target-triples.txt` in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ exclude = [
   # These files are required for the build.
   "!.gn",
   "!BUILD.gn",
+  "!build/rust/known-target-triples.txt",
   "!tools/clang/scripts/update.py",
   "!tools/win/DebugVisualizers",
   "!v8/test/torque/test-torque.tq",


### PR DESCRIPTION
This PR removes `build/rust/known-target-triples.txt` from the `exclude` list in Cargo.toml to ensure successful from-source builds.

Fixes #1949.