### PR TITLE
feat: x86_64-unknown-linux-musl builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,23 +120,13 @@ jobs:
 
           # musl: cross-compiled on the glibc runner (host tools stay glibc,
           # target objects are musl -- see build.rs). Not run on the runner.
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: x86_64-unknown-linux-musl
-            variant: debug
-            v8_enable_pointer_compression: false
-            cargo: cargo
-
+          # Release only for now, like the iOS targets: V8's debug-only
+          # execinfo backtrace path (external-reference-table.cc) assumes glibc
+          # and doesn't compile against musl.
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
             target: x86_64-unknown-linux-musl
             variant: release
             v8_enable_pointer_compression: false
-            cargo: cargo
-
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: x86_64-unknown-linux-musl
-            variant: debug
-            v8_enable_pointer_compression: false
-            simdutf: true
             cargo: cargo
 
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,34 @@ jobs:
             v8_enable_pointer_compression: true
             cargo: cargo
 
+          # musl: cross-compiled on the glibc runner (host tools stay glibc,
+          # target objects are musl -- see build.rs). Not run on the runner.
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
+            target: x86_64-unknown-linux-musl
+            variant: debug
+            v8_enable_pointer_compression: false
+            cargo: cargo
+
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
+            target: x86_64-unknown-linux-musl
+            variant: release
+            v8_enable_pointer_compression: false
+            cargo: cargo
+
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
+            target: x86_64-unknown-linux-musl
+            variant: debug
+            v8_enable_pointer_compression: false
+            simdutf: true
+            cargo: cargo
+
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
+            target: x86_64-unknown-linux-musl
+            variant: release
+            v8_enable_pointer_compression: false
+            simdutf: true
+            cargo: cargo
+
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'windows-2022-xxl' || 'windows-2022' }}
             target: x86_64-pc-windows-msvc
             variant: release # Note: we do not support windows debug builds.
@@ -300,6 +328,30 @@ jobs:
         if: contains(matrix.config.target, 'ios')
         run: rustup target add ${{ matrix.config.target }}
 
+      - name: Install musl cross compilation toolchain
+        if: matrix.config.target == 'x86_64-unknown-linux-musl'
+        run: |
+          rustup target add x86_64-unknown-linux-musl
+
+          sudo apt update
+          sudo apt install -yq --no-install-suggests --no-install-recommends \
+            musl-tools musl-dev
+
+          # Assemble a musl sysroot (musl headers/libs + kernel headers) for
+          # V8's target clang. The musl target is compile-only (objects are
+          # archived into librusty_v8.a, never linked), so no gcc runtime is
+          # needed here; the executable build tools are built with the glibc
+          # host toolchain.
+          SYSROOT="${HOME}/musl-sysroot"
+          mkdir -p "${SYSROOT}/usr/include" "${SYSROOT}/usr/lib"
+          cp -a /usr/include/x86_64-linux-musl/. "${SYSROOT}/usr/include/"
+          cp -a /usr/lib/x86_64-linux-musl/.     "${SYSROOT}/usr/lib/"
+          cp -a /usr/include/linux                "${SYSROOT}/usr/include/"
+          cp -a /usr/include/asm-generic          "${SYSROOT}/usr/include/"
+          cp -a /usr/include/x86_64-linux-gnu/asm "${SYSROOT}/usr/include/"
+
+          echo "RUSTY_V8_MUSL_SYSROOT=${SYSROOT}" >> ${GITHUB_ENV}
+
       - name: Write git_submodule_status.txt
         run: git submodule status --recursive > git_submodule_status.txt
 
@@ -332,6 +384,7 @@ jobs:
             @{ "x86_64-apple-darwin"       = "x86_64-apple-darwin"
                "aarch64-apple-darwin"      = "aarch64-apple-darwin"
                "x86_64-unknown-linux-gnu"  = "x86_64-unknown-linux-musl"
+               "x86_64-unknown-linux-musl" = "x86_64-unknown-linux-musl"
                "aarch64-unknown-linux-gnu" = "aarch64-unknown-linux-musl"
                # Unlike aarch64, the riscv64 sccache binary is not static, so use the host architecture one.
                "riscv64gc-unknown-linux-gnu" = "x86_64-unknown-linux-musl"
@@ -382,14 +435,23 @@ jobs:
           V8_FROM_SOURCE: 1
         run: ${{ matrix.config.cargo }} build -v --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
 
+      # musl is cross-compiled on a glibc runner, so the test suite is not run
+      # on the runner (build-only, like the iOS targets). This still produces
+      # gn_out/obj/librusty_v8.a for the publish step below.
+      - name: Build (musl)
+        if: matrix.config.target == 'x86_64-unknown-linux-musl'
+        env:
+          SCCACHE_IDLE_TIMEOUT: 0
+        run: ${{ matrix.config.cargo }} build -v --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
+
       - name: Test
         env:
           SCCACHE_IDLE_TIMEOUT: 0
-        if: (matrix.config.variant == 'debug' || matrix.config.variant == 'release') && !contains(matrix.config.target, 'ios')
+        if: (matrix.config.variant == 'debug' || matrix.config.variant == 'release') && !contains(matrix.config.target, 'ios') && matrix.config.target != 'x86_64-unknown-linux-musl'
         run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
 
       - name: Clippy
-        if: ${{ !contains(matrix.config.target, 'ios') }}
+        if: ${{ !contains(matrix.config.target, 'ios') && matrix.config.target != 'x86_64-unknown-linux-musl' }}
         run: ${{ matrix.config.cargo }} clippy --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }} -- -D clippy::all
 
       - name: Prepare binary publish

--- a/build.rs
+++ b/build.rs
@@ -424,6 +424,42 @@ fn build_v8(is_asan: bool) {
     }
   }
 
+  // musl libc. V8's build targets glibc by default; the vendored build config
+  // grows a target-scoped `use_musl` arg (see //build/config/rust.gni,
+  // sysroot.gni, c++/BUILD.gn, toolchain/*). The final librusty_v8.a is a
+  // static archive of musl-compiled objects (never linked here), so the target
+  // toolchain needs only musl headers -- the executable build tools (torque,
+  // mksnapshot, code generators) are built with a separate glibc toolchain so
+  // they link and run on the (glibc) build host.
+  let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+  if target_env == "musl" && target_os == "linux" {
+    gn_args.push("use_musl=true".to_string());
+    // V8-as-a-library has no glib dependency; skip it so a musl target_sysroot
+    // doesn't send pkg-config looking for glib inside the sysroot.
+    gn_args.push("use_glib=false".to_string());
+    // Build libstd + V8's internal Rust crates from source for the musl triple;
+    // V8's vendored Rust toolchain only ships a glibc host std.
+    gn_args.push("rust_prebuilt_stdlib=false".to_string());
+
+    let glibc_toolchain = match target_arch.as_str() {
+      "x86_64" => "//build/toolchain/linux:clang_x64_glibc",
+      other => panic!(
+        "musl builds are currently only supported for x86_64 (got {other})"
+      ),
+    };
+    gn_args.push(format!("host_toolchain=\"{glibc_toolchain}\""));
+    gn_args.push(format!("v8_snapshot_toolchain=\"{glibc_toolchain}\""));
+    // The glibc host toolchain builds against the amd64 sysroot, same as the
+    // host side of the aarch64/riscv64 cross builds.
+    maybe_install_sysroot("amd64");
+
+    // Cross-compiling on a glibc host needs a musl sysroot for the target's
+    // headers/libs. Native musl builds (e.g. on Alpine) can leave this unset.
+    if let Ok(sysroot) = env::var("RUSTY_V8_MUSL_SYSROOT") {
+      gn_args.push(format!("target_sysroot=\"{sysroot}\""));
+    }
+  }
+
   let target_triple = env::var("TARGET").unwrap();
   // check if the target triple describes a non-native environment
   if target_triple != env::var("HOST").unwrap() && target_os == "android" {

--- a/build.rs
+++ b/build.rs
@@ -440,6 +440,11 @@ fn build_v8(is_asan: bool) {
     // Build libstd + V8's internal Rust crates from source for the musl triple;
     // V8's vendored Rust toolchain only ships a glibc host std.
     gn_args.push("rust_prebuilt_stdlib=false".to_string());
+    // Some V8 sources have glibc-only code paths (e.g. execinfo-based
+    // backtraces in stack_trace_posix.cc) whose helpers are unused on musl,
+    // tripping -Werror,-Wunused-const-variable. Like the iOS/Android cross
+    // builds, don't treat warnings as errors here.
+    gn_args.push("treat_warnings_as_errors=false".to_string());
 
     let glibc_toolchain = match target_arch.as_str() {
       "x86_64" => "//build/toolchain/linux:clang_x64_glibc",


### PR DESCRIPTION
Deno can't build against a prebuilt rusty_v8 for musl targets, so this adds
x86_64-unknown-linux-musl builds. Every prior attempt stalled on the same
wall: V8 vendors its own glibc Rust toolchain and its build hardcodes the Rust
target triple to *-unknown-linux-gnu, so V8's internal Rust crates, libstd and
mksnapshot always link glibc and fail against musl's missing LFS64 symbols.

The fix is a target-scoped use_musl arg in the vendored chromium_build. V8's
internal Rust and libstd build for the musl triple, while the executable build
tools (torque, mksnapshot, code generators) build with a separate glibc
toolchain so they link and run on the glibc build host. The final
librusty_v8.a is a static archive of musl objects that is never linked here.
build.rs enables this automatically for musl targets, and CI cross-compiles
the artifact on the glibc runner (build-only, like the iOS targets).

Release only for now, like the iOS targets: V8's debug-only execinfo backtrace
path (external-reference-table.cc) assumes glibc and doesn't compile against
musl. x86_64 only; aarch64-musl is a follow-up.

Depends on denoland/chromium_build#205 (the GN patches). The build submodule
here points at that branch and should be re-pinned to the merged SHA before
landing.

Closes #49