### PR TITLE
perf: add fused callback info parts

### DIFF
--- a/benches/function.rs
+++ b/benches/function.rs
@@ -50,6 +50,17 @@ fn main() {
     global.set(scope, name.into(), func.into()).unwrap();
   }
   {
+    extern "C" fn callback(info: *const v8::FunctionCallbackInfo) {
+      let info = unsafe { &*info };
+      let parts = info.get_parts();
+      let mut rv = parts.return_value;
+      rv.set_uint32(42);
+    }
+    let func = v8::Function::new_raw(scope, callback).unwrap();
+    let name = v8::String::new(scope, "new_raw_parts_set_uint32").unwrap();
+    global.set(scope, name.into(), func.into()).unwrap();
+  }
+  {
     let func = v8::Function::new(
       scope,
       |_: &mut v8::PinScope,
@@ -113,6 +124,22 @@ fn main() {
     let name = v8::String::new(scope, "undefined_from_isolate").unwrap();
     global.set(scope, name.into(), func.into()).unwrap();
   }
+  {
+    extern "C" fn callback(info: *const v8::FunctionCallbackInfo) {
+      let info = unsafe { &*info };
+      let parts = info.get_parts();
+      let mut rv = parts.return_value;
+      rv.set(
+        v8::undefined(unsafe {
+          v8::Isolate::ref_from_raw_isolate_ptr_unchecked(&parts.isolate)
+        })
+        .into(),
+      );
+    }
+    let func = v8::Function::new_raw(scope, callback).unwrap();
+    let name = v8::String::new(scope, "undefined_from_parts").unwrap();
+    global.set(scope, name.into(), func.into()).unwrap();
+  }
 
   let runs = 100_000_000;
 
@@ -124,12 +151,17 @@ fn main() {
         "new_raw",
         "new_set_uint32",
         "new_raw_set_uint32",
+        "new_raw_parts_set_uint32",
         "new_fast",
       ][..],
     ),
     (
       "primitives",
-      &["undefined_from_scope", "undefined_from_isolate"][..],
+      &[
+        "undefined_from_scope",
+        "undefined_from_isolate",
+        "undefined_from_parts",
+      ][..],
     ),
   ] {
     println!("Running {group_name} ...");

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2494,6 +2494,17 @@ v8::Isolate* v8__FunctionCallbackInfo__GetIsolate(
   return self.GetIsolate();
 }
 
+function_callback_info_parts_t v8__FunctionCallbackInfo__GetParts(
+    const v8::FunctionCallbackInfo<v8::Value>& self) {
+  v8::ReturnValue<v8::Value> rv = self.GetReturnValue();
+  return {
+      self.GetIsolate(),
+      *reinterpret_cast<void**>(&rv),
+      local_to_ptr(self.Data()),
+      self.Length(),
+  };
+}
+
 const v8::Value* v8__FunctionCallbackInfo__Data(
     const v8::FunctionCallbackInfo<v8::Value>& self) {
   return local_to_ptr(self.Data());

--- a/src/function.rs
+++ b/src/function.rs
@@ -20,6 +20,7 @@ use crate::SealedLocal;
 use crate::Signature;
 use crate::String;
 use crate::UniqueRef;
+use crate::UnsafeRawIsolatePtr;
 use crate::Value;
 use crate::isolate::RealIsolate;
 use crate::scope::PinScope;
@@ -71,6 +72,9 @@ unsafe extern "C" {
   fn v8__FunctionCallbackInfo__GetIsolate(
     this: *const FunctionCallbackInfo,
   ) -> *mut RealIsolate;
+  fn v8__FunctionCallbackInfo__GetParts(
+    this: *const FunctionCallbackInfo,
+  ) -> RawFunctionCallbackInfoParts;
   fn v8__FunctionCallbackInfo__Data(
     this: *const FunctionCallbackInfo,
   ) -> *const Value;
@@ -152,8 +156,17 @@ pub enum SideEffectType {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 struct RawReturnValue(usize);
+
+#[repr(C)]
+#[derive(Debug)]
+struct RawFunctionCallbackInfoParts {
+  isolate: *mut RealIsolate,
+  return_value: usize,
+  data: *const Value,
+  length: int,
+}
 
 // Note: the 'cb lifetime is required because the ReturnValue object must not
 // outlive the FunctionCallbackInfo/PropertyCallbackInfo object from which it
@@ -161,7 +174,20 @@ struct RawReturnValue(usize);
 #[derive(Debug)]
 pub struct ReturnValue<'cb, T = Value>(RawReturnValue, PhantomData<&'cb T>);
 
+impl<T> Clone for ReturnValue<'_, T> {
+  fn clone(&self) -> Self {
+    *self
+  }
+}
+
+impl<T> Copy for ReturnValue<'_, T> {}
+
 impl<'cb, T> ReturnValue<'cb, T> {
+  #[inline(always)]
+  fn from_raw(raw: RawReturnValue) -> Self {
+    Self(raw, PhantomData)
+  }
+
   #[inline(always)]
   pub fn from_property_callback_info(
     info: &'cb PropertyCallbackInfo<T>,
@@ -254,10 +280,39 @@ where
 #[derive(Debug)]
 pub struct FunctionCallbackInfo(*mut Opaque);
 
+/// Values commonly needed at the start of a function callback.
+///
+/// This lets raw callbacks fetch the isolate, return value, callback data, and
+/// argument length with one FFI call. The returned parts can also seed
+/// [`FunctionCallbackArguments`] and [`CallbackScope`](crate::CallbackScope)
+/// without re-reading those values from V8.
+#[repr(C)]
+#[derive(Debug)]
+pub struct FunctionCallbackInfoParts<'cb> {
+  pub isolate: UnsafeRawIsolatePtr,
+  pub return_value: ReturnValue<'cb>,
+  pub data: Local<'cb, Value>,
+  pub length: int,
+}
+
 impl FunctionCallbackInfo {
   #[inline(always)]
   pub(crate) fn get_isolate_ptr(&self) -> *mut RealIsolate {
     unsafe { v8__FunctionCallbackInfo__GetIsolate(self) }
+  }
+
+  /// Returns the common callback entry values with a single C++ shim call.
+  #[inline(always)]
+  pub fn get_parts(&self) -> FunctionCallbackInfoParts<'_> {
+    let raw = unsafe { v8__FunctionCallbackInfo__GetParts(self) };
+    FunctionCallbackInfoParts {
+      isolate: UnsafeRawIsolatePtr::from_real_ptr(raw.isolate),
+      return_value: ReturnValue::from_raw(RawReturnValue(raw.return_value)),
+      data: unsafe {
+        Local::from_non_null(NonNull::new_unchecked(raw.data as *mut Value))
+      },
+      length: raw.length,
+    }
   }
 
   #[inline(always)]
@@ -325,12 +380,34 @@ impl<T> PropertyCallbackInfo<T> {
 }
 
 #[derive(Debug)]
-pub struct FunctionCallbackArguments<'s>(&'s FunctionCallbackInfo);
+pub struct FunctionCallbackArguments<'s> {
+  info: &'s FunctionCallbackInfo,
+  data: Option<Local<'s, Value>>,
+  length: Option<int>,
+}
 
 impl<'s> FunctionCallbackArguments<'s> {
   #[inline(always)]
   pub fn from_function_callback_info(info: &'s FunctionCallbackInfo) -> Self {
-    Self(info)
+    Self {
+      info,
+      data: None,
+      length: None,
+    }
+  }
+
+  /// Creates callback arguments from [`FunctionCallbackInfoParts`], reusing the
+  /// already-loaded callback data and argument length.
+  #[inline(always)]
+  pub fn from_function_callback_info_parts(
+    info: &'s FunctionCallbackInfo,
+    parts: &FunctionCallbackInfoParts<'s>,
+  ) -> Self {
+    Self {
+      info,
+      data: Some(parts.data),
+      length: Some(parts.length),
+    }
   }
 
   /// SAFETY: caller must guarantee that no other references to the isolate are
@@ -339,45 +416,47 @@ impl<'s> FunctionCallbackArguments<'s> {
   /// not be called.
   #[inline(always)]
   pub unsafe fn get_isolate(&mut self) -> &mut Isolate {
-    unsafe { &mut *(self.0.get_isolate_ptr() as *mut crate::isolate::Isolate) }
+    unsafe {
+      &mut *(self.info.get_isolate_ptr() as *mut crate::isolate::Isolate)
+    }
   }
 
   /// For construct calls, this returns the "new.target" value.
   #[inline(always)]
   pub fn new_target(&self) -> Local<'s, Value> {
-    self.0.new_target()
+    self.info.new_target()
   }
 
   /// Returns true if this is a construct call, i.e., if the function was
   /// called with the `new` operator.
   #[inline]
   pub fn is_construct_call(&self) -> bool {
-    self.0.is_construct_call()
+    self.info.is_construct_call()
   }
 
   /// Returns the receiver. This corresponds to the "this" value.
   #[inline(always)]
   pub fn this(&self) -> Local<'s, Object> {
-    self.0.this()
+    self.info.this()
   }
 
   /// Returns the data argument specified when creating the callback.
   #[inline(always)]
   pub fn data(&self) -> Local<'s, Value> {
-    self.0.data()
+    self.data.unwrap_or_else(|| self.info.data())
   }
 
   /// The number of available arguments.
   #[inline(always)]
   pub fn length(&self) -> int {
-    self.0.length()
+    self.length.unwrap_or_else(|| self.info.length())
   }
 
   /// Accessor for the available arguments. Returns `undefined` if the index is
   /// out of bounds.
   #[inline(always)]
   pub fn get(&self, i: int) -> Local<'s, Value> {
-    self.0.get(i)
+    self.info.get(i)
   }
 }
 

--- a/src/isolate.rs
+++ b/src/isolate.rs
@@ -802,12 +802,22 @@ pub struct Isolate(NonNull<RealIsolate>);
 pub struct UnsafeRawIsolatePtr(*mut RealIsolate);
 
 impl UnsafeRawIsolatePtr {
+  #[inline]
+  pub(crate) fn from_real_ptr(ptr: *mut RealIsolate) -> Self {
+    Self(ptr)
+  }
+
   pub fn null() -> Self {
     Self(std::ptr::null_mut())
   }
 
   pub fn is_null(&self) -> bool {
     self.0.is_null()
+  }
+
+  #[inline]
+  pub(crate) fn as_real_ptr(&self) -> *mut RealIsolate {
+    self.0
   }
 }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -130,6 +130,7 @@ use crate::{
   Message, Object, OwnedIsolate, PromiseRejectMessage, PropertyCallbackInfo,
   SealedLocal, Value,
   fast_api::FastApiCallbackOptions,
+  function::FunctionCallbackInfoParts,
   isolate::{IsolateAnnex, RealIsolate},
   support::assert_layout_subset,
 };
@@ -300,6 +301,12 @@ mod get_isolate_impls {
   impl GetIsolate for FunctionCallbackInfo {
     fn get_isolate_ptr(&self) -> *mut RealIsolate {
       self.get_isolate_ptr()
+    }
+  }
+
+  impl GetIsolate for FunctionCallbackInfoParts<'_> {
+    fn get_isolate_ptr(&self) -> *mut RealIsolate {
+      self.isolate.as_real_ptr()
     }
   }
 
@@ -1078,6 +1085,14 @@ impl<'s> NewCallbackScope<'s> for &'s mut OwnedIsolate {
 }
 
 impl<'s> NewCallbackScope<'s> for &'s FunctionCallbackInfo {
+  type NewScope = CallbackScope<'s>;
+
+  fn make_new_scope(me: Self) -> Self::NewScope {
+    make_new_callback_scope(me, None)
+  }
+}
+
+impl<'s> NewCallbackScope<'s> for &'s FunctionCallbackInfoParts<'s> {
   type NewScope = CallbackScope<'s>;
 
   fn make_new_scope(me: Self) -> Self::NewScope {

--- a/src/support.h
+++ b/src/support.h
@@ -166,6 +166,13 @@ struct three_pointers_t {
   void* c;
 };
 
+struct function_callback_info_parts_t {
+  void* isolate;
+  void* return_value;
+  const void* data;
+  int length;
+};
+
 }  // namespace support
 
 struct memory_span_t {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3830,6 +3830,54 @@ fn function_builder_raw() {
 }
 
 #[test]
+fn function_callback_info_parts() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  {
+    v8::scope!(let scope, isolate);
+
+    let context = v8::Context::new(scope, Default::default());
+    let scope = &mut v8::ContextScope::new(scope, context);
+    let global = context.global(scope);
+    let recv: v8::Local<v8::Value> = global.into();
+
+    extern "C" fn callback(info: *const v8::FunctionCallbackInfo) {
+      let info = unsafe { &*info };
+      let parts = info.get_parts();
+      v8::callback_scope!(unsafe scope, &parts);
+      let args =
+        v8::FunctionCallbackArguments::from_function_callback_info_parts(
+          info, &parts,
+        );
+      assert_eq!(args.length(), 1);
+      assert!(args.data().is_true());
+      assert!(args.get(0).is_string());
+
+      let mut rv = parts.return_value;
+      rv.set(
+        v8::String::new(scope, "Hello from function parts!")
+          .unwrap()
+          .into(),
+      );
+    }
+
+    let data = v8::Boolean::new(scope, true).into();
+    let func = v8::Function::builder_raw(callback)
+      .data(data)
+      .build(scope)
+      .unwrap();
+
+    let arg0 = v8::String::new(scope, "Hello").unwrap();
+    let value = func.call(scope, recv, &[arg0.into()]).unwrap();
+    assert!(value.is_string());
+    assert_eq!(
+      value.to_rust_string_lossy(scope),
+      "Hello from function parts!"
+    );
+  }
+}
+
+#[test]
 fn return_value() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
## Summary

Adds `FunctionCallbackInfo::get_parts()` as a single callback-entry shim that returns the isolate pointer, return value, callback data, and argument length together.

This lets raw callbacks avoid separate C++ FFI calls for the common callback prologue:

- `CallbackScope::new(info)` / isolate lookup
- `ReturnValue::from_function_callback_info(info)`
- `FunctionCallbackArguments::from_function_callback_info(info)` for callback data and argument length

The new `FunctionCallbackInfoParts` can be passed directly to `CallbackScope`, and `FunctionCallbackArguments::from_function_callback_info_parts(info, &parts)` reuses the already-loaded callback data and length.

## Deno usage

The main Deno consumer should be the generated slow op callback prologue in:

- `libs/ops/op2/dispatch_slow.rs`: `with_scope`, `with_retval`, and `with_fn_args` currently generate separate callback-info reads for slow ops.
- `libs/ops/op2/dispatch_async.rs`: async slow op generation reuses those same helpers and can benefit from the same callback-entry snapshot.

A smaller direct use is:

- `libs/core/ops_metrics.rs`: `slow_metrics_dispatch` currently constructs `FunctionCallbackArguments` only to read callback data and recover `OpCtx`; it can use `info.get_parts().data` directly.

There are also scattered core callbacks, for example `libs/core/error.rs` and `libs/core/runtime/bindings.rs`, but the op2 generator is the valuable centralized follow-up because it affects many generated slow callback paths.

## Validation

- `cargo fmt`
- `cargo check`
- `cargo check --benches`

I also tried `cargo test --test test_api function_callback_info_parts -- --nocapture`; it compiled Rust code but failed at the native link step in my local tree because the existing native archive is missing `_v8__FunctionCallbackInfo__GetParts` plus pre-existing missing symbols `_v8__Object__SetLazyDataProperty` and `_v8__String__Concat`.
