### PR TITLE
v150.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,7 +1759,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "v8"
-version = "149.2.0"
+version = "150.0.0"
 dependencies = [
  "align-data",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v8"
-version = "149.2.0"
+version = "150.0.0"
 description = "Rust bindings to V8"
 readme = "README.md"
 authors = ["the Deno authors"]


### PR DESCRIPTION
Release v150.0.0 — the V8 15.0 roll (breaking API).

Delta over v149.3.0 (already published):
- Roll to V8 15.0.245.2; require `&'static` for CFunction overload storage (#1990)

Note: profiler bindings (#2001) and the FFI flags fix (#1994) already shipped in **v149.3.0** on V8 14.7.173.20 — they are not part of this release.

Release mechanism: this is the version-bump commit (Cargo.toml + Cargo.lock 149.x → 150.0.0). The actual release is cut by **tagging this commit `v150.0.0`** — CI builds binaries, uploads to the GH release, and runs `cargo publish`. Merging the PR is not what publishes.