### PR TITLE
ci: declare empty permissions on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ on:
           - patch
         required: true
 
+permissions: {}
+
 jobs:
   rust:
     name: release


### PR DESCRIPTION
Pins the release job to `permissions: {}`. The job checks out the repo with `secrets.DENOBOT_PAT` and runs `deno run -A .../publish_release.ts` with `GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}`. The workflow's own `GITHUB_TOKEN` is never used.

Defense-in-depth angle: a compromised third-party action (cf. [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) on `tj-actions/changed-files`) runs inside the existing job context and exfiltrates whatever scope the workflow token holds via build logs. With `permissions: {}` the token has zero scope to leak; release authority lives only in `DENOBOT_PAT`.

Matches the per-job permission style already used in this repo's hardened workflows. YAML validated locally with `yaml.safe_load`.