### PR TITLE
v149.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,7 +1759,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "v8"
-version = "149.2.0"
+version = "149.3.0"
 dependencies = [
  "align-data",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v8"
-version = "149.2.0"
+version = "149.3.0"
 description = "Rust bindings to V8"
 readme = "README.md"
 authors = ["the Deno authors"]


### PR DESCRIPTION
Release v149.3.0 — ships the profiler bindings on V8 14.5, **before** the breaking V8 15.0 roll.

Cut at `ea42005` (V8 still 14.5.201.x). Includes since v149.2.0:
- Add Isolate::SetIdle and CpuProfiler bindings (#2001)
- fix: pass `flags` to `v8__ObjectTemplate__SetIndexedPropertyHandler` FFI (#1994)

Excludes the V8 15.0.245.2 roll (#1990) — that lands as v150.0.0 next.

Bumps `version` in Cargo.toml + Cargo.lock.