### PR TITLE
Add bindings for FunctionTemplate c_function_overloads

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -22,8 +22,10 @@
 #include "v8-platform.h"
 #include "v8-profiler.h"
 #include "v8.h"
+#include "v8/src/api/api-inl.h"
 #include "v8/src/flags/flags.h"
 #include "v8/src/libplatform/default-platform.h"
+#include "v8/src/objects/templates-inl.h"
 
 using namespace support;
 
@@ -2487,6 +2489,36 @@ const v8::ObjectTemplate* v8__FunctionTemplate__PrototypeTemplate(
 const v8::ObjectTemplate* v8__FunctionTemplate__InstanceTemplate(
     const v8::FunctionTemplate& self) {
   return local_to_ptr(ptr_to_local(&self)->InstanceTemplate());
+}
+
+// Returns the number of fast-call (C function) overloads attached to this
+// FunctionTemplate. Each overload corresponds to one
+// `Managed<CFunctionWithSignature>` heap object that V8 creates internally
+// when `SetCallHandler` is called with `c_function_overloads`. Embedders need
+// the count so they can iterate and register the overloads with the
+// SnapshotCreator (via `AddData`), otherwise the per-Managed weak global
+// handles trip `CheckGlobalAndEternalHandles` during snapshot creation.
+uint32_t v8__FunctionTemplate__GetCFunctionOverloadCount(
+    const v8::FunctionTemplate& self) {
+  auto info = v8::Utils::OpenDirectHandle(&self);
+  return v8::internal::Cast<v8::internal::FixedArray>(
+             info->GetCFunctionOverloads())
+      ->ulength()
+      .value();
+}
+
+// Returns the n-th fast-call overload as a `Local<Data>` so it can be passed
+// to `SnapshotCreator::AddData`. The returned handle wraps the internal
+// `Managed<CFunctionWithSignature>` object.
+const v8::Data* v8__FunctionTemplate__GetCFunctionOverload(
+    const v8::FunctionTemplate& self, uint32_t index) {
+  namespace i = v8::internal;
+  auto info = v8::Utils::OpenDirectHandle(&self);
+  i::Isolate* i_isolate = i::Isolate::Current();
+  i::Tagged<i::Object> overload =
+      i::Cast<i::FixedArray>(info->GetCFunctionOverloads())->get(index);
+  return local_to_ptr(
+      v8::Utils::ToLocal(i::direct_handle(overload, i_isolate)));
 }
 
 v8::Isolate* v8__FunctionCallbackInfo__GetIsolate(

--- a/src/template.rs
+++ b/src/template.rs
@@ -94,6 +94,13 @@ unsafe extern "C" {
   );
   fn v8__FunctionTemplate__ReadOnlyPrototype(this: *const FunctionTemplate);
   fn v8__FunctionTemplate__RemovePrototype(this: *const FunctionTemplate);
+  fn v8__FunctionTemplate__GetCFunctionOverloadCount(
+    this: *const FunctionTemplate,
+  ) -> u32;
+  fn v8__FunctionTemplate__GetCFunctionOverload(
+    this: *const FunctionTemplate,
+    index: u32,
+  ) -> *const Data;
 
   fn v8__ObjectTemplate__New(
     isolate: *mut RealIsolate,
@@ -837,6 +844,45 @@ impl FunctionTemplate {
   #[inline(always)]
   pub fn remove_prototype(&self) {
     unsafe { v8__FunctionTemplate__RemovePrototype(self) };
+  }
+
+  /// Returns the number of fast-call (C function) overloads attached to this
+  /// FunctionTemplate via [`FunctionBuilder::build_fast`].
+  ///
+  /// Each overload corresponds to one internal heap object that V8 tracks as
+  /// an isolate-level global handle. When creating a startup snapshot, these
+  /// handles must be registered with the [`SnapshotCreator`] (via
+  /// [`OwnedIsolate::add_isolate_data`]) so that the snapshot's
+  /// `CheckGlobalAndEternalHandles` pass succeeds. Iterate with
+  /// [`Self::get_c_function_overload`].
+  ///
+  /// [`SnapshotCreator`]: crate::SnapshotCreator
+  /// [`OwnedIsolate::add_isolate_data`]: crate::OwnedIsolate::add_isolate_data
+  #[inline(always)]
+  pub fn c_function_overload_count(&self) -> u32 {
+    unsafe { v8__FunctionTemplate__GetCFunctionOverloadCount(self) }
+  }
+
+  /// Returns the n-th fast-call overload as a [`Local<Data>`] suitable for
+  /// passing to [`OwnedIsolate::add_isolate_data`]. See
+  /// [`Self::c_function_overload_count`] for context.
+  ///
+  /// # Panics
+  ///
+  /// Panics if `index` is out of bounds.
+  ///
+  /// [`OwnedIsolate::add_isolate_data`]: crate::OwnedIsolate::add_isolate_data
+  #[inline(always)]
+  pub fn get_c_function_overload<'s>(
+    &self,
+    scope: &PinScope<'s, '_, ()>,
+    index: u32,
+  ) -> Local<'s, Data> {
+    assert!(index < self.c_function_overload_count());
+    unsafe {
+      scope.cast_local(|_sd| v8__FunctionTemplate__GetCFunctionOverload(self, index))
+    }
+    .unwrap()
   }
 
   /// Sets an [accessor property](https://tc39.es/ecma262/#sec-property-attributes)

--- a/src/template.rs
+++ b/src/template.rs
@@ -880,7 +880,9 @@ impl FunctionTemplate {
   ) -> Local<'s, Data> {
     assert!(index < self.c_function_overload_count());
     unsafe {
-      scope.cast_local(|_sd| v8__FunctionTemplate__GetCFunctionOverload(self, index))
+      scope.cast_local(|_sd| {
+        v8__FunctionTemplate__GetCFunctionOverload(self, index)
+      })
     }
     .unwrap()
   }


### PR DESCRIPTION
V8 14.9 changed how `FunctionTemplate` stores its fast-call entries:
each `CFunction` overload is now wrapped in an internal
`Managed<CFunctionWithSignature>` heap object, and `Managed::From`
registers a weak isolate global handle per overload to drive the
finalizer. Embedders that call `build_fast()` while creating a startup
snapshot pick up one extra global per fast-call op, none of which land
in `serialized_objects`. The snapshot's `CheckGlobalAndEternalHandles`
pass then aborts with a long list of unserialized `<Foreign>` globals.

This adds two accessors on `FunctionTemplate` — `c_function_overload_count`
and `get_c_function_overload(scope, index)` — so embedders can iterate
the overloads attached to a template and register each one with the
`SnapshotCreator` via `add_isolate_data`, satisfying the check. The
shim reaches into V8's internal `FunctionTemplateInfo::GetCFunctionOverloads`
accessor (already accessible from `binding.cc` since it includes the
v8 internal headers), so no V8 patch is required.

The consumer is denoland/deno#34226, which hits exactly this failure
when bumping rusty_v8 to 149.0.0.