### PR TITLE
build: keep ICU data out of the V8 static library

### DIFF
--- a/.gn
+++ b/.gn
@@ -78,9 +78,6 @@ default_args = {
 
   use_relative_vtables_abi = false
 
-  v8_depend_on_icu_data_file = false
-  icu_copy_icudata_to_root_build_dir = false
-
   # Keep ICU data OUT of the V8 static library. With `icu_use_data_file = true`
   # (ICU's default) the data is not embedded as the `icudt*_dat` symbol; the
   # embedder must supply it at runtime via `v8::icu::set_common_data` (or by
@@ -88,6 +85,16 @@ default_args = {
   # downstreams can ship full-icu, small-icu, or no data at all. Do not set this
   # to `false` (which bundles the ~10MB blob into libv8) on a V8 bump.
   icu_use_data_file = true
+
+  # `mksnapshot` initializes ICU at build time (to snapshot Intl/Temporal), so
+  # it needs `icudtl.dat` present even though the data is not embedded. These
+  # two must stay aligned with `icu_use_data_file`: `copy_icudata` drops the
+  # file into `root_out_dir` and `mksnapshot` takes an explicit dependency on
+  # it. The copied file is a build-time artifact only; it is NOT linked into
+  # the resulting static library. Forcing either to `false` makes mksnapshot
+  # fail with "Failed to initialize ICU".
+  v8_depend_on_icu_data_file = true
+  icu_copy_icudata_to_root_build_dir = true
 
   # TODO: third_party/compiler-rt missing?
   use_llvm_libatomic = false

--- a/.gn
+++ b/.gn
@@ -80,7 +80,14 @@ default_args = {
 
   v8_depend_on_icu_data_file = false
   icu_copy_icudata_to_root_build_dir = false
-  icu_use_data_file = false
+
+  # Keep ICU data OUT of the V8 static library. With `icu_use_data_file = true`
+  # (ICU's default) the data is not embedded as the `icudt*_dat` symbol; the
+  # embedder must supply it at runtime via `v8::icu::set_common_data` (or by
+  # loading `icudtl.dat`). This keeps ICU data a separate, swappable artifact so
+  # downstreams can ship full-icu, small-icu, or no data at all. Do not set this
+  # to `false` (which bundles the ~10MB blob into libv8) on a V8 bump.
+  icu_use_data_file = true
 
   # TODO: third_party/compiler-rt missing?
   use_llvm_libatomic = false


### PR DESCRIPTION
The 14.9 bump (12d7ef1) added icu_use_data_file = false to .gn, which
embeds the ICU data blob (icudt*_dat, ~10MB) directly into the V8 static
library. That made ICU data an inseparable part of libv8 and added a
roughly 11MB regression to downstream binary sizes. It also makes it
impossible to experiment with alternative data sets (small-icu, no data)
without rebuilding V8.

This restores icu_use_data_file to ICU's default of true, so the data is
no longer compiled in and the embedder supplies it at runtime via
v8::icu::set_common_data (or by loading icudtl.dat). Keeping ICU data as
a separate, swappable artifact is what lets downstreams choose full-icu,
small-icu, or no data at all.

mksnapshot initializes ICU while generating the snapshot, so it needs
icudtl.dat present at build time even though the data is not embedded
into the final library. To satisfy that, v8_depend_on_icu_data_file and
icu_copy_icudata_to_root_build_dir are aligned with icu_use_data_file:
the copy_icudata target stages the file in root_out_dir and mksnapshot
depends on it. The staged file is a build-time artifact only and is not
linked into libv8. Without this the build fails with "mksnapshot: Failed
to initialize ICU".

Verified with a from-source build (V8_FROM_SOURCE=1) on macOS arm64: the
library builds, icudtl.dat is not embedded, and the icu_date, icu_format,
icu_collator and get_default_locale tests pass once set_common_data is
called in the test harness.

Downstream: denoland/deno#34681 re-enables deno_core's include_icu_data
to consume this (verified end-to-end against a from-source build of this
branch).
