### PR TITLE
fix: shared-library-safe V8 TLS on Linux via v8_monolithic_for_shared_library

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -353,33 +353,25 @@ fn build_v8(is_asan: bool) {
     println!("cargo:warning=Not using sccache or ccache");
   }
 
-  // Use the shared-library-safe TLS mode by default on Linux so downstream
-  // cdylibs can link rusty_v8 archives. Skip injection when GN_ARGS already
-  // sets V8_TLS_USED_IN_LIBRARY.
-  let needs_tls_define = target_os == "linux";
-  let mut tls_define_injected = false;
-  if let Ok(raw_gn_args) = env::var("GN_ARGS")
-    && !raw_gn_args.trim().is_empty()
-  {
-    if raw_gn_args.contains("V8_TLS_USED_IN_LIBRARY") {
-      tls_define_injected = true;
-      gn_args.push(raw_gn_args);
-    } else if needs_tls_define && raw_gn_args.contains("extra_cflags=[") {
-      // Prepend our define into the existing extra_cflags array so we don't
-      // silently override the user's flags with a second assignment.
-      let modified = raw_gn_args.replacen(
-        "extra_cflags=[",
-        r#"extra_cflags=["-DV8_TLS_USED_IN_LIBRARY","#,
-        1,
-      );
-      tls_define_injected = true;
-      gn_args.push(modified);
-    } else {
-      gn_args.push(raw_gn_args);
-    }
+  // Forward caller-provided GN args verbatim.
+  let gn_args_env = env::var("GN_ARGS").unwrap_or_default();
+  if !gn_args_env.trim().is_empty() {
+    gn_args.push(gn_args_env.clone());
   }
-  if needs_tls_define && !tls_define_injected {
-    gn_args.push(r#"extra_cflags=["-DV8_TLS_USED_IN_LIBRARY"]"#.to_string());
+
+  // rusty_v8 ships a single static archive that downstream crates may link
+  // into a shared library (cdylib). On Linux, V8's default "local-exec" TLS
+  // model emits R_X86_64_TPOFF32 relocations against thread-locals such as
+  // `g_current_isolate_`, which lld refuses to place in a `-shared` object,
+  // so any cdylib that links the archive fails to link. Enabling this V8 GN
+  // arg routes the `V8_TLS_USED_IN_LIBRARY` define into both `internal_config`
+  // and the `features` config, switching V8 to the shared-library-safe TLS
+  // path (local-dynamic model + out-of-line accessor) uniformly across V8's
+  // own sources and rusty_v8's bindings.
+  if target_os == "linux"
+    && !gn_args_env.contains("v8_monolithic_for_shared_library")
+  {
+    gn_args.push("v8_monolithic_for_shared_library=true".to_string());
   }
   // cross-compilation setup
   if target_arch == "aarch64" {


### PR DESCRIPTION
## Problem

Linking the `rusty_v8` static archive into a downstream **shared library (cdylib)** fails to link on Linux:

```
rust-lld: error: relocation R_X86_64_TPOFF32 against v8::internal::g_current_isolate_
                 cannot be used with -shared
```

On Linux, V8's default TLS model is `local-exec`, which emits `R_X86_64_TPOFF32` relocations against thread-locals such as `g_current_isolate_`. `lld` refuses to place those in a `-shared` object. (GNU `bfd` accepts them but marks the result `DF_STATIC_TLS`, which risks `dlopen` failures — "cannot allocate memory in static TLS block" — so it's a latent bug there too.) The `deno` executable links fine because it's not `-shared`, which is why this only surfaces when embedding the archive in a cdylib.

## Why the existing mitigation didn't work

The current code injects `extra_cflags=["-DV8_TLS_USED_IN_LIBRARY"]`, but **`extra_cflags` is not a declared GN build arg** in the `chromium_build` fork (it only exists as a per-toolchain invoker variable). So the define never reached V8's compilation — `isolate.o` still carries `TPOFF32` relocations.

## Fix

Set the V8-sanctioned `v8_monolithic_for_shared_library=true` GN arg on Linux instead. In `denoland/v8` this routes `V8_TLS_USED_IN_LIBRARY` into **both** `config("internal_config")` (V8's own sources, e.g. `isolate.cc`) and `config("features")` (consumed by `rusty_v8`'s bindings via `//v8:features`). That switches the affected thread-locals to the shared-library-safe path in `src/common/thread-local-storage.h` (local-dynamic model + out-of-line accessor), eliminating the `TPOFF32` relocations everywhere.

The arg is guarded so a caller-supplied `GN_ARGS` override is respected.

## Verify

After building from source on Linux:

```
readelf -r isolate.o | grep g_current_isolate_   # expect TLSGD/TLSLD/DTPOFF, NOT TPOFF32
```

and a downstream cdylib that links the archive should now link with `lld`.