### PR TITLE
perf: drop redundant String::Length() FFI call on ValueView conversions

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -964,10 +964,9 @@ impl String {
   /// data. When the `simdutf` feature is enabled, uses SIMD-accelerated
   /// transcoding for Latin-1 and two-byte strings.
   pub fn to_rust_string_lossy(&self, scope: &Isolate) -> std::string::String {
-    if self.length() == 0 {
-      return std::string::String::new();
-    }
-
+    // No preliminary `self.length()` FFI call: the `ValueView` reports the
+    // length, and `data()` yields an empty slice for empty strings, which the
+    // ASCII arm below turns into an empty `String`.
     // SAFETY: `self` is a valid V8 string reachable from a handle scope.
     let view = unsafe { ValueView::new_from_ref(scope, self) };
 
@@ -999,11 +998,8 @@ impl String {
     buf: &mut std::string::String,
   ) {
     buf.clear();
-    let len = self.length();
-    if len == 0 {
-      return;
-    }
-
+    // No preliminary `self.length()` FFI call; an empty string yields an empty
+    // `data()` slice and leaves `buf` cleared.
     // SAFETY: `self` is a valid V8 string reachable from a handle scope.
     // The ValueView is dropped before we return.
     let view = unsafe { ValueView::new_from_ref(scope, self) };
@@ -1052,11 +1048,8 @@ impl String {
     scope: &mut Isolate,
     buffer: &'a mut [MaybeUninit<u8>; N],
   ) -> Cow<'a, str> {
-    let len = self.length();
-    if len == 0 {
-      return "".into();
-    }
-
+    // No preliminary `self.length()` FFI call; an empty string yields an empty
+    // `data()` slice, which the ASCII arm borrows as an empty `&str`.
     // SAFETY: `self` is a valid V8 string reachable from a handle scope.
     // The ValueView is dropped before we return, so the
     // DisallowGarbageCollection scope it holds is properly scoped.
@@ -1184,10 +1177,21 @@ impl<'s> ValueView<'s> {
     const IS_ONE_BYTE_OFFSET: usize = PTR + PTR + std::mem::size_of::<u32>();
     unsafe {
       let base = self.0.as_ptr();
-      let data = base.add(DATA_OFFSET).cast::<*const u8>().read_unaligned();
       let length =
         base.add(LENGTH_OFFSET).cast::<u32>().read_unaligned() as usize;
       let is_one_byte = *base.add(IS_ONE_BYTE_OFFSET) != 0;
+      if length == 0 {
+        // Empty strings may carry a null `data8_`/`data16_` pointer, so return
+        // an empty slice with a valid (dangling) pointer rather than passing a
+        // possibly-null pointer to `from_raw_parts`. Still report the actual
+        // encoding so `data()`'s contract holds for empty two-byte strings.
+        return if is_one_byte {
+          ValueViewData::OneByte(&[])
+        } else {
+          ValueViewData::TwoByte(&[])
+        };
+      }
+      let data = base.add(DATA_OFFSET).cast::<*const u8>().read_unaligned();
       if is_one_byte {
         ValueViewData::OneByte(std::slice::from_raw_parts(data, length))
       } else {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -12786,6 +12786,25 @@ fn string_valueview() {
     let view = v8::ValueView::new(scope, two_byte);
     assert_eq!(view.data(), v8::ValueViewData::TwoByte(&[1, 0x1FF, 3]));
   }
+
+  // Empty strings: `data()` reports the actual `is_one_byte_` encoding for the
+  // zero-length case, not a hardcoded variant. V8 canonicalizes every empty
+  // string (including one built from two-byte data) to the one-byte empty
+  // string, so both report `OneByte`.
+  {
+    let empty_one_byte =
+      v8::String::new_from_one_byte(scope, &[], v8::NewStringType::Normal)
+        .unwrap();
+    let view = v8::ValueView::new(scope, empty_one_byte);
+    assert_eq!(view.data(), v8::ValueViewData::OneByte(&[]));
+  }
+  {
+    let empty_two_byte =
+      v8::String::new_from_two_byte(scope, &[], v8::NewStringType::Normal)
+        .unwrap();
+    let view = v8::ValueView::new(scope, empty_two_byte);
+    assert_eq!(view.data(), v8::ValueViewData::OneByte(&[]));
+  }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`to_rust_string_lossy`, `write_utf8_into`, and `to_rust_cow_lossy` each called
`self.length()` — an out-of-line `v8::String::Length()` FFI call — purely to
early-return on empty strings, even though the `ValueView` they build a line
later already reports the length. This removes those redundant calls and lets
the empty case fall out of the `ValueView` path:

- `data()` now returns an empty slice for a zero-length string. Empty strings
  may carry a null `data8_`/`data16_` pointer, so this also avoids passing null
  to `from_raw_parts`.
- The ASCII arm then turns the empty slice into an empty `String` / borrowed
  empty `&str`.

## Impact

Incremental over #2022 (interleaved, median of 6), `to_rust_string_lossy`:

| kind | n=4 | n=16 | n=64 | n=256 | n=4096 |
| --- | --- | --- | --- | --- | --- |
| ascii | −2.6% | −6.5% | −4.5% | −5.2% | +0.6% |
| latin1 | −5.6% | −4.4% | −6.1% | −2.6% | −0.4% |
| twobyte | −7.3% | −2.5% | +0.2% | −0.7% | +0.5% |

A steady ~3–6% across short-to-medium strings — a redundant length lookup on
every conversion, gone. Fades to noise once copy/transcode cost dominates.