### PR TITLE
feat: aarch64-unknown-linux-musl builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,21 @@ jobs:
             simdutf: true
             cargo: cargo
 
+          # aarch64 musl: cross-compiled on the x64 glibc runner (host + snapshot
+          # toolchains stay glibc; only the arm64 target objects are musl).
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
+            target: aarch64-unknown-linux-musl
+            variant: release
+            v8_enable_pointer_compression: false
+            cargo: cargo
+
+          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
+            target: aarch64-unknown-linux-musl
+            variant: release
+            v8_enable_pointer_compression: false
+            simdutf: true
+            cargo: cargo
+
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'windows-2022-xxl' || 'windows-2022' }}
             target: x86_64-pc-windows-msvc
             variant: release # Note: we do not support windows debug builds.
@@ -319,26 +334,43 @@ jobs:
         run: rustup target add ${{ matrix.config.target }}
 
       - name: Install musl cross compilation toolchain
-        if: matrix.config.target == 'x86_64-unknown-linux-musl'
+        if: contains(matrix.config.target, '-linux-musl')
         run: |
-          rustup target add x86_64-unknown-linux-musl
-
-          sudo apt update
-          sudo apt install -yq --no-install-suggests --no-install-recommends \
-            musl-tools musl-dev
+          rustup target add ${{ matrix.config.target }}
 
           # Assemble a musl sysroot (musl headers/libs + kernel headers) for
           # V8's target clang. The musl target is compile-only (objects are
           # archived into librusty_v8.a, never linked), so no gcc runtime is
-          # needed here; the executable build tools are built with the glibc
+          # needed here; the executable build tools are built with a glibc
           # host toolchain.
           SYSROOT="${HOME}/musl-sysroot"
-          mkdir -p "${SYSROOT}/usr/include" "${SYSROOT}/usr/lib"
-          cp -a /usr/include/x86_64-linux-musl/. "${SYSROOT}/usr/include/"
-          cp -a /usr/lib/x86_64-linux-musl/.     "${SYSROOT}/usr/lib/"
-          cp -a /usr/include/linux                "${SYSROOT}/usr/include/"
-          cp -a /usr/include/asm-generic          "${SYSROOT}/usr/include/"
-          cp -a /usr/include/x86_64-linux-gnu/asm "${SYSROOT}/usr/include/"
+          case "${{ matrix.config.target }}" in
+            x86_64-*)
+              sudo apt update
+              sudo apt install -yq --no-install-suggests --no-install-recommends \
+                musl-tools musl-dev
+              mkdir -p "${SYSROOT}/usr/include" "${SYSROOT}/usr/lib"
+              cp -a /usr/include/x86_64-linux-musl/. "${SYSROOT}/usr/include/"
+              cp -a /usr/lib/x86_64-linux-musl/.     "${SYSROOT}/usr/lib/"
+              cp -a /usr/include/linux                "${SYSROOT}/usr/include/"
+              cp -a /usr/include/asm-generic          "${SYSROOT}/usr/include/"
+              cp -a /usr/include/x86_64-linux-gnu/asm "${SYSROOT}/usr/include/"
+              ;;
+            aarch64-*)
+              # apt has no aarch64 musl, so use Alpine's static apk to install
+              # the aarch64 musl headers/libs + kernel headers into the sysroot.
+              # These foreign-arch packages are only extracted, never executed.
+              ALPINE=v3.21; APK_VER=2.14.6-r3
+              curl -sSLo /tmp/apk.apk \
+                "https://dl-cdn.alpinelinux.org/alpine/${ALPINE}/main/x86_64/apk-tools-static-${APK_VER}.apk"
+              tar -xzf /tmp/apk.apk -C /tmp sbin/apk.static
+              mkdir -p "${SYSROOT}/etc/apk"
+              /tmp/sbin/apk.static --arch aarch64 \
+                -X "https://dl-cdn.alpinelinux.org/alpine/${ALPINE}/main" \
+                --root "${SYSROOT}" --initdb --allow-untrusted \
+                add musl-dev linux-headers
+              ;;
+          esac
 
           echo "RUSTY_V8_MUSL_SYSROOT=${SYSROOT}" >> ${GITHUB_ENV}
 
@@ -375,6 +407,8 @@ jobs:
                "aarch64-apple-darwin"      = "aarch64-apple-darwin"
                "x86_64-unknown-linux-gnu"  = "x86_64-unknown-linux-musl"
                "x86_64-unknown-linux-musl" = "x86_64-unknown-linux-musl"
+               # aarch64 musl cross-compiles on the x64 host, so use the host sccache.
+               "aarch64-unknown-linux-musl" = "x86_64-unknown-linux-musl"
                "aarch64-unknown-linux-gnu" = "aarch64-unknown-linux-musl"
                # Unlike aarch64, the riscv64 sccache binary is not static, so use the host architecture one.
                "riscv64gc-unknown-linux-gnu" = "x86_64-unknown-linux-musl"
@@ -429,7 +463,7 @@ jobs:
       # on the runner (build-only, like the iOS targets). This still produces
       # gn_out/obj/librusty_v8.a for the publish step below.
       - name: Build (musl)
-        if: matrix.config.target == 'x86_64-unknown-linux-musl'
+        if: contains(matrix.config.target, '-linux-musl')
         env:
           SCCACHE_IDLE_TIMEOUT: 0
         run: ${{ matrix.config.cargo }} build -v --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
@@ -437,11 +471,11 @@ jobs:
       - name: Test
         env:
           SCCACHE_IDLE_TIMEOUT: 0
-        if: (matrix.config.variant == 'debug' || matrix.config.variant == 'release') && !contains(matrix.config.target, 'ios') && matrix.config.target != 'x86_64-unknown-linux-musl'
+        if: (matrix.config.variant == 'debug' || matrix.config.variant == 'release') && !contains(matrix.config.target, 'ios') && !contains(matrix.config.target, '-linux-musl')
         run: ${{ matrix.config.cargo }} nextest run -v --cargo-verbose --cargo-verbose --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }}
 
       - name: Clippy
-        if: ${{ !contains(matrix.config.target, 'ios') && matrix.config.target != 'x86_64-unknown-linux-musl' }}
+        if: ${{ !contains(matrix.config.target, 'ios') && !contains(matrix.config.target, '-linux-musl') }}
         run: ${{ matrix.config.cargo }} clippy --all-targets --locked --target ${{ matrix.config.target }} ${{ env.CARGO_VARIANT_FLAG }} ${{ env.CARGO_FEATURE_FLAGS }} -- -D clippy::all
 
       - name: Prepare binary publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,13 +360,19 @@ jobs:
               # apt has no aarch64 musl, so use Alpine's static apk to install
               # the aarch64 musl headers/libs + kernel headers into the sysroot.
               # These foreign-arch packages are only extracted, never executed.
-              ALPINE=v3.21; APK_VER=2.14.6-r3
-              curl -sSLo /tmp/apk.apk \
-                "https://dl-cdn.alpinelinux.org/alpine/${ALPINE}/main/x86_64/apk-tools-static-${APK_VER}.apk"
+              ALPINE=v3.21
+              MIRROR="https://dl-cdn.alpinelinux.org/alpine/${ALPINE}/main"
+              # Alpine's main repo only keeps the latest revision of each
+              # package, so resolve apk-tools-static's current version from the
+              # index rather than pinning a filename that would later 404.
+              APK_VER=$(curl -fsSL "${MIRROR}/x86_64/APKINDEX.tar.gz" \
+                | tar -xzO APKINDEX \
+                | awk -v RS='' -v FS='\n' '{p="";v="";for(i=1;i<=NF;i++){if($i~/^P:/)p=substr($i,3);if($i~/^V:/)v=substr($i,3)}if(p=="apk-tools-static")print v}')
+              curl -fsSLo /tmp/apk.apk \
+                "${MIRROR}/x86_64/apk-tools-static-${APK_VER}.apk"
               tar -xzf /tmp/apk.apk -C /tmp sbin/apk.static
               mkdir -p "${SYSROOT}/etc/apk"
-              /tmp/sbin/apk.static --arch aarch64 \
-                -X "https://dl-cdn.alpinelinux.org/alpine/${ALPINE}/main" \
+              /tmp/sbin/apk.static --arch aarch64 -X "${MIRROR}" \
                 --root "${SYSROOT}" --initdb --allow-untrusted \
                 add musl-dev linux-headers
               ;;

--- a/build.rs
+++ b/build.rs
@@ -446,17 +446,29 @@ fn build_v8(is_asan: bool) {
     // builds, don't treat warnings as errors here.
     gn_args.push("treat_warnings_as_errors=false".to_string());
 
-    let glibc_toolchain = match target_arch.as_str() {
-      "x86_64" => "//build/toolchain/linux:clang_x64_glibc",
+    match target_arch.as_str() {
+      "x86_64" => {
+        // Host cpu == target cpu, so V8 would build the executable build tools
+        // with the (musl) default toolchain. Force the host and snapshot
+        // toolchains to a dedicated glibc toolchain so those tools stay glibc.
+        let glibc = "//build/toolchain/linux:clang_x64_glibc";
+        gn_args.push(format!("host_toolchain=\"{glibc}\""));
+        gn_args.push(format!("v8_snapshot_toolchain=\"{glibc}\""));
+        // That glibc toolchain builds against the amd64 sysroot, same as the
+        // host side of the aarch64/riscv64 cross builds.
+        maybe_install_sysroot("amd64");
+      }
+      "aarch64" => {
+        // Cross build (x64 host -> arm64 target). The host (clang_x64) and
+        // snapshot (clang_x64_v8_arm64) toolchains are already non-default, so
+        // the target-scoped `use_musl` guard keeps them glibc automatically --
+        // no toolchain overrides needed. target_cpu and the amd64/arm64
+        // sysroots are set by the aarch64 cross-compilation block above.
+      }
       other => panic!(
-        "musl builds are currently only supported for x86_64 (got {other})"
+        "musl builds are only supported for x86_64 and aarch64 (got {other})"
       ),
-    };
-    gn_args.push(format!("host_toolchain=\"{glibc_toolchain}\""));
-    gn_args.push(format!("v8_snapshot_toolchain=\"{glibc_toolchain}\""));
-    // The glibc host toolchain builds against the amd64 sysroot, same as the
-    // host side of the aarch64/riscv64 cross builds.
-    maybe_install_sysroot("amd64");
+    }
 
     // Cross-compiling on a glibc host needs a musl sysroot for the target's
     // headers/libs. Native musl builds (e.g. on Alpine) can leave this unset.

--- a/build.rs
+++ b/build.rs
@@ -216,13 +216,11 @@ fn build_binding() {
     // the musl triple (from $TARGET), so without this it looks for the target
     // arch's glibc multiarch headers, which aren't installed when cross-
     // compiling (e.g. aarch64 glibc headers on an x86_64 runner).
-    let is_musl = env::var("CARGO_CFG_TARGET_ENV")
-      .map(|e| e == "musl")
-      .unwrap_or(false);
-    if is_musl {
-      if let Ok(sysroot) = env::var("RUSTY_V8_MUSL_SYSROOT") {
-        clang_args.push(format!("--sysroot={sysroot}"));
-      }
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_env == "musl"
+      && let Ok(sysroot) = env::var("RUSTY_V8_MUSL_SYSROOT")
+    {
+      clang_args.push(format!("--sysroot={sysroot}"));
     }
   } else if target_os == "ios" {
     // iOS: point bindgen at the iOS (device) or iOS-simulator SDK and set the

--- a/build.rs
+++ b/build.rs
@@ -212,6 +212,17 @@ fn build_binding() {
         clang_args.push(format!("-isystem{}/include", resource_dir.trim()));
       }
     }
+    // Parse the V8 headers against the musl sysroot. bindgen already targets
+    // the musl triple (from $TARGET), so without this it looks for the target
+    // arch's glibc multiarch headers, which aren't installed when cross-
+    // compiling (e.g. aarch64 glibc headers on an x86_64 runner).
+    let is_musl =
+      env::var("CARGO_CFG_TARGET_ENV").map(|e| e == "musl").unwrap_or(false);
+    if is_musl {
+      if let Ok(sysroot) = env::var("RUSTY_V8_MUSL_SYSROOT") {
+        clang_args.push(format!("--sysroot={sysroot}"));
+      }
+    }
   } else if target_os == "ios" {
     // iOS: point bindgen at the iOS (device) or iOS-simulator SDK and set the
     // matching clang target triple so the V8 headers parse correctly.

--- a/build.rs
+++ b/build.rs
@@ -216,8 +216,9 @@ fn build_binding() {
     // the musl triple (from $TARGET), so without this it looks for the target
     // arch's glibc multiarch headers, which aren't installed when cross-
     // compiling (e.g. aarch64 glibc headers on an x86_64 runner).
-    let is_musl =
-      env::var("CARGO_CFG_TARGET_ENV").map(|e| e == "musl").unwrap_or(false);
+    let is_musl = env::var("CARGO_CFG_TARGET_ENV")
+      .map(|e| e == "musl")
+      .unwrap_or(false);
     if is_musl {
       if let Ok(sysroot) = env::var("RUSTY_V8_MUSL_SYSROOT") {
         clang_args.push(format!("--sysroot={sysroot}"));


### PR DESCRIPTION
Follow-up to the x86_64 musl builds (#2016), adding aarch64-unknown-linux-musl
so arm64 musl consumers (e.g. opencode's linux-arm64-musl) get a prebuilt too.

Unlike x86_64 musl, arm64 musl is a cross build (x64 host, arm64 target). V8
builds mksnapshot with an x64 host snapshot toolchain (clang_x64_v8_arm64), and
the previous musl guard would have leaked musl onto it. The companion
chromium_build change tightens the guard to the target toolchain only, so for
arm64 the x64 host and snapshot toolchains stay glibc automatically and build.rs
needs no toolchain overrides there -- only x86_64 (host cpu == target cpu) still
forces the glibc host/snapshot toolchains.

CI cross-compiles on the x64 glibc runner (build-only, like the existing musl
and iOS rows). apt has no aarch64 musl, so the sysroot is assembled from Alpine
packages using the static apk (the foreign-arch packages are only extracted,
never executed on the x64 host). Release only, matching the x86_64 musl rows.

Depends on denoland/chromium_build#206; the build submodule here points at that
branch and should be re-pinned to the merged SHA before landing.