### PR TITLE
feat: add new_external_twobyte and new_external_twobyte_raw

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1291,6 +1291,35 @@ size_t v8__ExternalOneByteStringResource__length(
   return self->length();
 }
 
+class ExternalTwoByteString : public v8::String::ExternalStringResource {
+ public:
+  using RustDestroy = void (*)(uint16_t*, size_t);
+  ExternalTwoByteString(uint16_t* data, size_t length, RustDestroy rustDestroy,
+                        v8::Isolate* isolate)
+      : data_(data),
+        length_(length),
+        rustDestroy_(rustDestroy),
+        isolate_(isolate) {
+    isolate_->AdjustAmountOfExternalAllocatedMemory(
+        static_cast<int64_t>(length_ * 2));
+  }
+  ~ExternalTwoByteString() override {
+    (*rustDestroy_)(data_, length_);
+    isolate_->AdjustAmountOfExternalAllocatedMemory(
+        -static_cast<int64_t>(length_ * 2));
+  }
+
+  const uint16_t* data() const override { return data_; }
+
+  size_t length() const override { return length_; }
+
+ private:
+  uint16_t* data_;
+  const size_t length_;
+  RustDestroy rustDestroy_;
+  v8::Isolate* isolate_;
+};
+
 class ExternalStaticStringResource : public v8::String::ExternalStringResource {
  public:
   ExternalStaticStringResource(const uint16_t* data, int length)
@@ -1308,6 +1337,13 @@ const v8::String* v8__String__NewExternalTwoByteStatic(v8::Isolate* isolate,
                                                        int length) {
   return maybe_local_to_ptr(v8::String::NewExternalTwoByte(
       isolate, new ExternalStaticStringResource(data, length)));
+}
+
+const v8::String* v8__String__NewExternalTwoByte(
+    v8::Isolate* isolate, uint16_t* data, size_t length,
+    ExternalTwoByteString::RustDestroy rustDestroy) {
+  return maybe_local_to_ptr(v8::String::NewExternalTwoByte(
+      isolate, new ExternalTwoByteString(data, length, rustDestroy, isolate)));
 }
 
 bool v8__String__IsExternal(const v8::String& self) {

--- a/src/string.rs
+++ b/src/string.rs
@@ -172,6 +172,13 @@ unsafe extern "C" {
     length: int,
   ) -> *const String;
 
+  fn v8__String__NewExternalTwoByte(
+    isolate: *mut RealIsolate,
+    buffer: *mut u16,
+    length: size_t,
+    free: unsafe extern "C" fn(*mut u16, size_t),
+  ) -> *const String;
+
   #[allow(dead_code)]
   fn v8__String__IsExternal(this: *const String) -> bool;
   fn v8__String__IsExternalOneByte(this: *const String) -> bool;
@@ -793,6 +800,57 @@ impl String {
     }
   }
 
+  /// Creates a `v8::String` from owned two-byte (UTF-16) data.
+  /// V8 will take ownership of the buffer and free it when the string
+  /// is garbage collected.
+  #[inline(always)]
+  pub fn new_external_twobyte<'s>(
+    scope: &PinScope<'s, '_, ()>,
+    buffer: Box<[u16]>,
+  ) -> Option<Local<'s, String>> {
+    let buffer_len = buffer.len();
+    unsafe {
+      scope.cast_local(|sd| {
+        v8__String__NewExternalTwoByte(
+          sd.get_isolate_ptr(),
+          Box::into_raw(buffer).cast::<u16>(),
+          buffer_len,
+          free_rust_external_twobyte,
+        )
+      })
+    }
+  }
+
+  /// Creates a `v8::String` from owned two-byte (UTF-16) data, length,
+  /// and a custom destructor.
+  /// V8 will take ownership of the buffer and call the destructor when
+  /// the string is garbage collected.
+  ///
+  /// # Safety
+  ///
+  /// `buffer` must be owned (valid for the lifetime of the string), and
+  /// `destructor` must be a valid function pointer that can free the
+  /// buffer. The destructor will be called with the buffer and length
+  /// when the string is garbage collected.
+  #[inline(always)]
+  pub unsafe fn new_external_twobyte_raw<'s>(
+    scope: &PinScope<'s, '_, ()>,
+    buffer: *mut u16,
+    buffer_len: usize,
+    destructor: unsafe extern "C" fn(*mut u16, usize),
+  ) -> Option<Local<'s, String>> {
+    unsafe {
+      scope.cast_local(|sd| {
+        v8__String__NewExternalTwoByte(
+          sd.get_isolate_ptr(),
+          buffer,
+          buffer_len,
+          destructor,
+        )
+      })
+    }
+  }
+
   /// Get the ExternalStringResource for an external string.
   ///
   /// Returns None if is_external() doesn't return true.
@@ -1120,6 +1178,14 @@ pub unsafe extern "C" fn free_rust_external_onebyte(s: *mut char, len: usize) {
     let slice = std::slice::from_raw_parts_mut(s, len);
 
     // Drop the slice
+    drop(Box::from_raw(slice));
+  }
+}
+
+#[inline]
+pub unsafe extern "C" fn free_rust_external_twobyte(s: *mut u16, len: usize) {
+  unsafe {
+    let slice = std::slice::from_raw_parts_mut(s, len);
     drop(Box::from_raw(slice));
   }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8293,8 +8293,7 @@ fn external_twobyte_string() {
   assert_eq!(s.utf8_length(scope), 5);
 
   let mut buf = [0u8; 10];
-  let written =
-    s.write_utf8(scope, &mut buf, None, v8::WriteOptions::NO_NULL_TERMINATION);
+  let written = s.write_utf8_v2(scope, &mut buf, v8::WriteFlags::empty(), None);
   assert_eq!(written, 5);
   assert_eq!(&buf[..5], b"hello");
 }
@@ -8326,8 +8325,7 @@ fn external_twobyte_string_raw() {
   assert_eq!(s.length(), 2);
 
   let mut buf = [0u8; 10];
-  let written =
-    s.write_utf8(scope, &mut buf, None, v8::WriteOptions::NO_NULL_TERMINATION);
+  let written = s.write_utf8_v2(scope, &mut buf, v8::WriteFlags::empty(), None);
   assert_eq!(written, 2);
   assert_eq!(&buf[..2], b"hi");
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8284,8 +8284,7 @@ fn external_twobyte_string() {
   v8::scope!(let scope, isolate);
 
   // "hello" in UTF-16
-  let input: Box<[u16]> =
-    Box::new([0x0068, 0x0065, 0x006C, 0x006C, 0x006F]);
+  let input: Box<[u16]> = Box::new([0x0068, 0x0065, 0x006C, 0x006C, 0x006F]);
   let s = v8::String::new_external_twobyte(scope, input).unwrap();
 
   assert!(s.is_external());
@@ -8294,12 +8293,8 @@ fn external_twobyte_string() {
   assert_eq!(s.utf8_length(scope), 5);
 
   let mut buf = [0u8; 10];
-  let written = s.write_utf8(
-    scope,
-    &mut buf,
-    None,
-    v8::WriteOptions::NO_NULL_TERMINATION,
-  );
+  let written =
+    s.write_utf8(scope, &mut buf, None, v8::WriteOptions::NO_NULL_TERMINATION);
   assert_eq!(written, 5);
   assert_eq!(&buf[..5], b"hello");
 }
@@ -8331,12 +8326,8 @@ fn external_twobyte_string_raw() {
   assert_eq!(s.length(), 2);
 
   let mut buf = [0u8; 10];
-  let written = s.write_utf8(
-    scope,
-    &mut buf,
-    None,
-    v8::WriteOptions::NO_NULL_TERMINATION,
-  );
+  let written =
+    s.write_utf8(scope, &mut buf, None, v8::WriteOptions::NO_NULL_TERMINATION);
   assert_eq!(written, 2);
   assert_eq!(&buf[..2], b"hi");
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -8278,6 +8278,70 @@ fn external_onebyte_string_frees_external_memory() {
 }
 
 #[test]
+fn external_twobyte_string() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  v8::scope!(let scope, isolate);
+
+  // "hello" in UTF-16
+  let input: Box<[u16]> =
+    Box::new([0x0068, 0x0065, 0x006C, 0x006C, 0x006F]);
+  let s = v8::String::new_external_twobyte(scope, input).unwrap();
+
+  assert!(s.is_external());
+  assert!(s.is_external_twobyte());
+  assert_eq!(s.length(), 5);
+  assert_eq!(s.utf8_length(scope), 5);
+
+  let mut buf = [0u8; 10];
+  let written = s.write_utf8(
+    scope,
+    &mut buf,
+    None,
+    v8::WriteOptions::NO_NULL_TERMINATION,
+  );
+  assert_eq!(written, 5);
+  assert_eq!(&buf[..5], b"hello");
+}
+
+#[test]
+fn external_twobyte_string_raw() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  v8::scope!(let scope, isolate);
+
+  unsafe extern "C" fn free_u16(s: *mut u16, len: usize) {
+    unsafe {
+      let slice = std::slice::from_raw_parts_mut(s, len);
+      drop(Box::from_raw(slice));
+    }
+  }
+
+  // "hi" in UTF-16, allocated via Box then leaked for raw API
+  let input: Box<[u16]> = Box::new([0x0068, 0x0069]);
+  let len = input.len();
+  let ptr = Box::into_raw(input) as *mut u16;
+
+  let s =
+    unsafe { v8::String::new_external_twobyte_raw(scope, ptr, len, free_u16) }
+      .unwrap();
+
+  assert!(s.is_external());
+  assert!(s.is_external_twobyte());
+  assert_eq!(s.length(), 2);
+
+  let mut buf = [0u8; 10];
+  let written = s.write_utf8(
+    scope,
+    &mut buf,
+    None,
+    v8::WriteOptions::NO_NULL_TERMINATION,
+  );
+  assert_eq!(written, 2);
+  assert_eq!(&buf[..2], b"hi");
+}
+
+#[test]
 fn bigint() {
   let _setup_guard: setup::SetupGuard<std::sync::RwLockReadGuard<'_, ()>> =
     setup::parallel_test();


### PR DESCRIPTION
## Summary

Adds two-byte (UTF-16) equivalents of the existing external one-byte string APIs, enabling zero-copy creation of V8 strings from owned UTF-16 data.

## New APIs

- **`String::new_external_twobyte(scope, buffer: Box<[u16]>)`** -- creates a `v8::String` from owned `Box<[u16]>`. V8 takes ownership and frees via `free_rust_external_twobyte` on GC.
- **`String::new_external_twobyte_raw(scope, buffer, len, destructor)`** -- creates a `v8::String` from a raw `*mut u16` with a custom destructor. Called when the string is GC'd. Unsafe.
- **`free_rust_external_twobyte`** -- public destructor for `Box<[u16]>` buffers.

These mirror `new_external_onebyte` / `new_external_onebyte_raw` / `free_rust_external_onebyte`.

## C++ binding

Adds `ExternalTwoByteString` class (mirrors `ExternalOneByteString`) which:
- Implements `v8::String::ExternalStringResource`
- Tracks external memory via `AdjustAmountOfExternalAllocatedMemory` (using `length * 2` for byte count)
- Calls the Rust destructor on destruction

## Motivation

Needed by denoland/deno#33283 for `node_api_create_external_string_utf16` to support zero-copy external UTF-16 strings (matching Node.js behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)