### PR TITLE
v150.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,7 +1759,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "v8"
-version = "150.0.0"
+version = "150.1.0"
 dependencies = [
  "align-data",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "v8"
-version = "150.0.0"
+version = "150.1.0"
 description = "Rust bindings to V8"
 readme = "README.md"
 authors = ["the Deno authors"]


### PR DESCRIPTION
Bump release version to 150.1.0.

First release off `main` to include the jitless `aarch64-apple-ios[-sim]` build support from #2011, so downstream consumers (Deno desktop iOS) can pull prebuilt iOS `librusty_v8` archives.
