### PR TITLE
feat: add icu::set_default_time_zone / get_default_time_zone

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -14,6 +14,8 @@
 #include "libplatform/libplatform.h"
 #include "support.h"
 #include "unicode/locid.h"
+#include "unicode/timezone.h"
+#include "unicode/unistr.h"
 #include "v8-callbacks.h"
 #include "v8-cppgc.h"
 #include "v8-fast-api-calls.h"
@@ -4284,6 +4286,24 @@ size_t icu_get_default_locale(char* output, size_t output_len) {
 void icu_set_default_locale(const char* locale) {
   UErrorCode status = U_ZERO_ERROR;
   icu::Locale::setDefault(icu::Locale(locale), status);
+}
+
+size_t icu_get_default_timezone(char* output, size_t output_len) {
+  icu::UnicodeString id;
+  std::unique_ptr<icu::TimeZone> tz(icu::TimeZone::createDefault());
+  tz->getID(id);
+  icu_77::CheckedArrayByteSink sink(output, static_cast<uint32_t>(output_len));
+  id.toUTF8(sink);
+  assert(!sink.Overflowed());
+  return sink.NumberOfBytesAppended();
+}
+
+void icu_set_default_timezone(const char* timezone) {
+  // Takes ownership of the created TimeZone and installs it as the process
+  // wide default, so ICU (and therefore V8's Date implementation) resolves
+  // the given IANA id regardless of how the host reports its time zone.
+  icu::TimeZone::adoptDefault(
+      icu::TimeZone::createTimeZone(icu::UnicodeString::fromUTF8(timezone)));
 }
 
 }  // extern "C"

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -16,6 +16,8 @@
 #include "libplatform/libplatform.h"
 #include "support.h"
 #include "unicode/locid.h"
+#include "unicode/timezone.h"
+#include "unicode/unistr.h"
 #include "v8-callbacks.h"
 #include "v8-cppgc.h"
 #include "v8-fast-api-calls.h"
@@ -4478,6 +4480,26 @@ size_t icu_get_default_locale(char* output, size_t output_len) {
 void icu_set_default_locale(const char* locale) {
   UErrorCode status = U_ZERO_ERROR;
   icu::Locale::setDefault(icu::Locale(locale), status);
+}
+
+size_t icu_get_default_timezone(char* output, size_t output_len) {
+  icu::UnicodeString id;
+  std::unique_ptr<icu::TimeZone> tz(icu::TimeZone::createDefault());
+  tz->getID(id);
+  icu::CheckedArrayByteSink sink(output, static_cast<uint32_t>(output_len));
+  id.toUTF8(sink);
+  assert(!sink.Overflowed());
+  return sink.NumberOfBytesAppended();
+}
+
+// NOTE: the parameter is deliberately not named `timezone`; glibc's <time.h>
+// declares a global with that name and the build uses -Werror,-Wshadow.
+void icu_set_default_timezone(const char* time_zone_id) {
+  // Takes ownership of the created TimeZone and installs it as the process
+  // wide default, so ICU (and therefore V8's Date implementation) resolves
+  // the given IANA id regardless of how the host reports its time zone.
+  icu::TimeZone::adoptDefault(icu::TimeZone::createTimeZone(
+      icu::UnicodeString::fromUTF8(time_zone_id)));
 }
 
 }  // extern "C"

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -4497,7 +4497,10 @@ size_t icu_get_default_time_zone(char* output, size_t output_len) {
   icu::CheckedArrayByteSink sink(output, static_cast<uint32_t>(output_len));
   id.toUTF8(sink);
   assert(!sink.Overflowed());
-  return sink.NumberOfBytesAppended();
+  // Deliberately not `NumberOfBytesAppended()`: that counts bytes the sink was
+  // asked to write, so on overflow it exceeds `output_len` and the caller would
+  // read past the buffer (the assert above is compiled out in release builds).
+  return sink.NumberOfBytesWritten();
 }
 
 // NOTE: the parameter is deliberately not named `timezone`; glibc's <time.h>
@@ -4508,15 +4511,14 @@ bool icu_set_default_time_zone(const char* time_zone_id) {
   // instead of silently installing GMT.
   std::unique_ptr<icu::TimeZone> tz(icu::TimeZone::createTimeZone(
       icu::UnicodeString::fromUTF8(time_zone_id)));
-  icu::UnicodeString id, unknown_id;
+  icu::UnicodeString id;
   tz->getID(id);
-  icu::TimeZone::getUnknown().getID(unknown_id);
-  if (id == unknown_id) {
+  if (id == icu::UnicodeString(UCAL_UNKNOWN_ZONE_ID, -1, US_INV)) {
     return false;
   }
   // Takes ownership of the created TimeZone and installs it as the process
   // wide default, so ICU (and therefore V8's Date implementation) resolves
-  // the given IANA id regardless of how the host reports its time zone.
+  // the given id regardless of how the host reports its time zone.
   icu::TimeZone::adoptDefault(tz.release());
   return true;
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -4490,7 +4490,7 @@ void icu_set_default_locale(const char* locale) {
   icu::Locale::setDefault(icu::Locale(locale), status);
 }
 
-size_t icu_get_default_timezone(char* output, size_t output_len) {
+size_t icu_get_default_time_zone(char* output, size_t output_len) {
   icu::UnicodeString id;
   std::unique_ptr<icu::TimeZone> tz(icu::TimeZone::createDefault());
   tz->getID(id);
@@ -4502,12 +4502,23 @@ size_t icu_get_default_timezone(char* output, size_t output_len) {
 
 // NOTE: the parameter is deliberately not named `timezone`; glibc's <time.h>
 // declares a global with that name and the build uses -Werror,-Wshadow.
-void icu_set_default_timezone(const char* time_zone_id) {
+bool icu_set_default_time_zone(const char* time_zone_id) {
+  // `createTimeZone()` never fails: an id it does not recognize yields the
+  // special "unknown" zone (which behaves as GMT). Detect that and report it
+  // instead of silently installing GMT.
+  std::unique_ptr<icu::TimeZone> tz(icu::TimeZone::createTimeZone(
+      icu::UnicodeString::fromUTF8(time_zone_id)));
+  icu::UnicodeString id, unknown_id;
+  tz->getID(id);
+  icu::TimeZone::getUnknown().getID(unknown_id);
+  if (id == unknown_id) {
+    return false;
+  }
   // Takes ownership of the created TimeZone and installs it as the process
   // wide default, so ICU (and therefore V8's Date implementation) resolves
   // the given IANA id regardless of how the host reports its time zone.
-  icu::TimeZone::adoptDefault(icu::TimeZone::createTimeZone(
-      icu::UnicodeString::fromUTF8(time_zone_id)));
+  icu::TimeZone::adoptDefault(tz.release());
+  return true;
 }
 
 }  // extern "C"

--- a/src/icu.rs
+++ b/src/icu.rs
@@ -5,6 +5,8 @@ use std::ffi::CString;
 unsafe extern "C" {
   fn icu_get_default_locale(output: *mut char, output_len: usize) -> usize;
   fn icu_set_default_locale(locale: *const char);
+  fn icu_get_default_timezone(output: *mut char, output_len: usize) -> usize;
+  fn icu_set_default_timezone(timezone: *const char);
   fn udata_setCommonData_77(this: *const u8, error_code: *mut i32);
 }
 
@@ -67,5 +69,31 @@ pub fn set_default_locale(locale: &str) {
   unsafe {
     let c_str = CString::new(locale).expect("Invalid locale");
     icu_set_default_locale(c_str.as_ptr());
+  }
+}
+
+/// Returns the IANA id of ICU's current default time zone (e.g.
+/// `"America/New_York"`).
+pub fn get_default_time_zone() -> String {
+  let mut output = [0u8; 1024];
+  let len = unsafe {
+    icu_get_default_timezone(output.as_mut_ptr() as *mut char, output.len())
+  };
+  std::str::from_utf8(&output[..len]).unwrap().to_owned()
+}
+
+/// Sets ICU's default time zone from an IANA id (e.g. `"UTC"`,
+/// `"Asia/Manila"`). This makes `Date` resolve the given zone on every
+/// platform, including Windows, where ICU otherwise reads the host time
+/// zone from the OS and ignores the `TZ` environment variable.
+///
+/// After calling this, notify each isolate via
+/// [`crate::Isolate::date_time_configuration_change_notification`] with
+/// [`crate::TimeZoneDetection::Skip`] so cached values are refreshed
+/// without re-detecting (and overwriting) the zone just set here.
+pub fn set_default_time_zone(timezone: &str) {
+  unsafe {
+    let c_str = CString::new(timezone).expect("Invalid timezone");
+    icu_set_default_timezone(c_str.as_ptr());
   }
 }

--- a/src/icu.rs
+++ b/src/icu.rs
@@ -5,8 +5,8 @@ use std::ffi::CString;
 unsafe extern "C" {
   fn icu_get_default_locale(output: *mut char, output_len: usize) -> usize;
   fn icu_set_default_locale(locale: *const char);
-  fn icu_get_default_timezone(output: *mut char, output_len: usize) -> usize;
-  fn icu_set_default_timezone(timezone: *const char);
+  fn icu_get_default_time_zone(output: *mut char, output_len: usize) -> usize;
+  fn icu_set_default_time_zone(time_zone_id: *const char) -> bool;
   fn udata_setCommonData_78(this: *const u8, error_code: *mut i32);
 }
 
@@ -74,11 +74,15 @@ pub fn set_default_locale(locale: &str) {
 
 /// Returns the IANA id of ICU's current default time zone (e.g.
 /// `"America/New_York"`).
+///
+/// If the host time zone could not be determined, ICU reports the special
+/// id `"Etc/Unknown"`, which behaves as GMT.
 pub fn get_default_time_zone() -> String {
   let mut output = [0u8; 1024];
   let len = unsafe {
-    icu_get_default_timezone(output.as_mut_ptr() as *mut char, output.len())
+    icu_get_default_time_zone(output.as_mut_ptr() as *mut char, output.len())
   };
+  let len = std::cmp::min(len, output.len());
   std::str::from_utf8(&output[..len]).unwrap().to_owned()
 }
 
@@ -87,13 +91,21 @@ pub fn get_default_time_zone() -> String {
 /// platform, including Windows, where ICU otherwise reads the host time
 /// zone from the OS and ignores the `TZ` environment variable.
 ///
-/// After calling this, notify each isolate via
-/// [`crate::Isolate::date_time_configuration_change_notification`] with
-/// [`crate::TimeZoneDetection::Skip`] so cached values are refreshed
-/// without re-detecting (and overwriting) the zone just set here.
-pub fn set_default_time_zone(timezone: &str) {
-  unsafe {
-    let c_str = CString::new(timezone).expect("Invalid timezone");
-    icu_set_default_timezone(c_str.as_ptr());
-  }
+/// Returns `false` — leaving the current default untouched — if `time_zone_id`
+/// is not a time zone id ICU recognizes. Note that ICU's own "unknown zone"
+/// id, `"Etc/Unknown"`, is rejected as well.
+///
+/// This mutates process wide state and is not synchronized with isolates
+/// running on other threads, so it should be called before those isolates
+/// evaluate any code observing the time zone. Afterwards, notify each isolate
+/// via [`crate::Isolate::date_time_configuration_change_notification`] with
+/// [`crate::TimeZoneDetection::Skip`] so cached values are refreshed without
+/// re-detecting (and overwriting) the zone just set here.
+#[must_use]
+pub fn set_default_time_zone(time_zone_id: &str) -> bool {
+  let Ok(c_str) = CString::new(time_zone_id) else {
+    // An interior nul byte can't be a valid time zone id.
+    return false;
+  };
+  unsafe { icu_set_default_time_zone(c_str.as_ptr()) }
 }

--- a/src/icu.rs
+++ b/src/icu.rs
@@ -72,8 +72,11 @@ pub fn set_default_locale(locale: &str) {
   }
 }
 
-/// Returns the IANA id of ICU's current default time zone (e.g.
-/// `"America/New_York"`).
+/// Returns the id of ICU's current default time zone, usually an IANA id such
+/// as `"America/New_York"`. It can also be a custom offset id like
+/// `"GMT+05:00"`, either because one was installed with
+/// [`set_default_time_zone`] or because the host reported its zone that way,
+/// so don't assume the result resolves against the tz database.
 ///
 /// If the host time zone could not be determined, ICU reports the special
 /// id `"Etc/Unknown"`, which behaves as GMT.
@@ -82,18 +85,18 @@ pub fn get_default_time_zone() -> String {
   let len = unsafe {
     icu_get_default_time_zone(output.as_mut_ptr() as *mut char, output.len())
   };
-  let len = std::cmp::min(len, output.len());
   std::str::from_utf8(&output[..len]).unwrap().to_owned()
 }
 
-/// Sets ICU's default time zone from an IANA id (e.g. `"UTC"`,
+/// Sets ICU's default time zone from a time zone id (e.g. `"UTC"`,
 /// `"Asia/Manila"`). This makes `Date` resolve the given zone on every
 /// platform, including Windows, where ICU otherwise reads the host time
 /// zone from the OS and ignores the `TZ` environment variable.
 ///
 /// Returns `false` — leaving the current default untouched — if `time_zone_id`
 /// is not a time zone id ICU recognizes. Note that ICU's own "unknown zone"
-/// id, `"Etc/Unknown"`, is rejected as well.
+/// id, `"Etc/Unknown"`, is rejected as well. Besides IANA ids, ICU accepts
+/// custom offset ids such as `"GMT+05:00"`.
 ///
 /// This mutates process wide state and is not synchronized with isolates
 /// running on other threads, so it should be called before those isolates

--- a/src/icu.rs
+++ b/src/icu.rs
@@ -5,6 +5,8 @@ use std::ffi::CString;
 unsafe extern "C" {
   fn icu_get_default_locale(output: *mut char, output_len: usize) -> usize;
   fn icu_set_default_locale(locale: *const char);
+  fn icu_get_default_timezone(output: *mut char, output_len: usize) -> usize;
+  fn icu_set_default_timezone(timezone: *const char);
   fn udata_setCommonData_78(this: *const u8, error_code: *mut i32);
 }
 
@@ -67,5 +69,31 @@ pub fn set_default_locale(locale: &str) {
   unsafe {
     let c_str = CString::new(locale).expect("Invalid locale");
     icu_set_default_locale(c_str.as_ptr());
+  }
+}
+
+/// Returns the IANA id of ICU's current default time zone (e.g.
+/// `"America/New_York"`).
+pub fn get_default_time_zone() -> String {
+  let mut output = [0u8; 1024];
+  let len = unsafe {
+    icu_get_default_timezone(output.as_mut_ptr() as *mut char, output.len())
+  };
+  std::str::from_utf8(&output[..len]).unwrap().to_owned()
+}
+
+/// Sets ICU's default time zone from an IANA id (e.g. `"UTC"`,
+/// `"Asia/Manila"`). This makes `Date` resolve the given zone on every
+/// platform, including Windows, where ICU otherwise reads the host time
+/// zone from the OS and ignores the `TZ` environment variable.
+///
+/// After calling this, notify each isolate via
+/// [`crate::Isolate::date_time_configuration_change_notification`] with
+/// [`crate::TimeZoneDetection::Skip`] so cached values are refreshed
+/// without re-detecting (and overwriting) the zone just set here.
+pub fn set_default_time_zone(timezone: &str) {
+  unsafe {
+    let c_str = CString::new(timezone).expect("Invalid timezone");
+    icu_set_default_timezone(c_str.as_ptr());
   }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -9814,7 +9814,11 @@ fn icu_set_common_data_fail() {
 
 #[test]
 fn icu_default_time_zone() {
-  let _setup_guard = setup::parallel_test();
+  // Mutates the process-wide ICU default time zone, which also affects how
+  // other tests' `Date`s render, so take the exclusive lock.
+  let _setup_guard = setup::sequential_test();
+  let original = v8::icu::get_default_time_zone();
+
   v8::icu::set_default_time_zone("America/New_York");
   assert_eq!(v8::icu::get_default_time_zone(), "America/New_York");
 
@@ -9833,8 +9837,8 @@ fn icu_default_time_zone() {
     assert_eq!(value.number_value(scope).unwrap(), 3.0);
   }
 
-  // Restore the default so other tests aren't affected by ordering.
-  v8::icu::set_default_time_zone("UTC");
+  // Restore the original default so test ordering doesn't matter.
+  v8::icu::set_default_time_zone(&original);
 }
 
 #[test]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -9813,6 +9813,31 @@ fn icu_set_common_data_fail() {
 }
 
 #[test]
+fn icu_default_time_zone() {
+  let _setup_guard = setup::parallel_test();
+  v8::icu::set_default_time_zone("America/New_York");
+  assert_eq!(v8::icu::get_default_time_zone(), "America/New_York");
+
+  let isolate = &mut v8::Isolate::new(Default::default());
+  isolate
+    .date_time_configuration_change_notification(v8::TimeZoneDetection::Skip);
+  {
+    v8::scope!(let scope, isolate);
+    let context = v8::Context::new(scope, Default::default());
+    let scope = &mut v8::ContextScope::new(scope, context);
+    // 2020-06-26T07:00:00Z is 03:00 in America/New_York (EDT, UTC-4).
+    let source = r#"
+      new Date(Date.UTC(2020, 5, 26, 7, 0, 0)).getHours();
+    "#;
+    let value = eval(scope, source).unwrap();
+    assert_eq!(value.number_value(scope).unwrap(), 3.0);
+  }
+
+  // Restore the default so other tests aren't affected by ordering.
+  v8::icu::set_default_time_zone("UTC");
+}
+
+#[test]
 fn icu_format() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -10457,6 +10457,31 @@ fn icu_set_common_data_fail() {
 }
 
 #[test]
+fn icu_default_time_zone() {
+  let _setup_guard = setup::parallel_test();
+  v8::icu::set_default_time_zone("America/New_York");
+  assert_eq!(v8::icu::get_default_time_zone(), "America/New_York");
+
+  let isolate = &mut v8::Isolate::new(Default::default());
+  isolate
+    .date_time_configuration_change_notification(v8::TimeZoneDetection::Skip);
+  {
+    v8::scope!(let scope, isolate);
+    let context = v8::Context::new(scope, Default::default());
+    let scope = &mut v8::ContextScope::new(scope, context);
+    // 2020-06-26T07:00:00Z is 03:00 in America/New_York (EDT, UTC-4).
+    let source = r#"
+      new Date(Date.UTC(2020, 5, 26, 7, 0, 0)).getHours();
+    "#;
+    let value = eval(scope, source).unwrap();
+    assert_eq!(value.number_value(scope).unwrap(), 3.0);
+  }
+
+  // Restore the default so other tests aren't affected by ordering.
+  v8::icu::set_default_time_zone("UTC");
+}
+
+#[test]
 fn icu_format() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -10458,7 +10458,11 @@ fn icu_set_common_data_fail() {
 
 #[test]
 fn icu_default_time_zone() {
-  let _setup_guard = setup::parallel_test();
+  // Mutates the process-wide ICU default time zone, which also affects how
+  // other tests' `Date`s render, so take the exclusive lock.
+  let _setup_guard = setup::sequential_test();
+  let original = v8::icu::get_default_time_zone();
+
   v8::icu::set_default_time_zone("America/New_York");
   assert_eq!(v8::icu::get_default_time_zone(), "America/New_York");
 
@@ -10477,8 +10481,8 @@ fn icu_default_time_zone() {
     assert_eq!(value.number_value(scope).unwrap(), 3.0);
   }
 
-  // Restore the default so other tests aren't affected by ordering.
-  v8::icu::set_default_time_zone("UTC");
+  // Restore the original default so test ordering doesn't matter.
+  v8::icu::set_default_time_zone(&original);
 }
 
 #[test]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -10477,9 +10477,29 @@ fn icu_default_time_zone() {
   // Mutates the process-wide ICU default time zone, which also affects how
   // other tests' `Date`s render, so take the exclusive lock.
   let _setup_guard = setup::sequential_test();
-  let original = v8::icu::get_default_time_zone();
 
-  v8::icu::set_default_time_zone("America/New_York");
+  // Restore the original default when the test ends, including on panic, so a
+  // failure here doesn't cascade into every test that renders a `Date`.
+  struct RestoreTimeZone(String);
+  impl Drop for RestoreTimeZone {
+    fn drop(&mut self) {
+      // The host zone may be undetectable ("Etc/Unknown"), which isn't
+      // settable; fall back to UTC rather than leaving the zone we installed.
+      // Deliberately no assert here: this can run while unwinding.
+      if !v8::icu::set_default_time_zone(&self.0) {
+        let _ = v8::icu::set_default_time_zone("UTC");
+      }
+    }
+  }
+  let _restore = RestoreTimeZone(v8::icu::get_default_time_zone());
+
+  // Unknown ids are rejected and leave the current default alone.
+  let before = v8::icu::get_default_time_zone();
+  assert!(!v8::icu::set_default_time_zone("Not/AZone"));
+  assert!(!v8::icu::set_default_time_zone("America/New\0_York"));
+  assert_eq!(v8::icu::get_default_time_zone(), before);
+
+  assert!(v8::icu::set_default_time_zone("America/New_York"));
   assert_eq!(v8::icu::get_default_time_zone(), "America/New_York");
 
   let isolate = &mut v8::Isolate::new(Default::default());
@@ -10496,9 +10516,6 @@ fn icu_default_time_zone() {
     let value = eval(scope, source).unwrap();
     assert_eq!(value.number_value(scope).unwrap(), 3.0);
   }
-
-  // Restore the original default so test ordering doesn't matter.
-  v8::icu::set_default_time_zone(&original);
 }
 
 #[test]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -10499,6 +10499,9 @@ fn icu_default_time_zone() {
   assert!(!v8::icu::set_default_time_zone("America/New\0_York"));
   assert_eq!(v8::icu::get_default_time_zone(), before);
 
+  assert!(v8::icu::set_default_time_zone("UTC"));
+  assert_eq!(v8::icu::get_default_time_zone(), "UTC");
+
   assert!(v8::icu::set_default_time_zone("America/New_York"));
   assert_eq!(v8::icu::get_default_time_zone(), "America/New_York");
 


### PR DESCRIPTION
Adds `v8::icu::set_default_time_zone(&str) -> bool` and
`v8::icu::get_default_time_zone() -> String`, wrapping
`icu::TimeZone::adoptDefault` and `createDefault`. Mirrors the existing
`set_default_locale` / `get_language_tag` pair.

Ids are usually IANA ids such as `America/New_York`; ICU also accepts and
reports custom offset ids like `GMT+05:00`. Ids ICU does not recognize are
rejected rather than silently installing GMT, and the setter is
`#[must_use]`.

This lets an embedder install the zone explicitly instead of relying on
ICU's host detection, which ignores `TZ` on Windows. Downstream:
denoland/deno#34705.
