### PR TITLE
perf: Reduce Global handle liveness overhead

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -12,6 +12,7 @@ use std::ptr::NonNull;
 use crate::Data;
 use crate::Isolate;
 use crate::IsolateHandle;
+use crate::isolate::IsolateLiveness;
 use crate::isolate::RealIsolate;
 use crate::scope::GetIsolate;
 use crate::scope::PinScope;
@@ -284,7 +285,7 @@ impl<'s, T> Local<'s, T> {
 #[derive(Debug)]
 pub struct Global<T> {
   data: NonNull<T>,
-  isolate_handle: IsolateHandle,
+  isolate_liveness: NonNull<IsolateLiveness>,
 }
 
 impl<T> Global<T> {
@@ -304,10 +305,10 @@ impl<T> Global<T> {
     unsafe {
       let data = v8__Global__New((*isolate).as_real_ptr(), data) as *const T;
       let data = NonNull::new_unchecked(data as *mut _);
-      let isolate_handle = (*isolate).thread_safe_handle();
+      let isolate_liveness = (*isolate).global_liveness();
       Self {
         data,
-        isolate_handle,
+        isolate_liveness,
       }
     }
   }
@@ -329,16 +330,23 @@ impl<T> Global<T> {
   /// original `Global`.
   #[inline(always)]
   pub unsafe fn from_raw(isolate: &mut Isolate, data: NonNull<T>) -> Self {
-    let isolate_handle = isolate.thread_safe_handle();
+    let isolate_liveness = isolate.global_liveness();
     Self {
       data,
-      isolate_handle,
+      isolate_liveness,
     }
   }
 
   #[inline(always)]
   pub fn open<'a>(&'a self, scope: &mut Isolate) -> &'a T {
     Handle::open(self, scope)
+  }
+
+  #[inline(always)]
+  fn get_handle_host(&self) -> HandleHost {
+    let isolate = unsafe { self.isolate_liveness.as_ref().get_isolate_ptr() };
+    NonNull::new(isolate)
+      .map_or(HandleHost::DisposedIsolate, HandleHost::Isolate)
   }
 }
 
@@ -353,7 +361,7 @@ impl<T> Clone for Global<T> {
 impl<T> Drop for Global<T> {
   fn drop(&mut self) {
     unsafe {
-      if self.isolate_handle.get_isolate_ptr().is_null() {
+      if self.isolate_liveness.as_ref().get_isolate_ptr().is_null() {
         // This `Global` handle is associated with an `Isolate` that has already
         // been disposed.
       } else {
@@ -448,14 +456,14 @@ impl<'a, 's: 'a, T> Handle for &'a Local<'s, T> {
 impl<T> Handle for Global<T> {
   type Data = T;
   fn get_handle_info(&self) -> HandleInfo<T> {
-    HandleInfo::new(self.data, (&self.isolate_handle).into())
+    HandleInfo::new(self.data, self.get_handle_host())
   }
 }
 
 impl<T> Handle for &Global<T> {
   type Data = T;
   fn get_handle_info(&self) -> HandleInfo<T> {
-    HandleInfo::new(self.data, (&self.isolate_handle).into())
+    HandleInfo::new(self.data, self.get_handle_host())
   }
 }
 
@@ -507,7 +515,7 @@ impl<T: Hash> Hash for Local<'_, T> {
 impl<T: Hash> Hash for Global<T> {
   fn hash<H: Hasher>(&self, state: &mut H) {
     unsafe {
-      if self.isolate_handle.get_isolate_ptr().is_null() {
+      if self.isolate_liveness.as_ref().get_isolate_ptr().is_null() {
         panic!("can't hash Global after its host Isolate has been disposed");
       }
       self.data.as_ref().hash(state);

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -70,6 +70,7 @@ use std::ptr::drop_in_place;
 use std::ptr::null_mut;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicPtr;
 
 /// Policy for running microtasks:
 ///   - explicit: microtasks are invoked with the
@@ -964,6 +965,11 @@ impl Isolate {
     self.get_annex().isolate_handle.clone()
   }
 
+  #[inline(always)]
+  pub(crate) fn global_liveness(&self) -> NonNull<IsolateLiveness> {
+    self.get_annex().global_liveness
+  }
+
   /// See [`IsolateHandle::terminate_execution`]
   #[inline(always)]
   pub fn terminate_execution(&self) -> bool {
@@ -1001,6 +1007,7 @@ impl Isolate {
     // Set the `isolate` pointer inside the annex struct to null, so any
     // IsolateHandle that outlives the isolate will know that it can't call
     // methods on the isolate.
+    annex.global_liveness().dispose();
     annex.isolate_handle.dispose();
 
     // Clear slots and drop owned objects that were taken out of `CreateParams`.
@@ -1904,17 +1911,28 @@ pub(crate) struct IsolateAnnex {
   finalizer_map: FinalizerMap,
   maybe_snapshot_creator: Option<SnapshotCreator>,
   isolate_handle: IsolateHandle,
+  global_liveness: NonNull<IsolateLiveness>,
 }
 
 impl IsolateAnnex {
   fn new(isolate: &Isolate, create_param_allocations: Box<dyn Any>) -> Self {
+    // Globals may be dropped after their host isolate is disposed. Keep this
+    // tiny liveness cell valid so those late drops can observe the null isolate
+    // pointer without retaining an Arc per Global.
+    let global_liveness = Box::leak(Box::new(IsolateLiveness::new(isolate)));
     Self {
       create_param_allocations,
       slots: HashMap::default(),
       finalizer_map: FinalizerMap::default(),
       maybe_snapshot_creator: None,
       isolate_handle: IsolateHandle::new(isolate),
+      global_liveness: NonNull::from(global_liveness),
     }
+  }
+
+  #[inline(always)]
+  fn global_liveness(&self) -> &IsolateLiveness {
+    unsafe { self.global_liveness.as_ref() }
   }
 
   #[inline(always)]
@@ -1947,6 +1965,31 @@ impl IsolateAnnex {
       .slots
       .remove(&TypeId::of::<T>())
       .map(|slot| unsafe { slot.into_inner::<T>() })
+  }
+}
+
+pub(crate) struct IsolateLiveness {
+  isolate: AtomicPtr<RealIsolate>,
+}
+
+impl IsolateLiveness {
+  #[inline(always)]
+  fn new(isolate: &Isolate) -> Self {
+    Self {
+      isolate: AtomicPtr::new(isolate.as_real_ptr()),
+    }
+  }
+
+  #[inline(always)]
+  fn dispose(&self) {
+    self
+      .isolate
+      .store(null_mut(), std::sync::atomic::Ordering::Relaxed);
+  }
+
+  #[inline(always)]
+  pub(crate) fn get_isolate_ptr(&self) -> *mut RealIsolate {
+    self.isolate.load(std::sync::atomic::Ordering::Relaxed)
   }
 }
 


### PR DESCRIPTION
## Summary
- replace per-`Global` `IsolateHandle`/`Arc` storage with a lightweight isolate liveness cell
- preserve late-drop behavior by marking the liveness cell null during isolate teardown
- keep the liveness cell valid after isolate disposal so late `Global` drops can observe disposal without retaining an `Arc`

## Verification
- `cargo fmt`
- `cargo check`

I also tried `cargo test --test test_api global -- --nocapture`, but this checkout failed at link time due existing unresolved symbols (`v8__Object__SetLazyDataProperty`, `v8__String__Concat`) after Rust compilation.