### PR TITLE
perf: decode Rust->V8 strings with simdutf in new_from_utf8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,5 +156,10 @@ name = "string_read"
 path = "benches/string_read.rs"
 harness = false
 
+[[bench]]
+name = "string_encode"
+path = "benches/string_encode.rs"
+harness = false
+
 [workspace]
 members = ["examples/android"]

--- a/benches/string_encode.rs
+++ b/benches/string_encode.rs
@@ -11,6 +11,11 @@ fn make(kind: &str, n: usize) -> String {
 }
 
 fn main() {
+  // Skip running benchmarks in debug or CI (cargo-nextest lists test binaries
+  // by running them; this harness=false bench must produce no output there).
+  if cfg!(debug_assertions) || std::env::var("CI").is_ok() {
+    return;
+  }
   let platform = v8::new_default_platform(0, false).make_shared();
   v8::V8::initialize_platform(platform);
   v8::V8::initialize();

--- a/benches/string_encode.rs
+++ b/benches/string_encode.rs
@@ -1,0 +1,60 @@
+// Rust -> V8 string creation benchmark: new_from_utf8 across sizes and content.
+use std::time::Instant;
+
+fn make(kind: &str, n: usize) -> String {
+  match kind {
+    "ascii" => "a".repeat(n),
+    "latin1" => "\u{00e9}".repeat(n),
+    "twobyte" => "\u{4e16}".repeat(n),
+    _ => unreachable!(),
+  }
+}
+
+fn main() {
+  let platform = v8::new_default_platform(0, false).make_shared();
+  v8::V8::initialize_platform(platform);
+  v8::V8::initialize();
+  let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
+  v8::scope!(let handle_scope, isolate);
+  let context = v8::Context::new(handle_scope, Default::default());
+  let scope = &mut v8::ContextScope::new(handle_scope, context);
+
+  let sizes = [4usize, 16, 64, 256, 4096];
+  let kinds = ["ascii", "latin1", "twobyte"];
+
+  // Correctness: created string must round-trip.
+  for kind in kinds {
+    for n in sizes {
+      let reference = make(kind, n);
+      let local = v8::String::new(scope, &reference).unwrap();
+      assert_eq!(local.to_rust_string_lossy(scope), reference, "{kind}/{n}");
+    }
+  }
+  println!("correctness OK");
+
+  let runs = 1_000_000u64;
+  for kind in kinds {
+    for n in sizes {
+      let s = make(kind, n);
+      let bytes = s.as_bytes();
+      let iters = if n >= 4096 { runs / 10 } else { runs };
+      for _ in 0..(iters / 10) {
+        v8::scope!(let hs, scope);
+        std::hint::black_box(
+          v8::String::new_from_utf8(hs, bytes, v8::NewStringType::Normal)
+            .unwrap(),
+        );
+      }
+      let t = Instant::now();
+      for _ in 0..iters {
+        v8::scope!(let hs, scope);
+        std::hint::black_box(
+          v8::String::new_from_utf8(hs, bytes, v8::NewStringType::Normal)
+            .unwrap(),
+        );
+      }
+      let ns = t.elapsed().as_nanos() as f64 / iters as f64;
+      println!("  new     {kind:8} {n:5}  {ns:9.2} ns/op");
+    }
+  }
+}

--- a/src/string.rs
+++ b/src/string.rs
@@ -81,6 +81,12 @@ pub unsafe fn latin1_to_utf8(
   }
 }
 
+/// Minimum non-ASCII UTF-8 byte length before `new_from_utf8` decodes with
+/// simdutf instead of V8's decoder. Below this the two potential simdutf FFI
+/// calls cost more than V8 handling the tiny string itself.
+#[cfg(feature = "simdutf")]
+const NONASCII_ENCODE_SIMD_THRESHOLD: usize = 16;
+
 unsafe extern "C" {
   fn v8__String__Empty(isolate: *mut RealIsolate) -> *const String;
 
@@ -471,6 +477,87 @@ impl String {
   ) -> Option<Local<'s, String>> {
     if buffer.is_empty() {
       return Some(Self::empty(scope));
+    }
+    // V8's `NewFromUtf8` runs a scalar UTF-8 decoder (twice: once to compute
+    // the width/length, once to write), which is very slow for non-ASCII. When
+    // simdutf is available we decode the input ourselves and hand V8 a
+    // pre-decoded one-byte (Latin-1) or two-byte (UTF-16) buffer — which it can
+    // just memcpy.
+    // `NewFromUtf8` rejects inputs whose *byte* length exceeds the maximum
+    // string length (conservatively, before decoding). Our decode paths would
+    // otherwise accept some of those (the decoded string is shorter), which
+    // would change behavior, so only take them when the byte length is in
+    // range and let V8 reject the rest.
+    #[cfg(feature = "simdutf")]
+    if buffer.len() <= Self::MAX_LENGTH {
+      // Pure ASCII (the common case): the bytes are already valid one-byte
+      // (Latin-1) data. `is_ascii` is an inline SWAR scan, cheaper than a
+      // simdutf FFI call for the short strings that dominate.
+      if buffer.is_ascii() {
+        return Self::new_from_one_byte(scope, buffer, new_type);
+      }
+      // Non-ASCII: transcode with simdutf only above a small threshold. For
+      // tiny strings the two potential simdutf FFI calls (Latin-1 attempt then
+      // UTF-16) cost more than V8's decoder, which is only slow at scale.
+      if buffer.len() >= NONASCII_ENCODE_SIMD_THRESHOLD {
+        return Self::new_from_utf8_transcode(scope, buffer, new_type);
+      }
+    }
+    let buffer_len = buffer.len().try_into().ok()?;
+    unsafe {
+      scope.cast_local(|sd| {
+        v8__String__NewFromUtf8(
+          sd.get_isolate_ptr(),
+          buffer.as_ptr() as *const char,
+          new_type,
+          buffer_len,
+        )
+      })
+    }
+  }
+
+  /// Decodes non-ASCII, non-empty valid UTF-8 into one-byte (Latin-1) or
+  /// two-byte (UTF-16) data with simdutf and hands it to V8. Falls back to
+  /// V8's lossy `NewFromUtf8` when the input isn't valid UTF-8.
+  #[cfg(feature = "simdutf")]
+  fn new_from_utf8_transcode<'s>(
+    scope: &PinScope<'s, '_, ()>,
+    buffer: &[u8],
+    new_type: NewStringType,
+  ) -> Option<Local<'s, String>> {
+    {
+      // Try Latin-1 first (more compact). The conversion errors if any code
+      // point exceeds U+00FF or the input isn't valid UTF-8; a Latin-1 result
+      // is never longer than the UTF-8 input.
+      let mut latin1: Vec<u8> = Vec::with_capacity(buffer.len());
+      // SAFETY: `latin1` has `buffer.len()` bytes of spare capacity, an upper
+      // bound on the Latin-1 length; simdutf only writes, never reads it.
+      let r = unsafe {
+        let out =
+          std::slice::from_raw_parts_mut(latin1.as_mut_ptr(), buffer.len());
+        crate::simdutf::convert_utf8_to_latin1_with_errors(buffer, out)
+      };
+      if r.is_ok() {
+        // SAFETY: simdutf wrote `r.count` valid Latin-1 bytes.
+        unsafe { latin1.set_len(r.count) };
+        return Self::new_from_one_byte(scope, &latin1, new_type);
+      }
+      // Not Latin-1 representable (or invalid UTF-8): try UTF-16. A UTF-16
+      // result is never more code units than the UTF-8 input has bytes.
+      let mut utf16: Vec<u16> = Vec::with_capacity(buffer.len());
+      // SAFETY: `utf16` has `buffer.len()` units of spare capacity, an upper
+      // bound on the UTF-16 length.
+      let r = unsafe {
+        let out =
+          std::slice::from_raw_parts_mut(utf16.as_mut_ptr(), buffer.len());
+        crate::simdutf::convert_utf8_to_utf16le_with_errors(buffer, out)
+      };
+      if r.is_ok() {
+        // SAFETY: simdutf wrote `r.count` valid UTF-16 code units.
+        unsafe { utf16.set_len(r.count) };
+        return Self::new_from_two_byte(scope, &utf16, new_type);
+      }
+      // Invalid UTF-8: fall through to V8's lossy `NewFromUtf8`.
     }
     let buffer_len = buffer.len().try_into().ok()?;
     unsafe {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -235,6 +235,55 @@ fn global_handle_drop() {
 }
 
 #[test]
+fn new_from_utf8_simd_transcode() {
+  // Exercises new_from_utf8's simdutf Latin-1 / UTF-16 transcode paths (>=
+  // threshold, non-ASCII) and the invalid-UTF-8 lossy fallback.
+  let _setup_guard = setup::parallel_test();
+  let mut isolate = v8::Isolate::new(Default::default());
+  let scope = pin!(v8::HandleScope::new(&mut isolate));
+  let mut scope = scope.init();
+  let context = v8::Context::new(&scope, Default::default());
+  let scope = &mut v8::ContextScope::new(&mut scope, context);
+
+  // Latin-1 (one-byte) path: accented text, all code points <= U+00FF.
+  let s = "café ".repeat(8);
+  assert_eq!(
+    v8::String::new(scope, &s)
+      .unwrap()
+      .to_rust_string_lossy(scope),
+    s
+  );
+
+  // UTF-16 (two-byte) path: CJK.
+  let s = "世界".repeat(8);
+  assert_eq!(
+    v8::String::new(scope, &s)
+      .unwrap()
+      .to_rust_string_lossy(scope),
+    s
+  );
+
+  // Mixed BMP + supplementary (emoji => surrogate pairs) -> UTF-16 path.
+  let s = "hi 🦕 世界!".repeat(3);
+  assert_eq!(
+    v8::String::new(scope, &s)
+      .unwrap()
+      .to_rust_string_lossy(scope),
+    s
+  );
+
+  // Invalid UTF-8 (>= threshold, non-ASCII) -> V8's lossy NewFromUtf8.
+  let invalid = b"valid_ascii_prefix_\xFF\xFE_invalid_tail";
+  let got =
+    v8::String::new_from_utf8(scope, invalid, v8::NewStringType::Normal)
+      .unwrap()
+      .to_rust_string_lossy(scope);
+  assert!(got.starts_with("valid_ascii_prefix_"));
+  assert!(got.ends_with("_invalid_tail"));
+  assert!(got.contains('\u{FFFD}'));
+}
+
+#[test]
 fn test_string() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
## Summary

`v8::String::NewFromUtf8` runs a **scalar** UTF-8 decoder — twice (once to
compute the width/length, once to write) — which is extremely slow for
non-ASCII input. When simdutf is available, decode the input ourselves and hand
V8 a pre-decoded buffer it can `memcpy`:

- **Pure ASCII** → `NewFromOneByte` directly (bytes are already valid Latin-1).
- **Non-ASCII, ≥16 bytes** → `convert_utf8_to_latin1_with_errors` (one-byte),
  else `convert_utf8_to_utf16le_with_errors` (two-byte); on invalid UTF-8, fall
  back to V8's lossy `NewFromUtf8`.
- **Tiny non-ASCII (<16 bytes)** stays on V8 (the two simdutf FFI calls cost
  more there).
- Inputs whose **byte** length exceeds `MAX_LENGTH` are left to V8, which
  rejects them (preserving the conservative `None` behavior).

## Impact

`new_from_utf8` (from-source, `--features simdutf`, median of 5):

| kind | 4 | 16 | 64 | 256 | 4096 |
| --- | --- | --- | --- | --- | --- |
| ascii | −25% | −28% | −21% | −10% | ~0 |
| latin1 | ~0 | **−44%** | **−75%** | **−87%** | **−93%** |
| twobyte | ~0 | **−33%** | **−74%** | **−88%** | **−93%** |

Non-ASCII string creation (accented text, CJK, emoji, unicode JSON crossing back
to JS) is up to **~14× faster**. `String::new`/`new_from_utf8` is how nearly
every op result string reaches V8.

## Correctness

Adds `new_from_utf8_simd_transcode` covering the Latin-1 / UTF-16 transcode
paths, mixed BMP+supplementary (emoji), and the invalid-UTF-8 lossy fallback.
All 16 `test_api` string tests pass with and without the `simdutf` feature.

Supersedes #2020 (based on a stale main; did only the ASCII half with std
`is_ascii`).