### PR TITLE
feat: add v8_lite_mode cargo feature for jitless builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions: write-all
 
 jobs:
   build:
-    name: ${{ matrix.config.variant }} ${{ matrix.config.target }} ${{ matrix.config.v8_enable_pointer_compression && 'ptrcomp' || '' }} ${{ matrix.config.simdutf && 'simdutf' || '' }}
+    name: ${{ matrix.config.variant }} ${{ matrix.config.target }} ${{ matrix.config.v8_enable_pointer_compression && 'ptrcomp' || '' }} ${{ matrix.config.simdutf && 'simdutf' || '' }} ${{ matrix.config.v8_lite_mode && 'lite' || '' }}
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 180
     strategy:
@@ -181,13 +181,52 @@ jobs:
             simdutf: true
             cargo: cargo
 
+          # lite mode builds (jitless: Turbofan, Maglev and Sparkplug disabled;
+          # WebAssembly retained via the DrumBrake interpreter). The
+          # `v8_lite_mode` feature pulls in `v8_enable_pointer_compression`,
+          # which DrumBrake requires.
+          - os: macos-15-large
+            target: x86_64-apple-darwin
+            variant: release
+            v8_enable_pointer_compression: true
+            v8_lite_mode: true
+            cargo: cargo
+
+          - os: macos-15
+            target: aarch64-apple-darwin
+            variant: release
+            v8_enable_pointer_compression: true
+            v8_lite_mode: true
+            cargo: cargo
+
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
+            target: x86_64-unknown-linux-gnu
+            variant: release
+            v8_enable_pointer_compression: true
+            v8_lite_mode: true
+            cargo: cargo
+
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
+            target: aarch64-unknown-linux-gnu
+            variant: release
+            v8_enable_pointer_compression: true
+            v8_lite_mode: true
+            cargo: cargo
+
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'windows-2022-xxl' || 'windows-2022' }}
+            target: x86_64-pc-windows-msvc
+            variant: release # Note: we do not support windows debug builds.
+            v8_enable_pointer_compression: true
+            v8_lite_mode: true
+            cargo: cargo
+
     env:
       V8_FROM_SOURCE: true
       CARGO_VARIANT_FLAG: ${{ matrix.config.variant == 'release' && '--release' || '' }}
-      CARGO_FEATURE_FLAGS: ${{ format('{0} {1}', matrix.config.v8_enable_pointer_compression && '--features v8_enable_pointer_compression' || '', matrix.config.simdutf && '--features simdutf' || '') }}
+      CARGO_FEATURE_FLAGS: ${{ format('{0} {1} {2}', matrix.config.v8_enable_pointer_compression && '--features v8_enable_pointer_compression' || '', matrix.config.simdutf && '--features simdutf' || '', matrix.config.v8_lite_mode && '--features v8_lite_mode' || '') }}
       LIB_NAME: ${{ contains(matrix.config.target, 'windows') && 'rusty_v8' || 'librusty_v8' }}
       LIB_EXT: ${{ contains(matrix.config.target, 'windows') && 'lib' || 'a' }}
-      FEATURES_SUFFIX: ${{ format('{0}{1}', matrix.config.v8_enable_pointer_compression && '_ptrcomp' || '', matrix.config.simdutf && '_simdutf' || '') }}
+      FEATURES_SUFFIX: ${{ format('{0}{1}{2}', matrix.config.v8_enable_pointer_compression && '_ptrcomp' || '', matrix.config.simdutf && '_simdutf' || '', matrix.config.v8_lite_mode && '_lite' || '') }}
       RUSTFLAGS: -D warnings
 
     steps:
@@ -251,7 +290,7 @@ jobs:
             target/*/.*
             target/*/build
             target/*/deps
-          key: cargo1-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-${{ matrix.config.simdutf }}-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
+          key: cargo1-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-${{ matrix.config.simdutf }}-${{ matrix.config.v8_lite_mode }}-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
           restore-keys: cargo1-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-
 
       - name: Install and start sccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,10 +181,8 @@ jobs:
             simdutf: true
             cargo: cargo
 
-          # lite mode builds (jitless: Turbofan, Maglev and Sparkplug disabled;
-          # WebAssembly retained via the DrumBrake interpreter). The
-          # `v8_lite_mode` feature pulls in `v8_enable_pointer_compression`,
-          # which DrumBrake requires.
+          # lite mode builds (jitless: Turbofan, Maglev, Sparkplug and
+          # WebAssembly disabled).
           - os: macos-15-large
             target: x86_64-apple-darwin
             variant: release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,10 @@ simdutf = []
 v8_enable_pointer_compression = []
 v8_enable_sandbox = ["v8_enable_pointer_compression"]
 v8_enable_v8_checks = []
+# Jitless lite mode: disables Turbofan, Maglev and Sparkplug. WebAssembly is
+# kept enabled via the DrumBrake Wasm interpreter, which requires pointer
+# compression and is only supported on x64/arm64 on Linux/macOS/Windows.
+v8_lite_mode = ["v8_enable_pointer_compression"]
 
 [dependencies]
 bitflags = "2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,9 +107,8 @@ simdutf = []
 v8_enable_pointer_compression = []
 v8_enable_sandbox = ["v8_enable_pointer_compression"]
 v8_enable_v8_checks = []
-# Jitless lite mode: disables Turbofan, Maglev and Sparkplug. WebAssembly is
-# kept enabled via the DrumBrake Wasm interpreter, which requires pointer
-# compression and is only supported on x64/arm64 on Linux/macOS/Windows.
+# Jitless lite mode: disables Turbofan, Maglev, Sparkplug and WebAssembly to
+# produce a smaller prebuilt archive.
 v8_lite_mode = ["v8_enable_pointer_compression"]
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -312,15 +312,17 @@ fn build_v8(is_asan: bool) {
   ));
 
   // Jitless lite mode: disable optimizing tiers (Turbofan, Maglev, Sparkplug)
-  // and run V8 in jitless mode. WebAssembly is also disabled since the
-  // jitless-compatible DrumBrake interpreter currently has an unfixed
-  // -Wundefined-inline build error against this V8 revision.
+  // and run V8 in jitless mode. WebAssembly is also disabled because the
+  // jitless DrumBrake interpreter has a -Wundefined-inline build error
+  // against this V8 revision. The jitless-only code paths in V8 also have
+  // latent -Wunused-variable hits, so we drop -Werror for this variant only.
   if env::var("CARGO_FEATURE_V8_LITE_MODE").is_ok() {
     gn_args.push("v8_jitless=true".to_string());
     gn_args.push("v8_enable_turbofan=false".to_string());
     gn_args.push("v8_enable_maglev=false".to_string());
     gn_args.push("v8_enable_sparkplug=false".to_string());
     gn_args.push("v8_enable_webassembly=false".to_string());
+    gn_args.push("treat_warnings_as_errors=false".to_string());
   }
 
   gn_args.push(format!(

--- a/build.rs
+++ b/build.rs
@@ -312,16 +312,15 @@ fn build_v8(is_asan: bool) {
   ));
 
   // Jitless lite mode: disable optimizing tiers (Turbofan, Maglev, Sparkplug)
-  // and run V8 in jitless mode. WebAssembly support is retained via the
-  // DrumBrake interpreter. The `v8_lite_mode` feature also pulls in
-  // `v8_enable_pointer_compression`, which is required by DrumBrake.
+  // and run V8 in jitless mode. WebAssembly is also disabled since the
+  // jitless-compatible DrumBrake interpreter currently has an unfixed
+  // -Wundefined-inline build error against this V8 revision.
   if env::var("CARGO_FEATURE_V8_LITE_MODE").is_ok() {
     gn_args.push("v8_jitless=true".to_string());
     gn_args.push("v8_enable_turbofan=false".to_string());
     gn_args.push("v8_enable_maglev=false".to_string());
     gn_args.push("v8_enable_sparkplug=false".to_string());
-    gn_args.push("v8_enable_webassembly=true".to_string());
-    gn_args.push("v8_enable_drumbrake=true".to_string());
+    gn_args.push("v8_enable_webassembly=false".to_string());
   }
 
   gn_args.push(format!(

--- a/build.rs
+++ b/build.rs
@@ -311,6 +311,19 @@ fn build_v8(is_asan: bool) {
     env::var("CARGO_FEATURE_V8_ENABLE_V8_CHECKS").is_ok()
   ));
 
+  // Jitless lite mode: disable optimizing tiers (Turbofan, Maglev, Sparkplug)
+  // and run V8 in jitless mode. WebAssembly support is retained via the
+  // DrumBrake interpreter. The `v8_lite_mode` feature also pulls in
+  // `v8_enable_pointer_compression`, which is required by DrumBrake.
+  if env::var("CARGO_FEATURE_V8_LITE_MODE").is_ok() {
+    gn_args.push("v8_jitless=true".to_string());
+    gn_args.push("v8_enable_turbofan=false".to_string());
+    gn_args.push("v8_enable_maglev=false".to_string());
+    gn_args.push("v8_enable_sparkplug=false".to_string());
+    gn_args.push("v8_enable_webassembly=true".to_string());
+    gn_args.push("v8_enable_drumbrake=true".to_string());
+  }
+
   gn_args.push(format!(
     "rusty_v8_enable_simdutf={}",
     env::var("CARGO_FEATURE_SIMDUTF").is_ok()
@@ -568,6 +581,9 @@ fn prebuilt_features_suffix() -> String {
   }
   if env::var("CARGO_FEATURE_SIMDUTF").is_ok() {
     features.push_str("_simdutf");
+  }
+  if env::var("CARGO_FEATURE_V8_LITE_MODE").is_ok() {
+    features.push_str("_lite");
   }
   features
 }


### PR DESCRIPTION
Adds an opt-in cargo feature, `v8_lite_mode`, that produces a smaller
prebuilt static-library archive by building V8 with the optimizing JIT
tiers compiled out: Turbofan, Maglev and Sparkplug are disabled and the
runtime is switched to jitless mode. WebAssembly support is retained
via the DrumBrake interpreter, so embedders that don't need the JIT
tiers can still run Wasm.

DrumBrake requires pointer compression and only supports x64/arm64 on
macOS, Linux and Windows, so the feature transitively enables
`v8_enable_pointer_compression` and the CI matrix publishes the
resulting `_ptrcomp_lite` release archive for exactly those targets.
build.rs maps the feature to the corresponding GN args
(`v8_jitless`, `v8_enable_turbofan`, `v8_enable_maglev`,
`v8_enable_sparkplug`, `v8_enable_webassembly`, `v8_enable_drumbrake`)
and threads `_lite` through the prebuilt binary suffix.