### PR TITLE
Jitless `aarch64-apple-ios` builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,16 +78,20 @@ jobs:
           # iOS: built from source. The simulator keeps the JIT; the device
           # build is jitless (no JIT entitlement on device) -- see build.rs.
           # Cross-compiled, so the test suite is not run on the runner.
+          # Built with simdutf (the variant downstream consumers like Deno
+          # need); WebAssembly is disabled (Torque can't build it jitless).
           - os: macos-15
             target: aarch64-apple-ios-sim
             variant: release
             v8_enable_pointer_compression: false
+            simdutf: true
             cargo: cargo
 
           - os: macos-15
             target: aarch64-apple-ios
             variant: release
             v8_enable_pointer_compression: false
+            simdutf: true
             cargo: cargo
 
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,21 @@ jobs:
             v8_enable_pointer_compression: true
             cargo: cargo
 
+          # iOS: built from source. The simulator keeps the JIT; the device
+          # build is jitless (no JIT entitlement on device) -- see build.rs.
+          # Cross-compiled, so the test suite is not run on the runner.
+          - os: macos-15
+            target: aarch64-apple-ios-sim
+            variant: release
+            v8_enable_pointer_compression: false
+            cargo: cargo
+
+          - os: macos-15
+            target: aarch64-apple-ios
+            variant: release
+            v8_enable_pointer_compression: false
+            cargo: cargo
+
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
             target: x86_64-unknown-linux-gnu
             variant: debug
@@ -277,6 +292,10 @@ jobs:
           echo "CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/riscv64-linux-gnu-gcc-10" >> ${GITHUB_ENV}
           echo "QEMU_LD_PREFIX=/usr/riscv64-linux-gnu" >> ${GITHUB_ENV}
 
+      - name: Install iOS target
+        if: contains(matrix.config.target, 'ios')
+        run: rustup target add ${{ matrix.config.target }}
+
       - name: Write git_submodule_status.txt
         run: git submodule status --recursive > git_submodule_status.txt
 
@@ -313,6 +332,9 @@ jobs:
                # Unlike aarch64, the riscv64 sccache binary is not static, so use the host architecture one.
                "riscv64gc-unknown-linux-gnu" = "x86_64-unknown-linux-musl"
                "x86_64-pc-windows-msvc"    = "x86_64-pc-windows-msvc"
+               # iOS cross-compiles on the arm64 macOS runner, so use the host sccache binary.
+               "aarch64-apple-ios"         = "aarch64-apple-darwin"
+               "aarch64-apple-ios-sim"     = "aarch64-apple-darwin"
              }['${{ matrix.config.target }}']
           $basename = "sccache-$version-$platform"
           $url = "https://github.com/mozilla/sccache/releases/download/$version/$basename.tar.gz"
@@ -346,13 +368,24 @@ jobs:
         run: |
           clang-format-19 --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h
 
+      # iOS targets cross-compile and cannot run on the runner, so they get a
+      # build-only step (which also produces gn_out/obj/librusty_v8.a for the
+      # publish step below) instead of the test + clippy steps.
+      - name: Build (iOS)
+        if: contains(matrix.config.target, 'ios')
+        env:
+          SCCACHE_IDLE_TIMEOUT: 0
+          V8_FROM_SOURCE: 1
+        run: ${{ matrix.config.cargo }} build -v --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
+
       - name: Test
         env:
           SCCACHE_IDLE_TIMEOUT: 0
-        if: matrix.config.variant == 'debug' || matrix.config.variant == 'release'
+        if: (matrix.config.variant == 'debug' || matrix.config.variant == 'release') && !contains(matrix.config.target, 'ios')
         run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
 
       - name: Clippy
+        if: ${{ !contains(matrix.config.target, 'ios') }}
         run: ${{ matrix.config.cargo }} clippy --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }} -- -D clippy::all
 
       - name: Prepare binary publish

--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ docker build --build-arg CROSS_BASE_IMAGE=ghcr.io/cross-rs/aarch64-linux-android
 V8_FROM_SOURCE=1 cross build -vv --target aarch64-linux-android
 ```
 
+For iOS builds: cross compile from an arm64 macOS host. The simulator target
+keeps the JIT; the device target (`aarch64-apple-ios`) is built jitless, since
+iOS denies the JIT entitlement to non-WebKit apps (WebAssembly is also disabled
+in this configuration). `build.rs` selects these settings automatically per
+target — no extra GN args required:
+
+```bash
+rustup target add aarch64-apple-ios-sim  # simulator
+rustup target add aarch64-apple-ios      # device (jitless)
+V8_FROM_SOURCE=1 cargo build -vv --target aarch64-apple-ios-sim
+```
+
 The build depends on several binary tools: `gn`, `ninja` and `clang`. The tools
 will automatically be downloaded, if they are not detected in the environment.
 

--- a/build.rs
+++ b/build.rs
@@ -212,6 +212,26 @@ fn build_binding() {
         clang_args.push(format!("-isystem{}/include", resource_dir.trim()));
       }
     }
+  } else if target_os == "ios" {
+    // iOS: point bindgen at the iOS (device) or iOS-simulator SDK and set the
+    // matching clang target triple so the V8 headers parse correctly.
+    let target_triple = env::var("TARGET").unwrap();
+    let is_sim = target_triple.ends_with("-sim")
+      || target_triple.starts_with("x86_64-apple-ios");
+    let sdk = if is_sim { "iphonesimulator" } else { "iphoneos" };
+    let output = Command::new("xcrun")
+      .args(["--sdk", sdk, "--show-sdk-path"])
+      .output()
+      .unwrap();
+    let sdk_path = String::from_utf8(output.stdout).unwrap();
+    clang_args.push("-isysroot".to_string());
+    clang_args.push(sdk_path.trim().to_string());
+    let clang_target = if is_sim {
+      "arm64-apple-ios-simulator"
+    } else {
+      "arm64-apple-ios"
+    };
+    clang_args.push(format!("--target={clang_target}"));
   }
 
   let bindings = bindgen::Builder::default()

--- a/build.rs
+++ b/build.rs
@@ -218,7 +218,11 @@ fn build_binding() {
     let target_triple = env::var("TARGET").unwrap();
     let is_sim = target_triple.ends_with("-sim")
       || target_triple.starts_with("x86_64-apple-ios");
-    let sdk = if is_sim { "iphonesimulator" } else { "iphoneos" };
+    let sdk = if is_sim {
+      "iphonesimulator"
+    } else {
+      "iphoneos"
+    };
     let output = Command::new("xcrun")
       .args(["--sdk", sdk, "--show-sdk-path"])
       .output()
@@ -471,6 +475,34 @@ fn build_v8(is_asan: bool) {
       "./third_party/catapult",
       &format!("{CHROMIUM_URI}/catapult.git"),
     );
+  }
+
+  // iOS / iOS-simulator. iOS denies the JIT entitlement to non-WebKit apps, so
+  // a device build must be jitless -- which in turn requires V8's optimizing
+  // tiers (Sparkplug/Maglev/Turbofan) and WebAssembly to be disabled. The
+  // simulator runs on the host and could keep the JIT, but WebAssembly is
+  // disabled there too because Torque can't generate the Wasm builtins in this
+  // configuration. `target_cpu="arm64"` is already set above for aarch64.
+  // Pass an explicit `target_os="ios"` in GN_ARGS to fully override this.
+  if target_os == "ios" && !gn_args_env.contains(r#"target_os="ios""#) {
+    let is_sim = target_triple.ends_with("-sim")
+      || target_triple.starts_with("x86_64-apple-ios");
+    gn_args.push(r#"target_os="ios""#.to_string());
+    gn_args.push(format!(
+      r#"target_environment="{}""#,
+      if is_sim { "simulator" } else { "device" }
+    ));
+    gn_args.push(r#"ios_deployment_target="14.0""#.to_string());
+    gn_args.push("ios_enable_code_signing=false".to_string());
+    gn_args.push("treat_warnings_as_errors=false".to_string());
+    gn_args.push("v8_enable_webassembly=false".to_string());
+    if !is_sim {
+      // Device: no JIT permitted -> jitless build, all tiers off.
+      gn_args.push("v8_jitless=true".to_string());
+      gn_args.push("v8_enable_sparkplug=false".to_string());
+      gn_args.push("v8_enable_maglev=false".to_string());
+      gn_args.push("v8_enable_turbofan=false".to_string());
+    }
   }
 
   if target_triple.starts_with("i686-") {

--- a/examples/ios_jitless.rs
+++ b/examples/ios_jitless.rs
@@ -1,0 +1,30 @@
+// Minimal jitless smoke test for the iOS spike: force V8 into jitless mode
+// (the mode required on a real iOS device, which denies the JIT entitlement)
+// and run a little recursive JS to confirm the Ignition interpreter executes.
+
+fn main() {
+  let platform = v8::new_default_platform(0, false).make_shared();
+  v8::V8::initialize_platform(platform);
+  // The flag a real device build needs: no runtime codegen / no RWX pages.
+  v8::V8::set_flags_from_string("--jitless");
+  v8::V8::initialize();
+
+  {
+    let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
+    v8::scope!(let handle_scope, isolate);
+    let context = v8::Context::new(handle_scope, Default::default());
+    let scope = &v8::ContextScope::new(handle_scope, context);
+
+    let src = "const fib=(n)=>n<2?n:fib(n-1)+fib(n-2); `fib(25)=${fib(25)}`";
+    let code = v8::String::new(scope, src).unwrap();
+    let script = v8::Script::compile(scope, code, None).unwrap();
+    let result = script.run(scope).unwrap();
+    let result = result.to_string(scope).unwrap();
+    println!("JITLESS OK: {}", result.to_rust_string_lossy(scope));
+  }
+
+  unsafe {
+    v8::V8::dispose();
+  }
+  v8::V8::dispose_platform();
+}


### PR DESCRIPTION
Builds V8 from source for `aarch64-apple-ios` (device) and `aarch64-apple-ios-sim` (simulator), and publishes the static libs from CI alongside the existing targets.

iOS denies the JIT entitlement to non-WebKit apps, so the device build has to be jitless, which means V8's optimizing tiers (Sparkplug/Maglev/Turbofan) and WebAssembly are disabled. The simulator runs on the host and keeps the JIT. build.rs picks the right config per target, so downstream is just `rustup target add` plus `V8_FROM_SOURCE=1 cargo build --target ...` with no extra GN args.

Changes:
- build.rs: iOS branch for bindgen (iphoneos/iphonesimulator sysroot + arm64-apple-ios[-simulator] clang target) and the iOS GN args (target_os, target_environment, ios_deployment_target, v8_enable_webassembly=false; device also sets v8_jitless=true and turns the tiers off).
- ci.yml: add both iOS targets (release) to the matrix. They cross-compile, so they get a build-only step instead of test/clippy; the existing publish step uploads the gzipped lib. The asset name already includes the target triple, so prebuilt download works downstream with no change.
- README: document the iOS build.
- examples/ios_jitless.rs: forces --jitless and runs recursive JS.

Verified locally (Xcode 26.2, arm64 macOS):
- V8 builds from source for both iOS targets (~60M librusty_v8.a each).
- The v8 crate links the simulator lib and runs JS on the simulator, including with --jitless (fib(25)=75025).
- The device lib builds with compile-time v8_jitless=true.

Notes:
- I don't have an iOS CI runner, so the matrix rows are untested in CI and may need adjusting (timeouts, sccache, etc.).
- iOS prebuilts here are without pointer compression, which is what I verified. A _ptrcomp variant can follow once it's checked.
- WebAssembly is off for iOS because Torque can't generate the Wasm builtins in this config; the Wasm interpreter (drumbrake) could be a follow-up.