### PR TITLE
fix: shared-library-safe V8 TLS on Linux (149.x backport)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -353,33 +353,25 @@ fn build_v8(is_asan: bool) {
     println!("cargo:warning=Not using sccache or ccache");
   }
 
-  // Use the shared-library-safe TLS mode by default on Linux so downstream
-  // cdylibs can link rusty_v8 archives. Skip injection when GN_ARGS already
-  // sets V8_TLS_USED_IN_LIBRARY.
-  let needs_tls_define = target_os == "linux";
-  let mut tls_define_injected = false;
-  if let Ok(raw_gn_args) = env::var("GN_ARGS")
-    && !raw_gn_args.trim().is_empty()
-  {
-    if raw_gn_args.contains("V8_TLS_USED_IN_LIBRARY") {
-      tls_define_injected = true;
-      gn_args.push(raw_gn_args);
-    } else if needs_tls_define && raw_gn_args.contains("extra_cflags=[") {
-      // Prepend our define into the existing extra_cflags array so we don't
-      // silently override the user's flags with a second assignment.
-      let modified = raw_gn_args.replacen(
-        "extra_cflags=[",
-        r#"extra_cflags=["-DV8_TLS_USED_IN_LIBRARY","#,
-        1,
-      );
-      tls_define_injected = true;
-      gn_args.push(modified);
-    } else {
-      gn_args.push(raw_gn_args);
-    }
+  // Forward caller-provided GN args verbatim.
+  let gn_args_env = env::var("GN_ARGS").unwrap_or_default();
+  if !gn_args_env.trim().is_empty() {
+    gn_args.push(gn_args_env.clone());
   }
-  if needs_tls_define && !tls_define_injected {
-    gn_args.push(r#"extra_cflags=["-DV8_TLS_USED_IN_LIBRARY"]"#.to_string());
+
+  // rusty_v8 ships a single static archive that downstream crates may link
+  // into a shared library (cdylib). On Linux, V8's default "local-exec" TLS
+  // model emits R_X86_64_TPOFF32 relocations against thread-locals such as
+  // `g_current_isolate_`, which lld refuses to place in a `-shared` object,
+  // so any cdylib that links the archive fails to link. Enabling this V8 GN
+  // arg routes the `V8_TLS_USED_IN_LIBRARY` define into both `internal_config`
+  // and the `features` config, switching V8 to the shared-library-safe TLS
+  // path (local-dynamic model + out-of-line accessor) uniformly across V8's
+  // own sources and rusty_v8's bindings.
+  if target_os == "linux"
+    && !gn_args_env.contains("v8_monolithic_for_shared_library")
+  {
+    gn_args.push("v8_monolithic_for_shared_library=true".to_string());
   }
   // cross-compilation setup
   if target_arch == "aarch64" {


### PR DESCRIPTION
Backport of #2008 to the **149.x** line, so downstream (deno on `v8 = "149.3.0"`) can pick up the cdylib link fix without jumping to v150.

## Problem

Linking the `rusty_v8` static archive into a downstream **shared library (cdylib)** fails on Linux:

```
rust-lld: error: relocation R_X86_64_TPOFF32 against v8::internal::g_current_isolate_
                 cannot be used with -shared
```

V8's default Linux TLS model is `local-exec`, which emits `R_X86_64_TPOFF32` relocations against thread-locals such as `g_current_isolate_`; `lld` refuses to place those in a `-shared` object. (bfd accepts them but marks `DF_STATIC_TLS` — latent `dlopen` failures.) The `deno` executable links fine because it isn't `-shared`.

## Why the existing mitigation didn't work

The current code injects `extra_cflags=["-DV8_TLS_USED_IN_LIBRARY"]`, but **`extra_cflags` is not a declared GN build arg** in the `chromium_build` fork, so the define never reached V8's compilation — `isolate.o` still carries `TPOFF32` relocations.

## Fix

Set `v8_monolithic_for_shared_library=true` on Linux. The v8 pinned at v149.3.0 (`73d1969`) already carries patch 0003, so this arg routes `V8_TLS_USED_IN_LIBRARY` into **both** `internal_config` (V8's own sources, e.g. `isolate.cc`) and `features` (consumed by `rusty_v8`'s bindings via `//v8:features`), switching the affected thread-locals to the shared-library-safe path (local-dynamic + out-of-line accessor). Guarded so a caller-supplied `GN_ARGS` override is respected.

Identical change to #2008.

## Verify

```
readelf -r isolate.o | grep g_current_isolate_   # expect TLSGD/TLSLD/DTPOFF, NOT TPOFF32
```

Once merged, cut **v149.4.0** from `v149.x`.