### PR TITLE
build: Clean up downloading process

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,8 @@ cargo build
 Use `V8_FROM_SOURCE=1 cargo build -vv` to build the crate completely from
 source.
 
-The build scripts require Python 3 to be available as `python` or `python3`
-in your `PATH`. If you want to specify the exact binary of Python to use,
-you should use the `PYTHON` environment variable.
+The build scripts require Python 3, located via the `PYTHON` environment
+variable, or as `python3` or `python` in your `PATH`.
 
 The build also requires `curl` to be installed on your system.
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ cargo build
 Use `V8_FROM_SOURCE=1 cargo build -vv` to build the crate completely from
 source.
 
-The build scripts require Python 3 to be available as `python3` in your `PATH`.
-If you want to specify the exact binary of Python to use, you should use the
-`PYTHON` environment variable.
+The build scripts require Python 3 to be available as `python` or `python3`
+in your `PATH`. If you want to specify the exact binary of Python to use,
+you should use the `PYTHON` environment variable.
 
 The build also requires `curl` to be installed on your system.
 
@@ -141,9 +141,7 @@ curl -fL https://chromium.googlesource.com/chromium/src/tools/win/+archive/faefd
   tar -xz -C tools/win
 ```
 
-For Mac builds: You'll need Xcode and Xcode CLT installed. Recent macOS versions
-will also require you to pass PYTHON=python3 because macOS no longer ships with
-`python` simlinked to Python 3.
+For Mac builds: You'll need Xcode and Xcode CLT installed.
 
 For Android builds: You'll need to cross compile from a x86_64 host to the
 aarch64 or x64 android. You can use the following commands:

--- a/build.rs
+++ b/build.rs
@@ -180,14 +180,12 @@ fn build_binding() {
     );
   }
 
-  let output = Command::new(
-    python().expect("Python must be available to build rusty_v8!"),
-  )
-  .arg("./tools/get_bindgen_args.py")
-  .arg("--gn-out")
-  .arg(build_dir().join("gn_out"))
-  .output()
-  .unwrap();
+  let output = Command::new(python_or_die())
+    .arg("./tools/get_bindgen_args.py")
+    .arg("--gn-out")
+    .arg(build_dir().join("gn_out"))
+    .output()
+    .unwrap();
   let args = String::from_utf8(output.stdout).unwrap();
   let args = args.split('\0').collect::<Vec<_>>();
 
@@ -632,12 +630,7 @@ fn build_v8(is_asan: bool) {
 fn print_gn_args(gn_out_dir: &Path) {
   assert!(
     Command::new(gn())
-      .arg(format!(
-        "--script-executable={}",
-        python()
-          .expect("Python must be available to build rusty_v8!")
-          .display()
-      ))
+      .arg(format!("--script-executable={}", python_or_die().display()))
       .arg("args")
       .arg(gn_out_dir)
       .arg("--list")
@@ -666,14 +659,12 @@ fn maybe_install_sysroot(arch: &str) {
   let sysroot_path = format!("build/linux/debian_sid_{arch}-sysroot");
   if !PathBuf::from(sysroot_path).is_dir() {
     assert!(
-      Command::new(
-        python().expect("Python must be available to build rusty_v8!")
-      )
-      .arg("./build/linux/sysroot_scripts/install-sysroot.py")
-      .arg(format!("--arch={arch}"))
-      .status()
-      .unwrap()
-      .success()
+      Command::new(python_or_die())
+        .arg("./build/linux/sysroot_scripts/install-sysroot.py")
+        .arg(format!("--arch={arch}"))
+        .status()
+        .unwrap()
+        .success()
     );
   }
 }
@@ -690,15 +681,13 @@ fn download_ninja_gn_binaries() {
 
   if !gn.exists() || !ninja.exists() {
     assert!(
-      Command::new(
-        python().expect("Python must be available to build rusty_v8!")
-      )
-      .arg("./tools/ninja_gn_binaries.py")
-      .arg("--dir")
-      .arg(&target_dir)
-      .status()
-      .unwrap()
-      .success()
+      Command::new(python_or_die())
+        .arg("./tools/ninja_gn_binaries.py")
+        .arg("--dir")
+        .arg(&target_dir)
+        .status()
+        .unwrap()
+        .success()
     );
   }
   assert!(gn.exists());
@@ -715,13 +704,11 @@ fn download_ninja_gn_binaries() {
 
 fn download_rust_toolchain() {
   assert!(
-    Command::new(
-      python().expect("Python must be available to build rusty_v8!")
-    )
-    .arg("./tools/rust_toolchain.py")
-    .status()
-    .unwrap()
-    .success()
+    Command::new(python_or_die())
+      .arg("./tools/rust_toolchain.py")
+      .status()
+      .unwrap()
+      .success()
   );
 }
 
@@ -1157,15 +1144,13 @@ fn clang_download() -> PathBuf {
   let clang_base_path = build_dir().join("clang");
   println!("clang_base_path (downloaded) {}", clang_base_path.display());
   assert!(
-    Command::new(
-      python().expect("Python must be available to build rusty_v8!")
-    )
-    .arg("./tools/clang/scripts/update.py")
-    .arg("--output-dir")
-    .arg(&clang_base_path)
-    .status()
-    .unwrap()
-    .success()
+    Command::new(python_or_die())
+      .arg("./tools/clang/scripts/update.py")
+      .arg("--output-dir")
+      .arg(&clang_base_path)
+      .status()
+      .unwrap()
+      .success()
   );
 
   // Chromium ships libclang separately from the compiler on Windows. Use the
@@ -1335,6 +1320,11 @@ fn python() -> io::Result<PathBuf> {
   })
 }
 
+/// Helper function to get the systems python binary or panic if none could be found.
+fn python_or_die() -> PathBuf {
+  python().expect("Python must be available to build rusty_v8 from source!")
+}
+
 type NinjaEnv = Vec<(String, String)>;
 
 fn ninja(gn_out_dir: &Path, maybe_env: Option<NinjaEnv>) -> Command {
@@ -1376,12 +1366,7 @@ fn run_gn_gen(gn_args: &[String]) -> PathBuf {
   assert!(
     Command::new(gn())
       .arg(format!("--root={}", dirs.root.display()))
-      .arg(format!(
-        "--script-executable={}",
-        python()
-          .expect("Python must be available to build rusty_v8!")
-          .display()
-      ))
+      .arg(format!("--script-executable={}", python_or_die().display()))
       .arg("gen")
       .arg(&gn_out_dir)
       .arg("--ide=json")

--- a/build.rs
+++ b/build.rs
@@ -837,8 +837,8 @@ fn download_file(url: &str, filename: &Path) {
   // If python is not available, try falling back to curl.
   println!("Downloading {url}");
   let status = download_with_deno(url, &tmpfile)
-    .or_else(|_| download_with_python(url, &tmpfile))
-    .or_else(|_| download_with_curl(url, &tmpfile))
+    .or_else(|| download_with_python(url, &tmpfile))
+    .or_else(|| download_with_curl(url, &tmpfile))
     .expect("Neither deno, python nor curl were available to download the V8 prebuilt archive.");
 
   // Assert DL was successful
@@ -866,69 +866,64 @@ fn download_file(url: &str, filename: &Path) {
 fn download_with_deno<P: AsRef<std::ffi::OsStr>>(
   url: &str,
   path: P,
-) -> io::Result<std::process::ExitStatus> {
-  which("deno")
-    .map_err(|e| io::Error::new(io::ErrorKind::NotFound, e))
-    .and_then(|deno| {
-      println!("Downloading with Deno...");
-      Command::new(deno)
-        .arg("eval")
-        .arg(
-          "const [url, path] = Deno.args; \
+) -> Option<std::process::ExitStatus> {
+  let deno_path = which("deno").ok()?;
+  println!("Downloading with Deno...");
+  Command::new(deno_path)
+    .arg("eval")
+    .arg(
+      "const [url, path] = Deno.args; \
          const resp = await fetch(url); \
          if (!resp.ok) Deno.exit(1); \
          const file = await Deno.open(path, { write: true, create: true }); \
          await resp.body.pipeTo(file.writable);",
-        )
-        // Note: `deno eval` runs with all permissions implicitly granted and does
-        // not accept `--allow-*` flags, so passing them here makes `deno eval`
-        // error out ("unexpected argument '--allow-net'") and the download
-        // silently falls back to Python/curl.
-        .arg("--")
-        .arg(url)
-        .arg(path)
-        .status()
-    })
+    )
+    // Note: `deno eval` runs with all permissions implicitly granted and does
+    // not accept `--allow-*` flags, so passing them here makes `deno eval`
+    // error out ("unexpected argument '--allow-net'") and the download
+    // silently falls back to Python/curl.
+    .arg("--")
+    .arg(url)
+    .arg(path)
+    .status()
+    .ok()
+    .filter(|s| s.success())
 }
 
 /// Downloads a file from `url` with Python and stores it at `path`.
 fn download_with_python<P: AsRef<std::ffi::OsStr>>(
   url: &str,
   path: P,
-) -> io::Result<std::process::ExitStatus> {
-  python().and_then(|python_path| {
-    println!("Downloading with Python...");
-    Command::new(python_path)
-      .arg("./tools/download_file.py")
-      .arg("--url")
-      .arg(url)
-      .arg("--filename")
-      .arg(path)
-      .status()
-  })
+) -> Option<std::process::ExitStatus> {
+  let python_path = python().ok()?;
+  println!("Downloading with Python...");
+  Command::new(python_path)
+    .arg("./tools/download_file.py")
+    .arg("--url")
+    .arg(url)
+    .arg("--filename")
+    .arg(path)
+    .status()
+    .ok()
+    .filter(|s| s.success())
 }
 
 /// Downloads a file from `url` with curl and stores it at `path`.
 fn download_with_curl<P: AsRef<std::ffi::OsStr>>(
   url: &str,
   path: P,
-) -> io::Result<std::process::ExitStatus> {
+) -> Option<std::process::ExitStatus> {
+  let curl_path = which("curl").ok()?;
   println!("Downloading with curl...");
-
-  // Using `which` here also allows us to use `curl.exe` instead of the
-  // PowerShell alias `Invoke-WebRequest` on Windows.
-  which("curl")
-    .map_err(|e| io::Error::new(io::ErrorKind::NotFound, e))
-    .and_then(|curl_path| {
-      Command::new(curl_path)
-        .arg("-L")
-        .arg("-f")
-        .arg("-s")
-        .arg("-o")
-        .arg(path)
-        .arg(url)
-        .status()
-    })
+  Command::new(curl_path)
+    .arg("-L")
+    .arg("-f")
+    .arg("-s")
+    .arg("-o")
+    .arg(path)
+    .arg(url)
+    .status()
+    .ok()
 }
 
 fn download_static_lib_binaries() {

--- a/build.rs
+++ b/build.rs
@@ -559,25 +559,21 @@ fn build_v8(is_asan: bool) {
     // NDK 23 and above removes libgcc entirely.
     // https://github.com/rust-lang/rust/pull/85806
     if !Path::new("./third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang++").exists() {
-        assert!(Command::new("curl")
-        .arg("-L")
-        .arg("-o").arg("./third_party/android-ndk-r26c-linux.zip")
-        .arg("https://dl.google.com/android/repository/android-ndk-r26c-linux.zip")
-        .status()
-        .unwrap()
-        .success());
+        let zip_path = "./third_party/android-ndk-r26c-linux.zip";
+        let download_result = download_with_curl("https://dl.google.com/android/repository/android-ndk-r26c-linux.zip", zip_path);
+        assert!(download_result.unwrap().success());
 
         assert!(Command::new("unzip")
         .arg("-d").arg("./third_party/")
         .arg("-o")
         .arg("-q")
-        .arg("./third_party/android-ndk-r26c-linux.zip")
+        .arg(zip_path)
         .status()
         .unwrap()
         .success());
 
         fs::rename("./third_party/android-ndk-r26c", "./third_party/android_ndk").unwrap();
-        fs::remove_file("./third_party/android-ndk-r26c-linux.zip").unwrap();
+        fs::remove_file(zip_path).unwrap();
       }
     static CHROMIUM_URI: &str = "https://chromium.googlesource.com";
     maybe_clone_repo(

--- a/build.rs
+++ b/build.rs
@@ -917,14 +917,21 @@ fn download_with_curl<P: AsRef<std::ffi::OsStr>>(
   path: P,
 ) -> io::Result<std::process::ExitStatus> {
   println!("Downloading with curl...");
-  Command::new("curl")
-    .arg("-L")
-    .arg("-f")
-    .arg("-s")
-    .arg("-o")
-    .arg(path)
-    .arg(url)
-    .status()
+
+  // Using `which` here also allows us to use `curl.exe` instead of the
+  // PowerShell alias `Invoke-WebRequest` on Windows.
+  which("curl")
+    .map_err(|e| io::Error::new(io::ErrorKind::NotFound, e))
+    .and_then(|curl_path| {
+      Command::new(curl_path)
+        .arg("-L")
+        .arg("-f")
+        .arg("-s")
+        .arg("-o")
+        .arg(path)
+        .arg(url)
+        .status()
+    })
 }
 
 fn download_static_lib_binaries() {

--- a/build.rs
+++ b/build.rs
@@ -1312,7 +1312,8 @@ fn gn() -> String {
 
 /// Get the system's python binary in the following order
 /// 1. The `PYTHON` environment variable
-/// 2. Look for `python` or `python3` in `PATH`
+/// 2. Look for `python3` in `PATH`
+/// 3. Look for `python` in `PATH`
 ///
 /// Returns `Err` if no Python binary could be found or the
 /// given path does not point to an executable.
@@ -1326,7 +1327,7 @@ fn python() -> io::Result<PathBuf> {
     });
   }
 
-  which("python").or_else(|_| which("python3")).map_err(|_| {
+  which("python3").or_else(|_| which("python")).map_err(|_| {
     io::Error::new(
       io::ErrorKind::NotFound,
       "Python executable not found in PATH!",

--- a/build.rs
+++ b/build.rs
@@ -1154,7 +1154,7 @@ fn clang_download() -> PathBuf {
   #[cfg(target_os = "windows")]
   if env::var_os("LIBCLANG_PATH").is_none() {
     assert!(
-      Command::new(python())
+      Command::new(python_or_die())
         .arg("./tools/clang/scripts/update.py")
         .arg("--output-dir")
         .arg(&clang_base_path)

--- a/build.rs
+++ b/build.rs
@@ -839,63 +839,14 @@ fn download_file(url: &str, filename: &Path) {
   }
 
   // Try downloading with deno first, then python, then curl.
+  // Python is a V8 build dependency, so this saves us from adding a Rust HTTP client dependency.
+  // Python is only a required dependency for `V8_FROM_SOURCE` builds.
+  // If python is not available, try falling back to curl.
   println!("Downloading {url}");
-  let status = which("deno").ok().and_then(|deno| {
-    println!("Trying with Deno...");
-    Command::new(deno)
-      .arg("eval")
-      .arg(
-        "const [url, path] = Deno.args; \
-         const resp = await fetch(url); \
-         if (!resp.ok) Deno.exit(1); \
-         const file = await Deno.open(path, { write: true, create: true }); \
-         await resp.body.pipeTo(file.writable);",
-      )
-      // Note: `deno eval` runs with all permissions implicitly granted and does
-      // not accept `--allow-*` flags, so passing them here makes `deno eval`
-      // error out ("unexpected argument '--allow-net'") and the download
-      // silently falls back to Python/curl.
-      .arg("--")
-      .arg(url)
-      .arg(&tmpfile)
-      .status()
-      .ok()
-      .filter(|s| s.success())
-  });
-
-  // Try downloading with python. Python is a V8 build dependency,
-  // so this saves us from adding a Rust HTTP client dependency.
-  let status = match status {
-    Some(status) => status,
-    _ => {
-      println!("Trying with Python...");
-      let python_status = Command::new(python())
-        .arg("./tools/download_file.py")
-        .arg("--url")
-        .arg(url)
-        .arg("--filename")
-        .arg(&tmpfile)
-        .status();
-
-      // Python is only a required dependency for `V8_FROM_SOURCE` builds.
-      // If python is not available, try falling back to curl.
-      match python_status {
-        Ok(status) if status.success() => status,
-        _ => {
-          println!("Python downloader failed, trying with curl.");
-          Command::new("curl")
-            .arg("-L")
-            .arg("-f")
-            .arg("-s")
-            .arg("-o")
-            .arg(&tmpfile)
-            .arg(url)
-            .status()
-            .unwrap()
-        }
-      }
-    }
-  };
+  let status = download_with_deno(url, &tmpfile)
+    .or_else(|_| download_with_python(url, &tmpfile))
+    .or_else(|_| download_with_curl(url, &tmpfile))
+    .expect("Neither deno, python nor curl were available to download the V8 prebuilt archive.");
 
   // Assert DL was successful
   if !status.success() {
@@ -916,6 +867,68 @@ fn download_file(url: &str, filename: &Path) {
   assert!(filename.exists());
   assert!(static_checksum_path(filename).exists());
   assert!(!tmpfile.exists());
+}
+
+/// Downloads a file from `url` with Deno and stores it at `path`.
+fn download_with_deno<P: AsRef<std::ffi::OsStr>>(
+  url: &str,
+  path: P,
+) -> io::Result<std::process::ExitStatus> {
+  which("deno")
+    .map_err(|e| io::Error::new(io::ErrorKind::NotFound, e))
+    .and_then(|deno| {
+      println!("Downloading with Deno...");
+      Command::new(deno)
+        .arg("eval")
+        .arg(
+          "const [url, path] = Deno.args; \
+         const resp = await fetch(url); \
+         if (!resp.ok) Deno.exit(1); \
+         const file = await Deno.open(path, { write: true, create: true }); \
+         await resp.body.pipeTo(file.writable);",
+        )
+        // Note: `deno eval` runs with all permissions implicitly granted and does
+        // not accept `--allow-*` flags, so passing them here makes `deno eval`
+        // error out ("unexpected argument '--allow-net'") and the download
+        // silently falls back to Python/curl.
+        .arg("--")
+        .arg(url)
+        .arg(path)
+        .status()
+    })
+}
+
+/// Downloads a file from `url` with Python and stores it at `path`.
+fn download_with_python<P: AsRef<std::ffi::OsStr>>(
+  url: &str,
+  path: P,
+) -> io::Result<std::process::ExitStatus> {
+  python().and_then(|python_path| {
+    println!("Downloading with Python...");
+    Command::new(python_path)
+      .arg("./tools/download_file.py")
+      .arg("--url")
+      .arg(url)
+      .arg("--filename")
+      .arg(path)
+      .status()
+  })
+}
+
+/// Downloads a file from `url` with curl and stores it at `path`.
+fn download_with_curl<P: AsRef<std::ffi::OsStr>>(
+  url: &str,
+  path: P,
+) -> io::Result<std::process::ExitStatus> {
+  println!("Downloading with curl...");
+  Command::new("curl")
+    .arg("-L")
+    .arg("-f")
+    .arg("-s")
+    .arg("-o")
+    .arg(path)
+    .arg(url)
+    .status()
 }
 
 fn download_static_lib_binaries() {

--- a/build.rs
+++ b/build.rs
@@ -180,12 +180,14 @@ fn build_binding() {
     );
   }
 
-  let output = Command::new(python().unwrap())
-    .arg("./tools/get_bindgen_args.py")
-    .arg("--gn-out")
-    .arg(build_dir().join("gn_out"))
-    .output()
-    .unwrap();
+  let output = Command::new(
+    python().expect("Python must be available to build rusty_v8!"),
+  )
+  .arg("./tools/get_bindgen_args.py")
+  .arg("--gn-out")
+  .arg(build_dir().join("gn_out"))
+  .output()
+  .unwrap();
   let args = String::from_utf8(output.stdout).unwrap();
   let args = args.split('\0').collect::<Vec<_>>();
 
@@ -632,7 +634,9 @@ fn print_gn_args(gn_out_dir: &Path) {
     Command::new(gn())
       .arg(format!(
         "--script-executable={}",
-        python().unwrap().display()
+        python()
+          .expect("Python must be available to build rusty_v8!")
+          .display()
       ))
       .arg("args")
       .arg(gn_out_dir)
@@ -662,12 +666,14 @@ fn maybe_install_sysroot(arch: &str) {
   let sysroot_path = format!("build/linux/debian_sid_{arch}-sysroot");
   if !PathBuf::from(sysroot_path).is_dir() {
     assert!(
-      Command::new(python().unwrap())
-        .arg("./build/linux/sysroot_scripts/install-sysroot.py")
-        .arg(format!("--arch={arch}"))
-        .status()
-        .unwrap()
-        .success()
+      Command::new(
+        python().expect("Python must be available to build rusty_v8!")
+      )
+      .arg("./build/linux/sysroot_scripts/install-sysroot.py")
+      .arg(format!("--arch={arch}"))
+      .status()
+      .unwrap()
+      .success()
     );
   }
 }
@@ -684,13 +690,15 @@ fn download_ninja_gn_binaries() {
 
   if !gn.exists() || !ninja.exists() {
     assert!(
-      Command::new(python().unwrap())
-        .arg("./tools/ninja_gn_binaries.py")
-        .arg("--dir")
-        .arg(&target_dir)
-        .status()
-        .unwrap()
-        .success()
+      Command::new(
+        python().expect("Python must be available to build rusty_v8!")
+      )
+      .arg("./tools/ninja_gn_binaries.py")
+      .arg("--dir")
+      .arg(&target_dir)
+      .status()
+      .unwrap()
+      .success()
     );
   }
   assert!(gn.exists());
@@ -707,11 +715,13 @@ fn download_ninja_gn_binaries() {
 
 fn download_rust_toolchain() {
   assert!(
-    Command::new(python().unwrap())
-      .arg("./tools/rust_toolchain.py")
-      .status()
-      .unwrap()
-      .success()
+    Command::new(
+      python().expect("Python must be available to build rusty_v8!")
+    )
+    .arg("./tools/rust_toolchain.py")
+    .status()
+    .unwrap()
+    .success()
   );
 }
 
@@ -1147,13 +1157,15 @@ fn clang_download() -> PathBuf {
   let clang_base_path = build_dir().join("clang");
   println!("clang_base_path (downloaded) {}", clang_base_path.display());
   assert!(
-    Command::new(python().unwrap())
-      .arg("./tools/clang/scripts/update.py")
-      .arg("--output-dir")
-      .arg(&clang_base_path)
-      .status()
-      .unwrap()
-      .success()
+    Command::new(
+      python().expect("Python must be available to build rusty_v8!")
+    )
+    .arg("./tools/clang/scripts/update.py")
+    .arg("--output-dir")
+    .arg(&clang_base_path)
+    .status()
+    .unwrap()
+    .success()
   );
 
   // Chromium ships libclang separately from the compiler on Windows. Use the
@@ -1365,7 +1377,9 @@ fn run_gn_gen(gn_args: &[String]) -> PathBuf {
       .arg(format!("--root={}", dirs.root.display()))
       .arg(format!(
         "--script-executable={}",
-        python().unwrap().display()
+        python()
+          .expect("Python must be available to build rusty_v8!")
+          .display()
       ))
       .arg("gen")
       .arg(&gn_out_dir)

--- a/build.rs
+++ b/build.rs
@@ -180,7 +180,7 @@ fn build_binding() {
     );
   }
 
-  let output = Command::new(python())
+  let output = Command::new(python().unwrap())
     .arg("./tools/get_bindgen_args.py")
     .arg("--gn-out")
     .arg(build_dir().join("gn_out"))
@@ -634,7 +634,10 @@ fn build_v8(is_asan: bool) {
 fn print_gn_args(gn_out_dir: &Path) {
   assert!(
     Command::new(gn())
-      .arg(format!("--script-executable={}", python()))
+      .arg(format!(
+        "--script-executable={}",
+        python().unwrap().display()
+      ))
       .arg("args")
       .arg(gn_out_dir)
       .arg("--list")
@@ -663,7 +666,7 @@ fn maybe_install_sysroot(arch: &str) {
   let sysroot_path = format!("build/linux/debian_sid_{arch}-sysroot");
   if !PathBuf::from(sysroot_path).is_dir() {
     assert!(
-      Command::new(python())
+      Command::new(python().unwrap())
         .arg("./build/linux/sysroot_scripts/install-sysroot.py")
         .arg(format!("--arch={arch}"))
         .status()
@@ -685,7 +688,7 @@ fn download_ninja_gn_binaries() {
 
   if !gn.exists() || !ninja.exists() {
     assert!(
-      Command::new(python())
+      Command::new(python().unwrap())
         .arg("./tools/ninja_gn_binaries.py")
         .arg("--dir")
         .arg(&target_dir)
@@ -708,7 +711,7 @@ fn download_ninja_gn_binaries() {
 
 fn download_rust_toolchain() {
   assert!(
-    Command::new(python())
+    Command::new(python().unwrap())
       .arg("./tools/rust_toolchain.py")
       .status()
       .unwrap()
@@ -1128,7 +1131,7 @@ fn clang_download() -> PathBuf {
   let clang_base_path = build_dir().join("clang");
   println!("clang_base_path (downloaded) {}", clang_base_path.display());
   assert!(
-    Command::new(python())
+    Command::new(python().unwrap())
       .arg("./tools/clang/scripts/update.py")
       .arg("--output-dir")
       .arg(&clang_base_path)
@@ -1279,12 +1282,28 @@ fn gn() -> String {
   env::var("GN").unwrap_or_else(|_| "gn".to_owned())
 }
 
-/*
- * Get the system's python binary - specified via the PYTHON environment
- * variable or defaulting to `python3`.
- */
-fn python() -> String {
-  env::var("PYTHON").unwrap_or_else(|_| "python3".to_owned())
+/// Get the system's python binary in the following order
+/// 1. The `PYTHON` environment variable
+/// 2. Look for `python` or `python3` in `PATH`
+///
+/// Returns `Err` if no Python binary could be found or the
+/// given path does not point to an executable.
+fn python() -> io::Result<PathBuf> {
+  if let Ok(python_path) = env::var("PYTHON") {
+    return which(python_path).map_err(|_| {
+      io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "Path in PYTHON environment variable does not point to an executable!",
+      )
+    });
+  }
+
+  which("python").or_else(|_| which("python3")).map_err(|_| {
+    io::Error::new(
+      io::ErrorKind::NotFound,
+      "Python executable not found in PATH!",
+    )
+  })
 }
 
 type NinjaEnv = Vec<(String, String)>;
@@ -1328,7 +1347,10 @@ fn run_gn_gen(gn_args: &[String]) -> PathBuf {
   assert!(
     Command::new(gn())
       .arg(format!("--root={}", dirs.root.display()))
-      .arg(format!("--script-executable={}", python()))
+      .arg(format!(
+        "--script-executable={}",
+        python().unwrap().display()
+      ))
       .arg("gen")
       .arg(&gn_out_dir)
       .arg("--ide=json")


### PR DESCRIPTION
This PR cleans up the pre-built archive download functionality in `build.rs`. I originally worked on this because on a fresh install of Windows, none of the downloaders are available and the build fails.

I implemented the following changes:
- `python()` now checks `PATH` for `python` and `python3` if the `PYTHON` env var doesn't exist or is empty. Additionally, it checks whether the recieved path from those methods is a valid executable. For most calls, I used `expect()`, as the build from source requires Python to be present. However, just downloading the prebuilt archive does not.
- Refactored `download_file()` to more cleanly show in what order the downloaders are executed. The execution of the downloaders has been moved to seperate functions
- Downloads with curl now check if `curl` is present. ~This also uses `curl.exe` instead of the [alias for `Invoke-WebRequest`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-5.1#notes) on the preinstalled PowerShell 5.1 on Windows.~