### PR TITLE
perf: single-pass UTF-16 to UTF-8 conversion via simdutf

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -1337,10 +1337,11 @@ impl<'s> ValueView<'s> {
 // ---------------------------------------------------------------------------
 
 /// The minimum number of UTF-16 code units before we try the SIMD path.
-/// Below this threshold the overhead of validation + length pre-scan is
-/// not worth it, so we fall back to the scalar loop.
+/// With the single-pass `convert_utf16le_to_utf8_with_errors` conversion the
+/// crossover against the scalar `decode_utf16` loop is low; measured wins start
+/// around 16 units.
 #[cfg(feature = "simdutf")]
-const WTF16_SIMD_THRESHOLD: usize = 96;
+const WTF16_SIMD_THRESHOLD: usize = 16;
 
 /// Minimum one-byte string length before the simdutf `utf8_length_from_latin1`
 /// path beats std's inline `is_ascii` SWAR scan (the simdutf FFI call has fixed
@@ -1437,18 +1438,24 @@ fn latin1_to_string(bytes: &[u8]) -> std::string::String {
 fn wtf16_to_string(units: &[u16]) -> std::string::String {
   #[cfg(feature = "simdutf")]
   {
-    // For longer, valid UTF-16 strings, use simdutf's SIMD-accelerated path.
-    if units.len() >= WTF16_SIMD_THRESHOLD
-      && crate::simdutf::validate_utf16le(units)
-    {
-      let utf8_len = crate::simdutf::utf8_length_from_utf16le(units);
-      let mut buf: Vec<u8> = Vec::with_capacity(utf8_len);
-      unsafe {
-        let out = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), utf8_len);
-        let written = crate::simdutf::convert_utf16le_to_utf8(units, out);
-        debug_assert_eq!(written, utf8_len);
-        buf.set_len(written);
-        return std::string::String::from_utf8_unchecked(buf);
+    // Single simdutf pass that validates *and* converts. Each UTF-16 code unit
+    // yields at most 3 UTF-8 bytes (surrogate pairs are 2 units -> 4 bytes), so
+    // `len * 3` is a safe upper bound. On a lone-surrogate error we fall
+    // through to the scalar WTF-16 loop below.
+    if units.len() >= WTF16_SIMD_THRESHOLD {
+      let cap = units.len() * 3;
+      let mut buf: Vec<u8> = Vec::with_capacity(cap);
+      // SAFETY: `buf` has `cap` bytes of spare capacity.
+      let result = unsafe {
+        let out = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), cap);
+        crate::simdutf::convert_utf16le_to_utf8_with_errors(units, out)
+      };
+      if result.is_ok() {
+        // SAFETY: simdutf wrote `result.count` valid UTF-8 bytes.
+        unsafe {
+          buf.set_len(result.count);
+          return std::string::String::from_utf8_unchecked(buf);
+        }
       }
     }
   }
@@ -1466,19 +1473,24 @@ fn wtf16_to_string(units: &[u16]) -> std::string::String {
 fn wtf16_into_string(units: &[u16], buf: &mut std::string::String) {
   #[cfg(feature = "simdutf")]
   {
-    if units.len() >= WTF16_SIMD_THRESHOLD
-      && crate::simdutf::validate_utf16le(units)
-    {
-      let utf8_len = crate::simdutf::utf8_length_from_utf16le(units);
-      buf.reserve(utf8_len);
-      unsafe {
-        let vec = buf.as_mut_vec();
-        let out = std::slice::from_raw_parts_mut(vec.as_mut_ptr(), utf8_len);
-        let written = crate::simdutf::convert_utf16le_to_utf8(units, out);
-        debug_assert_eq!(written, utf8_len);
-        vec.set_len(written);
+    if units.len() >= WTF16_SIMD_THRESHOLD {
+      let cap = units.len() * 3;
+      buf.reserve(cap);
+      // SAFETY: appended bytes are valid UTF-8 (or we roll back on error).
+      let vec = unsafe { buf.as_mut_vec() };
+      let start = vec.len();
+      let result = unsafe {
+        let out =
+          std::slice::from_raw_parts_mut(vec.as_mut_ptr().add(start), cap);
+        crate::simdutf::convert_utf16le_to_utf8_with_errors(units, out)
+      };
+      if result.is_ok() {
+        // SAFETY: simdutf wrote `result.count` valid UTF-8 bytes at `start`.
+        unsafe { vec.set_len(start + result.count) };
+        return;
       }
-      return;
+      // Lone surrogate: `vec` len is unchanged (`start`); fall through to
+      // the scalar loop, which appends over the untouched spare capacity.
     }
   }
   // Scalar fallback.
@@ -1537,28 +1549,27 @@ fn wtf16_to_cow_str<'a, const N: usize>(
 ) -> Cow<'a, str> {
   #[cfg(feature = "simdutf")]
   {
-    if units.len() >= WTF16_SIMD_THRESHOLD
-      && crate::simdutf::validate_utf16le(units)
-    {
-      let utf8_len = crate::simdutf::utf8_length_from_utf16le(units);
-
-      if utf8_len <= N {
-        let written = unsafe {
-          let out = std::slice::from_raw_parts_mut(
-            buffer.as_mut_ptr() as *mut u8,
-            utf8_len,
-          );
-          crate::simdutf::convert_utf16le_to_utf8(units, out)
+    if units.len() >= WTF16_SIMD_THRESHOLD {
+      // Each unit is at most 3 UTF-8 bytes, so if `len * 3` fits the stack
+      // buffer the single-pass conversion is guaranteed to fit; borrow it.
+      if units.len() * 3 <= N {
+        let result = unsafe {
+          let out =
+            std::slice::from_raw_parts_mut(buffer.as_mut_ptr() as *mut u8, N);
+          crate::simdutf::convert_utf16le_to_utf8_with_errors(units, out)
         };
-        return unsafe {
-          let buf = &mut buffer[..written];
-          let buf = &mut *(buf as *mut [_] as *mut [u8]);
-          Cow::Borrowed(std::str::from_utf8_unchecked(buf))
-        };
+        if result.is_ok() {
+          return unsafe {
+            let buf = &mut buffer[..result.count];
+            let buf = &mut *(buf as *mut [_] as *mut [u8]);
+            Cow::Borrowed(std::str::from_utf8_unchecked(buf))
+          };
+        }
+        // Lone surrogate: fall through to the scalar path below.
+      } else {
+        // The worst case may not fit the stack buffer — allocate.
+        return Cow::Owned(wtf16_to_string(units));
       }
-
-      // Doesn't fit in the stack buffer — allocate.
-      return Cow::Owned(wtf16_to_string(units));
     }
   }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -12966,6 +12966,37 @@ fn string_valueview_to_cow_lossy() {
 }
 
 #[test]
+fn to_rust_string_lossy_wtf16_simd_path() {
+  // Exercises the >= WTF16_SIMD_THRESHOLD single-pass conversion path (the
+  // existing two-byte tests use short strings that take the scalar fallback).
+  let _setup_guard = setup::parallel_test();
+  let mut isolate = v8::Isolate::new(Default::default());
+  let scope = pin!(v8::HandleScope::new(&mut isolate));
+  let mut scope = scope.init();
+  let context = v8::Context::new(&scope, Default::default());
+  let scope = &mut v8::ContextScope::new(&mut scope, context);
+
+  // Long valid two-byte string -> single-pass simdutf conversion.
+  let units: Vec<u16> = std::iter::repeat(0x4E16).take(64).collect(); // 世
+  let s =
+    v8::String::new_from_two_byte(scope, &units, v8::NewStringType::Normal)
+      .unwrap();
+  assert_eq!(s.to_rust_string_lossy(scope), "世".repeat(64));
+
+  // Long string with an unpaired surrogate -> single-pass reports an error and
+  // we fall back to the scalar loop, which substitutes U+FFFD.
+  let mut units2: Vec<u16> = std::iter::repeat(0x4E16).take(32).collect();
+  units2[10] = 0xD800; // lone high surrogate
+  let s2 =
+    v8::String::new_from_two_byte(scope, &units2, v8::NewStringType::Normal)
+      .unwrap();
+  let expected: String = (0..32)
+    .map(|i| if i == 10 { '\u{FFFD}' } else { '世' })
+    .collect();
+  assert_eq!(s2.to_rust_string_lossy(scope), expected);
+}
+
+#[test]
 fn string_write_utf8_into() {
   let _setup_guard = setup::parallel_test();
   let mut isolate = v8::Isolate::new(Default::default());

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -12977,7 +12977,7 @@ fn to_rust_string_lossy_wtf16_simd_path() {
   let scope = &mut v8::ContextScope::new(&mut scope, context);
 
   // Long valid two-byte string -> single-pass simdutf conversion.
-  let units: Vec<u16> = std::iter::repeat(0x4E16).take(64).collect(); // 世
+  let units: Vec<u16> = std::iter::repeat_n(0x4E16, 64).collect(); // 世
   let s =
     v8::String::new_from_two_byte(scope, &units, v8::NewStringType::Normal)
       .unwrap();
@@ -12985,7 +12985,7 @@ fn to_rust_string_lossy_wtf16_simd_path() {
 
   // Long string with an unpaired surrogate -> single-pass reports an error and
   // we fall back to the scalar loop, which substitutes U+FFFD.
-  let mut units2: Vec<u16> = std::iter::repeat(0x4E16).take(32).collect();
+  let mut units2: Vec<u16> = std::iter::repeat_n(0x4E16, 32).collect();
   units2[10] = 0xD800; // lone high surrogate
   let s2 =
     v8::String::new_from_two_byte(scope, &units2, v8::NewStringType::Normal)


### PR DESCRIPTION
## Summary

The two-byte read path ran **three** full simdutf passes — `validate_utf16le` +
`utf8_length_from_utf16le` + `convert_utf16le_to_utf8` — and only above 96
units; anything shorter (or with a lone surrogate) fell back to a char-by-char
`decode_utf16` + `String::push` loop.

This uses `convert_utf16le_to_utf8_with_errors`, which **validates and converts
in a single pass**, in `wtf16_to_string` / `wtf16_into_string` /
`wtf16_to_cow_str`. It reserves `len * 3` (a UTF-16 unit is ≤3 UTF-8 bytes) and,
on a lone-surrogate error, falls back to the scalar loop (which substitutes
U+FFFD). One pass instead of three lowers the crossover, so the threshold drops
from **96 → 16** units.

## Impact

`to_rust_string_lossy` on two-byte strings (CJK / emoji / unicode JSON / URLs),
median of 6:

| units | delta |
| --- | --- |
| 16 | **−9%** |
| 64 | **−53%** (was below the 96 threshold → slow scalar loop) |
| 256 | **−15%** |
| 4096 | **−24%** |

ASCII / Latin-1 paths are unchanged.

## Correctness

Adds `to_rust_string_lossy_wtf16_simd_path`, covering both the single-pass valid
path and the lone-surrogate fallback → U+FFFD. The pre-existing two-byte tests
all use short strings that take the scalar path, so this is the first coverage
of the SIMD conversion. `test_string` / `string_valueview` pass.