### PR TITLE
Add bindings for String::Concat

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1184,6 +1184,13 @@ const v8::String* v8__String__NewFromTwoByte(v8::Isolate* isolate,
       v8::String::NewFromTwoByte(isolate, data, new_type, length));
 }
 
+const v8::String* v8__String__Concat(v8::Isolate* isolate,
+                                     const v8::String& left,
+                                     const v8::String& right) {
+  return local_to_ptr(
+      v8::String::Concat(isolate, ptr_to_local(&left), ptr_to_local(&right)));
+}
+
 int v8__String__Length(const v8::String& self) { return self.Length(); }
 
 int v8__String__Utf8Length(const v8::String& self, v8::Isolate* isolate) {

--- a/src/string.rs
+++ b/src/string.rs
@@ -106,6 +106,12 @@ unsafe extern "C" {
     length: int,
   ) -> *const String;
 
+  fn v8__String__Concat(
+    isolate: *mut RealIsolate,
+    left: *const String,
+    right: *const String,
+  ) -> *const String;
+
   fn v8__String__Length(this: *const String) -> int;
 
   fn v8__String__Utf8Length(
@@ -662,6 +668,22 @@ impl String {
     value: &str,
   ) -> Option<Local<'s, String>> {
     Self::new_from_utf8(scope, value.as_ref(), NewStringType::Normal)
+  }
+
+  /// Creates a new string by concatenating `left` and `right`.
+  #[inline(always)]
+  pub fn concat<'s>(
+    scope: &PinScope<'s, '_, ()>,
+    left: Local<String>,
+    right: Local<String>,
+  ) -> Local<'s, String> {
+    unsafe {
+      scope
+        .cast_local(|sd| {
+          v8__String__Concat(sd.get_isolate_ptr(), &*left, &*right)
+        })
+        .unwrap()
+    }
   }
 
   /// Compile-time function to create an external string resource.

--- a/src/string.rs
+++ b/src/string.rs
@@ -671,18 +671,18 @@ impl String {
   }
 
   /// Creates a new string by concatenating `left` and `right`.
+  /// Returns `None` if the resulting string would exceed
+  /// `v8::String::kMaxLength`.
   #[inline(always)]
   pub fn concat<'s>(
     scope: &PinScope<'s, '_, ()>,
     left: Local<String>,
     right: Local<String>,
-  ) -> Local<'s, String> {
+  ) -> Option<Local<'s, String>> {
     unsafe {
-      scope
-        .cast_local(|sd| {
-          v8__String__Concat(sd.get_isolate_ptr(), &*left, &*right)
-        })
-        .unwrap()
+      scope.cast_local(|sd| {
+        v8__String__Concat(sd.get_isolate_ptr(), &*left, &*right)
+      })
     }
   }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -12428,6 +12428,26 @@ fn clear_slots_annex_uninitialized() {
 }
 
 #[test]
+fn string_concat() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  v8::scope!(let scope, isolate);
+
+  let context = v8::Context::new(scope, Default::default());
+  let scope = &mut v8::ContextScope::new(scope, context);
+
+  let left = v8::String::new(scope, "hello").unwrap();
+  let right = v8::String::new(scope, " world").unwrap();
+  let result = v8::String::concat(scope, left, right);
+  assert_eq!(result.to_rust_string_lossy(scope), "hello world");
+
+  // Concat with empty string.
+  let empty = v8::String::empty(scope);
+  let result2 = v8::String::concat(scope, left, empty);
+  assert_eq!(result2.to_rust_string_lossy(scope), "hello");
+}
+
+#[test]
 fn string_valueview() {
   let _setup_guard = setup::parallel_test();
   let mut isolate = v8::Isolate::new(Default::default());

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -12438,12 +12438,12 @@ fn string_concat() {
 
   let left = v8::String::new(scope, "hello").unwrap();
   let right = v8::String::new(scope, " world").unwrap();
-  let result = v8::String::concat(scope, left, right);
+  let result = v8::String::concat(scope, left, right).unwrap();
   assert_eq!(result.to_rust_string_lossy(scope), "hello world");
 
   // Concat with empty string.
   let empty = v8::String::empty(scope);
-  let result2 = v8::String::concat(scope, left, empty);
+  let result2 = v8::String::concat(scope, left, empty).unwrap();
   assert_eq!(result2.to_rust_string_lossy(scope), "hello");
 }
 


### PR DESCRIPTION
## Summary
- Add C++ binding, Rust FFI, and public `v8::String::concat(scope, left, right)` method wrapping `v8::String::Concat`
- Add test covering normal concatenation and concatenation with an empty string

## Test plan
- [ ] CI passes (`string_concat` test)