### PR TITLE
fix: correct v8__String__NewExternalOneByte length parameter type

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1275,7 +1275,7 @@ const v8::String* v8__String__NewExternalOneByteStatic(v8::Isolate* isolate,
 }
 
 const v8::String* v8__String__NewExternalOneByte(
-    v8::Isolate* isolate, char* data, int length,
+    v8::Isolate* isolate, char* data, size_t length,
     ExternalOneByteString::RustDestroy rustDestroy) {
   return maybe_local_to_ptr(v8::String::NewExternalOneByte(
       isolate, new ExternalOneByteString(data, length, rustDestroy, isolate)));


### PR DESCRIPTION
## Summary

- Fix FFI type mismatch in `v8__String__NewExternalOneByte`: the C++ function declared `int length` (4 bytes) while the Rust FFI binding declared `size_t` (8 bytes)
- Aligns with `v8__String__NewExternalTwoByte` which already correctly uses `size_t length`

Related: denoland/deno#32693, denoland/deno#32904

## Test plan

- [x] `external_onebyte_string` test passes
- [x] `external_onebyte_string_frees_external_memory` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)