### PR TITLE
fix: don't pass --allow-* flags to `deno eval` when downloading

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -686,8 +686,10 @@ fn download_file(url: &str, filename: &Path) {
          const file = await Deno.open(path, { write: true, create: true }); \
          await resp.body.pipeTo(file.writable);",
       )
-      .arg("--allow-net")
-      .arg("--allow-write")
+      // Note: `deno eval` runs with all permissions implicitly granted and does
+      // not accept `--allow-*` flags, so passing them here makes `deno eval`
+      // error out ("unexpected argument '--allow-net'") and the download
+      // silently falls back to Python/curl.
       .arg("--")
       .arg(url)
       .arg(&tmpfile)


### PR DESCRIPTION
The static-lib download path in `build.rs` tries Deno first via `deno
eval`, passing `--allow-net` and `--allow-write`:

```rust
Command::new(deno)
  .arg("eval")
  .arg("const [url, path] = Deno.args; const resp = await fetch(url); ...")
  .arg("--allow-net")
  .arg("--allow-write")
  .arg("--")
  .arg(url)
  .arg(&tmpfile)
```

But `deno eval` runs with all permissions implicitly granted and does not
register the `--allow-*` flags, so it rejects them and exits with an
error (the only permission-like flag it accepts is `--allow-scripts`):

```
$ deno eval '...' --allow-net --allow-write -- url path
error: unexpected argument '--allow-net' found
  tip: a similar argument exists: '--allow-scripts'
```

As a result the Deno attempt always fails and the download silently falls
back to Python/curl. This has been the case for a long time (eval has had
implicit all-permissions for years) but went unnoticed because the
fallback succeeds. The only visible symptom is a confusing clap error
printed to stderr during the build, which has confused users into thinking
their build is broken (see denoland/deno#35417).

The flags are unnecessary since `deno eval` already has full permissions,
so this just drops them. The download script still has `fetch` and
`Deno.open` available, which I verified manually.