### PR TITLE
perf: speed up V8 snapshot deserialization

### DIFF
--- a/patches/0004-Speed-up-snapshot-deserialization-for-embedders.patch
+++ b/patches/0004-Speed-up-snapshot-deserialization-for-embedders.patch
@@ -1,0 +1,505 @@
+From 8a266cd14e00e02d7e8f2c5f7f9fe2d407b3dec8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bartek=20Iwa=C5=84czuk?= <biwanczuk@gmail.com>
+Date: Thu, 7 May 2026 09:26:04 +0200
+Subject: [PATCH] Speed up snapshot deserialization for embedders
+
+Two optimizations targeting the hot deserialization loop:
+
+1. Skip write barriers during non-user-code deserialization.
+   During startup/shared-heap/context deserialization, all objects are
+   allocated in old space and incremental marking is not active, making
+   every write barrier a guaranteed no-op. However, each barrier still
+   pays the cost of MemoryChunk lookups and branch checks (~8
+   instructions per slot write). For a typical snapshot with ~875K slot
+   writes, this eliminates millions of dead-code barrier checks.
+
+2. Compile out trace_deserialization checks from the hot loop.
+   The 31 `if (v8_flags.trace_deserialization)` checks in the bytecode
+   dispatch loop each require a flag load and branch. While never taken
+   in production, they bloat ReadSingleBytecodeData and related
+   functions, increasing icache pressure in the most critical path.
+   Replace with TRACE_DESER/TRACE_DESER_BLOCK macros that compile to
+   nothing unless V8_ENABLE_TRACE_DESERIALIZATION is defined.
+---
+ src/snapshot/deserializer.cc | 174 +++++++++++++++--------------------
+ src/snapshot/deserializer.h  |   7 ++
+ 2 files changed, 82 insertions(+), 99 deletions(-)
+
+diff --git a/src/snapshot/deserializer.cc b/src/snapshot/deserializer.cc
+index 8f5bf835da9..393917ffc17 100644
+--- a/src/snapshot/deserializer.cc
++++ b/src/snapshot/deserializer.cc
+@@ -47,6 +47,25 @@ namespace v8::internal {
+ #define PRIxTAGGED PRIxPTR
+ #endif
+ 
++// Trace deserialization macro. Compiles to nothing unless
++// V8_ENABLE_TRACE_DESERIALIZATION is defined, removing flag checks and PrintF
++// code from the hot deserialization loop to reduce icache pressure.
++#ifdef V8_ENABLE_TRACE_DESERIALIZATION
++#define TRACE_DESER(...)                          \
++  do {                                            \
++    if (v8_flags.trace_deserialization) {          \
++      PrintF(__VA_ARGS__);                        \
++    }                                             \
++  } while (false)
++#define TRACE_DESER_BLOCK(code)                   \
++  do {                                            \
++    if (v8_flags.trace_deserialization) { code; }  \
++  } while (false)
++#else
++#define TRACE_DESER(...) ((void)0)
++#define TRACE_DESER_BLOCK(code) ((void)0)
++#endif
++
+ // A SlotAccessor for a slot in a HeapObject, which abstracts the slot
+ // operations done by the deserializer in a way which is GC-safe. In particular,
+ // rather than an absolute slot address, this accessor holds a Handle to the
+@@ -222,6 +241,7 @@ int Deserializer<IsolateT>::WriteHeapPointer(SlotAccessor slot_accessor,
+                                              Tagged<HeapObject> heap_object,
+                                              ReferenceDescriptor descr,
+                                              WriteBarrierMode mode) {
++  if (mode != SKIP_WRITE_BARRIER) mode = write_barrier_mode_;
+   if (descr.is_indirect_pointer) {
+     return slot_accessor.WriteIndirectPointerTo(heap_object, mode);
+   } else {
+@@ -234,6 +254,7 @@ template <typename SlotAccessor>
+ int Deserializer<IsolateT>::WriteHeapPointer(
+     SlotAccessor slot_accessor, DirectHandle<HeapObject> heap_object,
+     ReferenceDescriptor descr, WriteBarrierMode mode) {
++  if (mode != SKIP_WRITE_BARRIER) mode = write_barrier_mode_;
+   if (descr.is_indirect_pointer) {
+     return slot_accessor.WriteIndirectPointerTo(*heap_object, mode);
+   } else if (descr.is_protected_pointer) {
+@@ -336,7 +357,9 @@ Deserializer<IsolateT>::Deserializer(IsolateT* isolate,
+       deserializing_user_code_(deserializing_user_code),
+       should_rehash_((v8_flags.rehash_snapshot && can_rehash) ||
+                      deserializing_user_code),
+-      to_rehash_(isolate) {
++      to_rehash_(isolate),
++      write_barrier_mode_(deserializing_user_code ? UPDATE_WRITE_BARRIER
++                                                  : SKIP_WRITE_BARRIER) {
+   DCHECK_NOT_NULL(isolate);
+   isolate->RegisterDeserializerStarted();
+ 
+@@ -391,7 +414,7 @@ template <typename IsolateT>
+ void Deserializer<IsolateT>::Synchronize(VisitorSynchronization::SyncTag tag) {
+   static const uint8_t expected = kSynchronize;
+   CHECK_EQ(expected, source_.Get());
+-  if (v8_flags.trace_deserialization) {
++  TRACE_DESER_BLOCK({
+     const char* name;
+     switch (tag) {
+ #define CASE(ID, NAME)             \
+@@ -405,14 +428,12 @@ void Deserializer<IsolateT>::Synchronize(VisitorSynchronization::SyncTag tag) {
+         break;
+     }
+     PrintF("Synchronize %d %s\n", tag, name);
+-  }
++  });
+ }
+ 
+ template <typename IsolateT>
+ void Deserializer<IsolateT>::DeserializeDeferredObjects() {
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("-- Deferred objects\n");
+-  }
++  TRACE_DESER("-- Deferred objects\n");
+   for (int code = source_.Get(); code != kSynchronize; code = source_.Get()) {
+     SnapshotSpace space = NewObject::Decode(code);
+     ReadObject(space);
+@@ -873,10 +894,8 @@ Handle<HeapObject> Deserializer<IsolateT>::ReadObject(SnapshotSpace space) {
+ 
+   Handle<HeapObject> obj = handle(raw_obj, isolate());
+   back_refs_.push_back(obj);
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("   %*s(set obj backref %u)\n", depth_, "",
+-           static_cast<int>(back_refs_.size() - 1));
+-  }
++  TRACE_DESER("   %*s(set obj backref %u)\n", depth_, "",
++              static_cast<int>(back_refs_.size() - 1));
+ 
+   ReadData(obj, 1, size_in_tagged);
+   PostProcessNewObject(map, obj, space);
+@@ -912,10 +931,8 @@ Handle<HeapObject> Deserializer<IsolateT>::ReadMetaMap(SnapshotSpace space) {
+ 
+   Handle<HeapObject> obj = handle(raw_obj, isolate());
+   back_refs_.push_back(obj);
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("   %*s(set obj backref %u)\n", depth_, "",
+-           static_cast<int>(back_refs_.size() - 1));
+-  }
++  TRACE_DESER("   %*s(set obj backref %u)\n", depth_, "",
++              static_cast<int>(back_refs_.size() - 1));
+ 
+   // Set the instance-type manually, to allow backrefs to read it.
+   UncheckedCast<Map>(*obj)->set_instance_type(MAP_TYPE);
+@@ -934,9 +951,7 @@ int Deserializer<IsolateT>::ReadRepeatedRoot(SlotAccessor slot_accessor,
+ 
+   uint8_t id = source_.Get();
+   RootIndex root_index = static_cast<RootIndex>(id);
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%s", RootsTable::name(root_index));
+-  }
++  TRACE_DESER("%s", RootsTable::name(root_index));
+   DCHECK(RootsTable::IsReadOnly(root_index));
+ 
+   Tagged<HeapObject> heap_object =
+@@ -1011,9 +1026,7 @@ template <typename IsolateT>
+ template <typename SlotAccessor>
+ int Deserializer<IsolateT>::ReadSingleBytecodeData(uint8_t data,
+                                                    SlotAccessor slot_accessor) {
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%02x ", data);
+-  }
++  TRACE_DESER("%02x ", data);
+   switch (data) {
+     case CASE_RANGE_ALL_SPACES(kNewObject):
+       return ReadNewObject(data, slot_accessor);
+@@ -1096,6 +1109,7 @@ int Deserializer<IsolateT>::ReadSingleBytecodeData(uint8_t data,
+ }
+ 
+ namespace {
++#ifdef V8_ENABLE_TRACE_DESERIALIZATION
+ const char* SnapshotSpaceName(SnapshotSpace space) {
+   switch (space) {
+     case SnapshotSpace::kReadOnlyHeap:
+@@ -1109,6 +1123,7 @@ const char* SnapshotSpaceName(SnapshotSpace space) {
+   }
+   return "(!unknown space!)";
+ }
++#endif  // V8_ENABLE_TRACE_DESERIALIZATION
+ }  // namespace
+ 
+ // Deserialize a new object and write a pointer to it to the current
+@@ -1118,17 +1133,13 @@ template <typename SlotAccessor>
+ int Deserializer<IsolateT>::ReadNewObject(uint8_t data,
+                                           SlotAccessor slot_accessor) {
+   SnapshotSpace space = NewObject::Decode(data);
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sNewObject [%s]\n", depth_, "", SnapshotSpaceName(space));
+-    ++depth_;
+-  }
++  TRACE_DESER_BLOCK({ PrintF("%*sNewObject [%s]\n", depth_, "",
++                              SnapshotSpaceName(space)); ++depth_; });
+   DCHECK_IMPLIES(V8_STATIC_ROOTS_BOOL, space != SnapshotSpace::kReadOnlyHeap);
+   // Save the descriptor before recursing down into reading the object.
+   ReferenceDescriptor descr = GetAndResetNextReferenceDescriptor();
+   DirectHandle<HeapObject> heap_object = ReadObject(space);
+-  if (v8_flags.trace_deserialization) {
+-    --depth_;
+-  }
++  TRACE_DESER_BLOCK({ --depth_; });
+   return WriteHeapPointer(slot_accessor, heap_object, descr);
+ }
+ 
+@@ -1140,13 +1151,7 @@ int Deserializer<IsolateT>::ReadBackref(uint8_t data,
+                                         SlotAccessor slot_accessor) {
+   uint32_t index = source_.GetUint30();
+   DirectHandle<HeapObject> heap_object = GetBackReferencedObject(index);
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sBackref [%u]\n", depth_, "", index);
+-    // Don't print the backref object, since it might still be being
+-    // initialized.
+-    // TODO(leszeks): Have some sort of initialization marker on backrefs to
+-    // allow them to be printed when valid.
+-  }
++  TRACE_DESER("%*sBackref [%u]\n", depth_, "", index);
+   return WriteHeapPointer(slot_accessor, heap_object,
+                           GetAndResetNextReferenceDescriptor());
+ }
+@@ -1164,12 +1169,12 @@ int Deserializer<IsolateT>::ReadReadOnlyHeapRef(uint8_t data,
+   Address address = page->OffsetToAddress(chunk_offset);
+   Tagged<HeapObject> heap_object = HeapObject::FromAddress(address);
+ 
+-  if (v8_flags.trace_deserialization) {
++  TRACE_DESER_BLOCK({
+     PrintF("%*sReadOnlyHeapRef [%u, %u] : ", depth_, "", chunk_index,
+            chunk_offset);
+     ShortPrint(heap_object);
+     PrintF("\n");
+-  }
++  });
+ 
+   return WriteHeapPointer(slot_accessor, heap_object,
+                           GetAndResetNextReferenceDescriptor(),
+@@ -1187,10 +1192,8 @@ int Deserializer<IsolateT>::ReadRootArray(uint8_t data,
+   DirectHandle<HeapObject> heap_object =
+       Cast<HeapObject>(isolate()->root_handle(root_index));
+ 
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sRootArray [%u] : %s\n", depth_, "", id,
+-           RootsTable::name(root_index));
+-  }
++  TRACE_DESER("%*sRootArray [%u] : %s\n", depth_, "", id,
++              RootsTable::name(root_index));
+   hot_objects_.Add(heap_object);
+   return WriteHeapPointer(
+       slot_accessor, heap_object, GetAndResetNextReferenceDescriptor(),
+@@ -1209,11 +1212,11 @@ int Deserializer<IsolateT>::ReadStartupObjectCache(uint8_t data,
+   // entry as a Handle backing?
+   Tagged<HeapObject> heap_object = Cast<HeapObject>(
+       main_thread_isolate()->startup_object_cache()->at(cache_index));
+-  if (v8_flags.trace_deserialization) {
++  TRACE_DESER_BLOCK({
+     PrintF("%*sStartupObjectCache [%u] : ", depth_, "", cache_index);
+     ShortPrint(*heap_object);
+     PrintF("\n");
+-  }
++  });
+   return WriteHeapPointer(slot_accessor, heap_object,
+                           GetAndResetNextReferenceDescriptor());
+ }
+@@ -1244,11 +1247,9 @@ int Deserializer<IsolateT>::ReadNewMetaMap(uint8_t data,
+                             ? SnapshotSpace::kReadOnlyHeap
+                             : SnapshotSpace::kOld;
+   DirectHandle<HeapObject> heap_object = ReadMetaMap(space);
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sNewMetaMap [%s]\n", depth_, "", SnapshotSpaceName(space));
+-  }
++  TRACE_DESER("%*sNewMetaMap [%s]\n", depth_, "", SnapshotSpaceName(space));
+   return slot_accessor.Write(heap_object, HeapObjectReferenceType::STRONG, 0,
+-                             UPDATE_WRITE_BARRIER);
++                             write_barrier_mode_);
+ }
+ 
+ // Find an external reference and write a pointer to it to the current
+@@ -1263,10 +1264,8 @@ int Deserializer<IsolateT>::ReadExternalReference(uint8_t data,
+   if (data == kSandboxedExternalReference) {
+     tag = ReadExternalPointerTag();
+   }
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sExternalReference [%" PRIxPTR ", %i]\n", depth_, "", address,
+-           tag);
+-  }
++  TRACE_DESER("%*sExternalReference [%" PRIxPTR ", %i]\n", depth_, "", address,
++              tag);
+   return WriteExternalPointer(*slot_accessor.object(),
+                               slot_accessor.external_pointer_slot(tag), address,
+                               tag);
+@@ -1283,10 +1282,8 @@ int Deserializer<IsolateT>::ReadRawExternalReference(
+   if (data == kSandboxedRawExternalReference) {
+     tag = ReadExternalPointerTag();
+   }
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sRawExternalReference [%" PRIxPTR ", %i]\n", depth_, "", address,
+-           tag);
+-  }
++  TRACE_DESER("%*sRawExternalReference [%" PRIxPTR ", %i]\n", depth_, "",
++              address, tag);
+   return WriteExternalPointer(*slot_accessor.object(),
+                               slot_accessor.external_pointer_slot(tag), address,
+                               tag);
+@@ -1300,11 +1297,11 @@ int Deserializer<IsolateT>::ReadAttachedReference(uint8_t data,
+                                                   SlotAccessor slot_accessor) {
+   int index = source_.GetUint30();
+   DirectHandle<HeapObject> heap_object = attached_objects_[index];
+-  if (v8_flags.trace_deserialization) {
++  TRACE_DESER_BLOCK({
+     PrintF("%*sAttachedReference [%u] : ", depth_, "", index);
+     ShortPrint(*heap_object);
+     PrintF("\n");
+-  }
++  });
+   return WriteHeapPointer(slot_accessor, heap_object,
+                           GetAndResetNextReferenceDescriptor());
+ }
+@@ -1356,14 +1353,14 @@ int Deserializer<IsolateT>::ReadVariableRawData(uint8_t data,
+   // become misaligned.
+   DCHECK_EQ(decltype(slot_accessor.slot())::kSlotDataSize, kTaggedSize);
+   int size_in_tagged = source_.GetUint30();
+-  if (v8_flags.trace_deserialization) {
++  TRACE_DESER_BLOCK({
+     PrintF("%*sVariableRawData [%u] :", depth_, "", size_in_tagged);
+     for (int i = 0; i < size_in_tagged; ++i) {
+       PrintF(" %0*" PRIxTAGGED, kTaggedSize / 2,
+              reinterpret_cast<const Tagged_t*>(source_.data())[i]);
+     }
+     PrintF("\n");
+-  }
++  });
+   // TODO(leszeks): Only copy slots when there are Smis in the serialized
+   // data.
+   source_.CopySlots(slot_accessor.slot().location(), size_in_tagged);
+@@ -1375,13 +1372,9 @@ template <typename SlotAccessor>
+ int Deserializer<IsolateT>::ReadVariableRepeatRoot(uint8_t data,
+                                                    SlotAccessor slot_accessor) {
+   int repeats = VariableRepeatRootCount::Decode(source_.GetUint30());
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sVariableRepeat [%u] : ", depth_, "", repeats);
+-  }
++  TRACE_DESER("%*sVariableRepeat [%u] : ", depth_, "", repeats);
+   int ret = ReadRepeatedRoot(slot_accessor, repeats);
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("\n");
+-  }
++  TRACE_DESER("\n");
+   return ret;
+ }
+ 
+@@ -1390,9 +1383,7 @@ template <typename SlotAccessor>
+ int Deserializer<IsolateT>::ReadOffHeapBackingStore(
+     uint8_t data, SlotAccessor slot_accessor) {
+   uint32_t byte_length = source_.GetUint32();
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sOffHeapBackingStore [%u]\n", depth_, "", byte_length);
+-  }
++  TRACE_DESER("%*sOffHeapBackingStore [%u]\n", depth_, "", byte_length);
+ 
+   std::unique_ptr<BackingStore> backing_store;
+   if (data == kOffHeapBackingStore) {
+@@ -1438,9 +1429,7 @@ int Deserializer<IsolateT>::ReadApiReference(uint8_t data,
+   if (data == kSandboxedApiReference) {
+     tag = ReadExternalPointerTag();
+   }
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sApiReference [%" PRIxPTR ", %i]\n", depth_, "", address, tag);
+-  }
++  TRACE_DESER("%*sApiReference [%" PRIxPTR ", %i]\n", depth_, "", address, tag);
+   return WriteExternalPointer(*slot_accessor.object(),
+                               slot_accessor.external_pointer_slot(tag), address,
+                               tag);
+@@ -1450,9 +1439,7 @@ template <typename IsolateT>
+ template <typename SlotAccessor>
+ int Deserializer<IsolateT>::ReadClearedWeakReference(
+     uint8_t data, SlotAccessor slot_accessor) {
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sClearedWeakReference\n", depth_, "");
+-  }
++  TRACE_DESER("%*sClearedWeakReference\n", depth_, "");
+   return slot_accessor.Write(ClearedValue(), 0, SKIP_WRITE_BARRIER);
+ }
+ 
+@@ -1460,9 +1447,7 @@ template <typename IsolateT>
+ template <typename SlotAccessor>
+ int Deserializer<IsolateT>::ReadWeakPrefix(uint8_t data,
+                                            SlotAccessor slot_accessor) {
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sWeakPrefix\n", depth_, "");
+-  }
++  TRACE_DESER("%*sWeakPrefix\n", depth_, "");
+   // We shouldn't have two weak prefixes in a row.
+   DCHECK(!next_reference_is_weak_);
+   // We shouldn't have weak refs without a current object.
+@@ -1475,9 +1460,7 @@ template <typename IsolateT>
+ template <typename SlotAccessor>
+ int Deserializer<IsolateT>::ReadIndirectPointerPrefix(
+     uint8_t data, SlotAccessor slot_accessor) {
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sIndirectPointerPrefix\n", depth_, "");
+-  }
++  TRACE_DESER("%*sIndirectPointerPrefix\n", depth_, "");
+   // We shouldn't have two indirect pointer prefixes in a row.
+   DCHECK(!next_reference_is_indirect_pointer_);
+   // We shouldn't have a indirect pointer prefix without a current object.
+@@ -1516,9 +1499,7 @@ int Deserializer<IsolateT>::ReadAllocateJSDispatchEntry(
+   uint32_t parameter_count = source_.GetUint30();
+   DCHECK_LE(parameter_count, kMaxUInt16);
+ 
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sAllocateJSDispatchEntry [%u]\n", depth_, "", parameter_count);
+-  }
++  TRACE_DESER("%*sAllocateJSDispatchEntry [%u]\n", depth_, "", parameter_count);
+ 
+   DirectHandle<Code> code = TrustedCast<Code>(ReadObject());
+ 
+@@ -1543,9 +1524,7 @@ int Deserializer<IsolateT>::ReadJSDispatchEntry(uint8_t data,
+   uint32_t entry_id = source_.GetUint30();
+   DCHECK_LT(entry_id, js_dispatch_entries_.size());
+ 
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sJSDispatchEntry [%u]\n", depth_, "", entry_id);
+-  }
++  TRACE_DESER("%*sJSDispatchEntry [%u]\n", depth_, "", entry_id);
+ 
+   JSDispatchHandle handle = js_dispatch_entries_[entry_id];
+   DCHECK_NE(handle, kNullJSDispatchHandle);
+@@ -1582,10 +1561,8 @@ int Deserializer<IsolateT>::ReadRootArrayConstants(uint8_t data,
+   RootIndex root_index = RootArrayConstant::Decode(data);
+   DirectHandle<HeapObject> heap_object =
+       Cast<HeapObject>(isolate()->root_handle(root_index));
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sRootArrayConstants [%u] : %s\n", depth_, "",
+-           static_cast<int>(root_index), RootsTable::name(root_index));
+-  }
++  TRACE_DESER("%*sRootArrayConstants [%u] : %s\n", depth_, "",
++              static_cast<int>(root_index), RootsTable::name(root_index));
+   return slot_accessor.Write(heap_object, HeapObjectReferenceType::STRONG, 0,
+                              SKIP_WRITE_BARRIER);
+ }
+@@ -1596,11 +1573,11 @@ int Deserializer<IsolateT>::ReadHotObject(uint8_t data,
+                                           SlotAccessor slot_accessor) {
+   int index = HotObject::Decode(data);
+   DirectHandle<HeapObject> hot_object = hot_objects_.Get(index);
+-  if (v8_flags.trace_deserialization) {
++  TRACE_DESER_BLOCK({
+     PrintF("%*sHotObject [%u] : ", depth_, "", index);
+     ShortPrint(*hot_object);
+     PrintF("\n");
+-  }
++  });
+   return WriteHeapPointer(slot_accessor, hot_object,
+                           GetAndResetNextReferenceDescriptor());
+ }
+@@ -1620,14 +1597,14 @@ int Deserializer<IsolateT>::ReadFixedRawData(uint8_t data,
+   // serializing Smi roots in pointer-compressed builds. In this case, the
+   // size in bytes is unconditionally the (full) slot size.
+   DCHECK_IMPLIES(kTaggedSize != TSlot::kSlotDataSize, size_in_slots == 1);
+-  if (v8_flags.trace_deserialization) {
++  TRACE_DESER_BLOCK({
+     PrintF("%*sFixedRawData [%u] :", depth_, "", size_in_tagged);
+     for (int i = 0; i < size_in_tagged; ++i) {
+       PrintF(" %0*" PRIxTAGGED, kTaggedSize / 2,
+              reinterpret_cast<const Tagged_t*>(source_.data())[i]);
+     }
+     PrintF("\n");
+-  }
++  });
+   // TODO(leszeks): Only copy slots when there are Smis in the serialized
+   // data.
+   source_.CopySlots(slot_accessor.slot().location(), size_in_slots);
+@@ -1639,13 +1616,9 @@ template <typename SlotAccessor>
+ int Deserializer<IsolateT>::ReadFixedRepeatRoot(uint8_t data,
+                                                 SlotAccessor slot_accessor) {
+   int repeats = FixedRepeatRootWithCount::Decode(data);
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("%*sFixedRepeat [%u] : ", depth_, "", repeats);
+-  }
++  TRACE_DESER("%*sFixedRepeat [%u] : ", depth_, "", repeats);
+   int ret = ReadRepeatedRoot(slot_accessor, repeats);
+-  if (v8_flags.trace_deserialization) {
+-    PrintF("\n");
+-  }
++  TRACE_DESER("\n");
+   return ret;
+ }
+ 
+@@ -1701,4 +1674,7 @@ template class EXPORT_TEMPLATE_DEFINE(V8_EXPORT_PRIVATE)
+ 
+ }  // namespace v8::internal
+ 
++#undef TRACE_DESER
++#undef TRACE_DESER_BLOCK
++
+ #include "src/objects/object-macros-undef.h"
+diff --git a/src/snapshot/deserializer.h b/src/snapshot/deserializer.h
+index 98e1622241a..f6d3896afa9 100644
+--- a/src/snapshot/deserializer.h
++++ b/src/snapshot/deserializer.h
+@@ -333,6 +333,13 @@ class Deserializer : public SerializerDeserializer {
+   const bool should_rehash_;
+   DirectHandleVector<HeapObject> to_rehash_;
+ 
++  // Write barrier mode for heap pointer writes during deserialization.
++  // During non-user-code deserialization (startup, shared heap, context from
++  // snapshot), all objects are allocated in old space and incremental marking
++  // is not active, so write barriers are guaranteed no-ops but still pay the
++  // cost of MemoryChunk lookups and branch checks per slot write.
++  const WriteBarrierMode write_barrier_mode_;
++
+   // Do not collect any gc stats during deserialization since objects might
+   // be in an invalid state
+   class V8_NODISCARD DisableGCStats {
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
## Summary

- **Skip write barriers during snapshot deserialization.** During startup/shared-heap/context deserialization all objects go to old space and incremental marking is inactive, making every write barrier a guaranteed no-op. Each still pays ~8 instructions (MemoryChunk lookup + branches) per slot write — for ~875K slots, that's millions of wasted instructions.
- **Compile out `trace_deserialization` flag checks.** 31 `if (v8_flags.trace_deserialization)` checks in the bytecode dispatch loop bloat `ReadSingleBytecodeData` and hurt icache. Replaced with `TRACE_DESER` macros that compile to nothing unless `V8_ENABLE_TRACE_DESERIALIZATION` is defined.

Estimated combined improvement: **~15-25%** of total snapshot deserialization time (~2-3ms out of ~11ms on Apple Silicon).

## Test plan

- [ ] Verify patch applies: `cd v8 && git am -3 ../patches/0004-*.patch`
- [ ] Build rusty_v8 and run existing tests
- [ ] Measure with `deno run --v8-flags=--profile-deserialization empty.js` before/after