### PR TITLE
Add bindings for Object::SetLazyDataProperty

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1648,6 +1648,17 @@ MaybeBool v8__Object__SetAccessor(const v8::Object& self,
       ptr_to_local(data_or_null), attr));
 }
 
+MaybeBool v8__Object__SetLazyDataProperty(const v8::Object& self,
+                                          const v8::Context& context,
+                                          const v8::Name& key,
+                                          v8::AccessorNameGetterCallback getter,
+                                          const v8::Value* data_or_null,
+                                          v8::PropertyAttribute attr) {
+  return maybe_to_maybe_bool(ptr_to_local(&self)->SetLazyDataProperty(
+      ptr_to_local(&context), ptr_to_local(&key), getter,
+      ptr_to_local(data_or_null), attr));
+}
+
 int v8__Object__GetIdentityHash(const v8::Object& self) {
   return ptr_to_local(&self)->GetIdentityHash();
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1648,15 +1648,15 @@ MaybeBool v8__Object__SetAccessor(const v8::Object& self,
       ptr_to_local(data_or_null), attr));
 }
 
-MaybeBool v8__Object__SetLazyDataProperty(const v8::Object& self,
-                                          const v8::Context& context,
-                                          const v8::Name& key,
-                                          v8::AccessorNameGetterCallback getter,
-                                          const v8::Value* data_or_null,
-                                          v8::PropertyAttribute attr) {
+MaybeBool v8__Object__SetLazyDataProperty(
+    const v8::Object& self, const v8::Context& context, const v8::Name& key,
+    v8::AccessorNameGetterCallback getter, const v8::Value* data_or_null,
+    v8::PropertyAttribute attr, v8::SideEffectType getter_side_effect_type,
+    v8::SideEffectType setter_side_effect_type) {
   return maybe_to_maybe_bool(ptr_to_local(&self)->SetLazyDataProperty(
       ptr_to_local(&context), ptr_to_local(&key), getter,
-      ptr_to_local(data_or_null), attr));
+      ptr_to_local(data_or_null), attr, getter_side_effect_type,
+      setter_side_effect_type));
 }
 
 int v8__Object__GetIdentityHash(const v8::Object& self) {

--- a/src/object.rs
+++ b/src/object.rs
@@ -54,6 +54,14 @@ unsafe extern "C" {
     data_or_null: *const Value,
     attr: PropertyAttribute,
   ) -> MaybeBool;
+  fn v8__Object__SetLazyDataProperty(
+    this: *const Object,
+    context: *const Context,
+    key: *const Name,
+    getter: AccessorNameGetterCallback,
+    data_or_null: *const Value,
+    attr: PropertyAttribute,
+  ) -> MaybeBool;
   fn v8__Object__Get(
     this: *const Object,
     context: *const Context,
@@ -579,6 +587,52 @@ impl Object {
         configuration.setter,
         configuration.data.map_or_else(null, |p| &*p),
         configuration.property_attribute,
+      )
+    }
+    .into()
+  }
+
+  /// Sets a lazy data property on this object. The getter is invoked the first
+  /// time the property is read, and then the property is replaced with an
+  /// ordinary data property containing the value returned by the getter.
+  #[inline(always)]
+  pub fn set_lazy_data_property(
+    &self,
+    scope: &PinScope<'_, '_>,
+    name: Local<Name>,
+    getter: impl MapFnTo<AccessorNameGetterCallback>,
+  ) -> Option<bool> {
+    unsafe {
+      v8__Object__SetLazyDataProperty(
+        self,
+        &*scope.get_current_context(),
+        &*name,
+        getter.map_fn_to(),
+        null(),
+        PropertyAttribute::NONE,
+      )
+    }
+    .into()
+  }
+
+  /// Sets a lazy data property with data and attributes on this object.
+  #[inline(always)]
+  pub fn set_lazy_data_property_with_data(
+    &self,
+    scope: &PinScope<'_, '_>,
+    name: Local<Name>,
+    getter: impl MapFnTo<AccessorNameGetterCallback>,
+    data: Local<Value>,
+    attr: PropertyAttribute,
+  ) -> Option<bool> {
+    unsafe {
+      v8__Object__SetLazyDataProperty(
+        self,
+        &*scope.get_current_context(),
+        &*name,
+        getter.map_fn_to(),
+        &*data,
+        attr,
       )
     }
     .into()

--- a/src/object.rs
+++ b/src/object.rs
@@ -17,6 +17,7 @@ use crate::PropertyAttribute;
 use crate::PropertyDescriptor;
 use crate::PropertyFilter;
 use crate::Set;
+use crate::SideEffectType;
 use crate::String;
 use crate::Value;
 use crate::binding::RustObj;
@@ -61,6 +62,8 @@ unsafe extern "C" {
     getter: AccessorNameGetterCallback,
     data_or_null: *const Value,
     attr: PropertyAttribute,
+    getter_side_effect_type: SideEffectType,
+    setter_side_effect_type: SideEffectType,
   ) -> MaybeBool;
   fn v8__Object__Get(
     this: *const Object,
@@ -610,12 +613,15 @@ impl Object {
         getter.map_fn_to(),
         null(),
         PropertyAttribute::NONE,
+        SideEffectType::HasSideEffect,
+        SideEffectType::HasSideEffect,
       )
     }
     .into()
   }
 
-  /// Sets a lazy data property with data and attributes on this object.
+  /// Sets a lazy data property with data, attributes, and side effect types
+  /// on this object.
   #[inline(always)]
   pub fn set_lazy_data_property_with_data(
     &self,
@@ -624,6 +630,8 @@ impl Object {
     getter: impl MapFnTo<AccessorNameGetterCallback>,
     data: Local<Value>,
     attr: PropertyAttribute,
+    getter_side_effect_type: SideEffectType,
+    setter_side_effect_type: SideEffectType,
   ) -> Option<bool> {
     unsafe {
       v8__Object__SetLazyDataProperty(
@@ -633,6 +641,8 @@ impl Object {
         getter.map_fn_to(),
         &*data,
         attr,
+        getter_side_effect_type,
+        setter_side_effect_type,
       )
     }
     .into()

--- a/src/object.rs
+++ b/src/object.rs
@@ -55,6 +55,7 @@ unsafe extern "C" {
     data_or_null: *const Value,
     attr: PropertyAttribute,
   ) -> MaybeBool;
+  #[allow(clippy::too_many_arguments)]
   fn v8__Object__SetLazyDataProperty(
     this: *const Object,
     context: *const Context,

--- a/src/object.rs
+++ b/src/object.rs
@@ -624,6 +624,7 @@ impl Object {
   /// Sets a lazy data property with data, attributes, and side effect types
   /// on this object.
   #[inline(always)]
+  #[allow(clippy::too_many_arguments)]
   pub fn set_lazy_data_property_with_data(
     &self,
     scope: &PinScope<'_, '_>,

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3571,6 +3571,53 @@ fn object_set_accessor_with_data() {
 }
 
 #[test]
+fn object_set_lazy_data_property() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  v8::scope!(let scope, isolate);
+
+  let context = v8::Context::new(scope, Default::default());
+  let scope = &mut v8::ContextScope::new(scope, context);
+
+  {
+    static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    let getter = |scope: &mut v8::PinScope,
+                  _key: v8::Local<v8::Name>,
+                  _args: v8::PropertyCallbackArguments,
+                  mut rv: v8::ReturnValue<v8::Value>| {
+      let val = v8::String::new(scope, "lazy_value").unwrap();
+      rv.set(val.into());
+      CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+    };
+
+    let obj = v8::Object::new(scope);
+    let key = v8::String::new(scope, "lazy_key").unwrap();
+    assert_eq!(
+      obj.set_lazy_data_property(scope, key.into(), getter),
+      Some(true)
+    );
+
+    let obj_name = v8::String::new(scope, "obj").unwrap();
+    context
+      .global(scope)
+      .set(scope, obj_name.into(), obj.into());
+
+    // First access triggers the getter.
+    let actual = eval(scope, "obj.lazy_key").unwrap();
+    let expected = v8::String::new(scope, "lazy_value").unwrap();
+    assert!(actual.strict_equals(expected.into()));
+    assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 1);
+
+    // Second access should NOT invoke the getter again —
+    // the property has been replaced with a plain data property.
+    let actual2 = eval(scope, "obj.lazy_key").unwrap();
+    assert!(actual2.strict_equals(expected.into()));
+    assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 1);
+  }
+}
+
+#[test]
 fn promise_resolved() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
## Summary
- Add C++ binding and Rust FFI for `v8::Object::SetLazyDataProperty`
- Expose two Rust methods: `set_lazy_data_property` (simple) and `set_lazy_data_property_with_data` (with data + attributes)
- Add test verifying the getter fires once on first access and the property becomes a plain data property on subsequent reads

## Test plan
- [ ] CI passes (`object_set_lazy_data_property` test)