### PR TITLE
fix: pass `flags` to `v8__ObjectTemplate__SetIndexedPropertyHandler` FFI

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -149,6 +149,7 @@ unsafe extern "C" {
     definer: Option<IndexedPropertyDefinerCallback>,
     descriptor: Option<IndexedPropertyDescriptorCallback>,
     data_or_null: *const Value,
+    flags: PropertyHandlerFlags,
   );
 
   fn v8__ObjectTemplate__SetImmutableProto(this: *const ObjectTemplate);
@@ -1006,6 +1007,7 @@ impl ObjectTemplate {
         configuration.definer,
         configuration.descriptor,
         configuration.data.map_or_else(null, |p| &*p),
+        configuration.flags,
       );
     }
   }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2951,6 +2951,56 @@ fn object_template_set_indexed_property_handler() {
 }
 
 #[test]
+fn indexed_property_handler_non_masking() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  v8::scope!(let scope, isolate);
+
+  let context = v8::Context::new(scope, Default::default());
+  let scope = &mut v8::ContextScope::new(scope, context);
+
+  let getter = |scope: &mut v8::PinScope,
+                index: u32,
+                _args: v8::PropertyCallbackArguments,
+                mut rv: v8::ReturnValue<v8::Value>| {
+    let value = v8::Integer::new(scope, (index as i32) * 100);
+    rv.set(value.into());
+    v8::Intercepted::kYes
+  };
+
+  let templ = v8::ObjectTemplate::new(scope);
+  templ.set_indexed_property_handler(
+    v8::IndexedPropertyHandlerConfiguration::new()
+      .getter(getter)
+      .flags(v8::PropertyHandlerFlags::NON_MASKING),
+  );
+
+  let obj = templ.new_instance(scope).unwrap();
+  let name = v8::String::new(scope, "obj").unwrap();
+  scope
+    .get_current_context()
+    .global(scope)
+    .set(scope, name.into(), obj.into());
+
+  // Without a real element, the interceptor handles the access.
+  let val = eval(scope, "obj[5]").unwrap();
+  assert!(val.is_int32());
+  assert_eq!(val.int32_value(scope).unwrap(), 500);
+
+  // Store a real indexed element on the instance.
+  let real_value = v8::Integer::new(scope, 7);
+  obj.set_index(scope, 5, real_value.into());
+
+  // With NON_MASKING, the real element takes priority over the interceptor.
+  let val = eval(scope, "obj[5]").unwrap();
+  assert_eq!(val.int32_value(scope).unwrap(), 7);
+
+  // Other indices still fall through to the interceptor.
+  let val = eval(scope, "obj[3]").unwrap();
+  assert_eq!(val.int32_value(scope).unwrap(), 300);
+}
+
+#[test]
 fn object() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
The FFI declaration for `SetIndexedPropertyHandler` omitted the `flags` parameter that the C++ binding accepts, causing any flags set on `IndexedPropertyHandlerConfiguration` (e.g., `NON_MASKING`) to be silently discarded. I think it also results in UB because we're calling a C/C++ function with fewer args than expected... and the Rust compiler cannot detect because we correctly called the binding function. The problem is that the `extern "C"` binding function does not match the actual signature of the C++ function.

The named handler's declaration already passes flags correctly—this aligns the indexed handler to match.

Added a test that sets `NON_MASKING` on an indexed handler and verifies real indexed elements take priority over the interceptor.

For reference, here is the C++ function that we're trying to match:
https://github.com/denoland/rusty_v8/blob/5d0e31ea6bf67f4559faa759b91e22bc3f1cd696/src/binding.cc#L1505-L1517
