### PR TITLE
feat: expose WebAssembly trap handler binding

### DIFF
--- a/src/V8.rs
+++ b/src/V8.rs
@@ -27,6 +27,7 @@ unsafe extern "C" {
   fn v8__V8__Dispose() -> bool;
   fn v8__V8__DisposePlatform();
   fn v8__V8__SetFatalErrorHandler(that: V8FatalErrorCallback);
+  fn v8__V8__EnableWebAssemblyTrapHandler(use_v8_signal_handler: bool) -> bool;
 }
 
 pub type V8FatalErrorCallback = unsafe extern "C" fn(
@@ -279,6 +280,14 @@ pub fn set_fatal_error_handler(that: impl MapFnTo<V8FatalErrorCallback>) {
   unsafe {
     v8__V8__SetFatalErrorHandler(that.map_fn_to());
   }
+}
+
+/// Activate trap-based bounds checking for WebAssembly.
+///
+/// If `use_v8_signal_handler` is true, V8 installs its own signal handler.
+/// Otherwise, V8 relies on the embedder to invoke its trap handler.
+pub fn enable_web_assembly_trap_handler(use_v8_signal_handler: bool) -> bool {
+  unsafe { v8__V8__EnableWebAssemblyTrapHandler(use_v8_signal_handler) }
 }
 
 #[cfg(test)]

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -159,6 +159,10 @@ void v8__V8__SetFatalErrorHandler(v8::V8FatalErrorCallback that) {
   v8::V8::SetFatalErrorHandler(that);
 }
 
+bool v8__V8__EnableWebAssemblyTrapHandler(bool use_v8_signal_handler) {
+  return v8::V8::EnableWebAssemblyTrapHandler(use_v8_signal_handler);
+}
+
 v8::Isolate* v8__Isolate__New(const v8::Isolate::CreateParams& params) {
   return v8::Isolate::New(params);
 }


### PR DESCRIPTION
## Summary

Adds a thin Rust binding for `v8::V8::EnableWebAssemblyTrapHandler(bool)`.

The new `v8::V8::enable_web_assembly_trap_handler(use_v8_signal_handler)` wrapper forwards through a C shim in `src/binding.cc`, matching the existing `V8` global API binding style.

## Validation

- `cargo fmt --check`
- `ninja -C target/debug/gn_out obj/rusty_v8/binding.o`

`cargo check -p v8` currently stops on an unrelated existing bindgen constant mismatch in `src/string.rs` (`v8_String_WriteFlags_*` vs `WriteFlags_*`).
