### PR TITLE
fix: use real GN arg for linux shared-library TLS mode

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -352,32 +352,21 @@ fn build_v8(is_asan: bool) {
   }
 
   // Use the shared-library-safe TLS mode by default on Linux so downstream
-  // cdylibs can link rusty_v8 archives. Skip injection when GN_ARGS already
-  // sets V8_TLS_USED_IN_LIBRARY.
-  let needs_tls_define = target_os == "linux";
-  let mut tls_define_injected = false;
+  // cdylibs can link rusty_v8 archives. This sets a real declared GN arg
+  // (read by v8/BUILD.gn) which switches V8's thread_local variables to a
+  // -fPIC-compatible TLS model. Skip injection when GN_ARGS already sets it.
+  let needs_tls_arg = target_os == "linux";
+  let mut tls_arg_injected = false;
   if let Ok(raw_gn_args) = env::var("GN_ARGS")
     && !raw_gn_args.trim().is_empty()
   {
-    if raw_gn_args.contains("V8_TLS_USED_IN_LIBRARY") {
-      tls_define_injected = true;
-      gn_args.push(raw_gn_args);
-    } else if needs_tls_define && raw_gn_args.contains("extra_cflags=[") {
-      // Prepend our define into the existing extra_cflags array so we don't
-      // silently override the user's flags with a second assignment.
-      let modified = raw_gn_args.replacen(
-        "extra_cflags=[",
-        r#"extra_cflags=["-DV8_TLS_USED_IN_LIBRARY","#,
-        1,
-      );
-      tls_define_injected = true;
-      gn_args.push(modified);
-    } else {
-      gn_args.push(raw_gn_args);
+    if raw_gn_args.contains("v8_monolithic_for_shared_library") {
+      tls_arg_injected = true;
     }
+    gn_args.push(raw_gn_args);
   }
-  if needs_tls_define && !tls_define_injected {
-    gn_args.push(r#"extra_cflags=["-DV8_TLS_USED_IN_LIBRARY"]"#.to_string());
+  if needs_tls_arg && !tls_arg_injected {
+    gn_args.push("v8_monolithic_for_shared_library=true".to_string());
   }
   // cross-compilation setup
   if target_arch == "aarch64" {


### PR DESCRIPTION
## Summary

Fixes the shared-library TLS mode injection introduced in #1911 -- the previous implementation wrote `extra_cflags=["-DV8_TLS_USED_IN_LIBRARY"]` into `args.gn`, but `extra_cflags` is **not a declared top-level GN arg** anywhere in chromium_build or V8. It's only used as an *invoker parameter* inside toolchain definitions (`build/toolchain/gcc_toolchain.gni:277`). GN silently accepts unknown args, so the define never reached the compiler. V8's thread-locals stayed in `local-exec` TLS model, and linking rusty_v8 into a downstream cdylib failed with:

```
rust-lld: error: relocation R_X86_64_TPOFF32 against
  v8::internal::g_current_isolate_ cannot be used with -shared
```

You can verify on `main` today: build with `V8_FROM_SOURCE=1`, then grep `gn_out/obj/v8/v8_base_without_compiler.ninja` -- `V8_TLS_USED_IN_LIBRARY` is absent from the `defines = ...` line, despite being present in `args.gn`.

## Change

Replace the `extra_cflags=[...]` injection with `v8_monolithic_for_shared_library=true`, which is a **real declared GN arg** in V8's `BUILD.gn:379`.

## Companion change in denoland/v8

This PR alone is not sufficient -- denoland/v8#20 is required to wire `v8_monolithic_for_shared_library` into V8's `internal_config` so the define actually reaches V8 internal `.cc` files (where the TLS variables live). Currently the arg only adds the define inside the `:features` config, which is consumed only by external embedders, not by V8 itself.

This rusty_v8 PR should land **after** denoland/v8#20 has been picked up by the autoroll into `14.7-lkgr-denoland` and the v8 submodule pointer here has been bumped to that commit.

## Test plan

- [ ] After v8 PR lands and submodule is bumped: `V8_FROM_SOURCE=1 cargo build` succeeds for a cdylib downstream (verified locally against Deno's `denort_desktop`).
- [ ] Grep generated `gn_out/obj/v8/v8_base_without_compiler.ninja` -- `V8_TLS_USED_IN_LIBRARY` is now in `defines = ...`.