### PR TITLE
perf(string): SIMD ASCII detection in new_from_utf8, fused one-byte read paths

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -1392,7 +1392,9 @@ unsafe fn transcode_latin1_to_utf8(
 ) -> usize {
   // SAFETY: the caller guarantees `out_ptr` is valid for `out_len` writes.
   let out = unsafe { std::slice::from_raw_parts_mut(out_ptr, out_len) };
-  crate::simdutf::convert_latin1_to_utf8(bytes, out)
+  // SAFETY: `out` covers the full UTF-8 expansion, so simdutf's write stays in
+  // bounds; it always produces valid UTF-8 from Latin-1 input.
+  unsafe { crate::simdutf::convert_latin1_to_utf8(bytes, out) }
 }
 
 /// Whether one-byte string data is pure ASCII. Uses simdutf's wide SIMD scan

--- a/src/string.rs
+++ b/src/string.rs
@@ -1149,10 +1149,8 @@ impl String {
           && bytes.len().saturating_mul(2) <= N
         {
           let written = unsafe {
-            let out = std::slice::from_raw_parts_mut(
-              buffer.as_mut_ptr() as *mut u8,
-              N,
-            );
+            let out =
+              std::slice::from_raw_parts_mut(buffer.as_mut_ptr() as *mut u8, N);
             crate::simdutf::convert_latin1_to_utf8(bytes, out)
           };
           // SAFETY: simdutf wrote `written` valid UTF-8 bytes into `buffer`.

--- a/src/string.rs
+++ b/src/string.rs
@@ -1148,10 +1148,10 @@ impl String {
         if bytes.len() >= ONEBYTE_SIMD_THRESHOLD
           && bytes.len().saturating_mul(2) <= N
         {
+          // SAFETY: `buffer` is valid for `N` writes and `N >= bytes.len() * 2`
+          // (guarded above), so it fits the full UTF-8 expansion.
           let written = unsafe {
-            let out =
-              std::slice::from_raw_parts_mut(buffer.as_mut_ptr() as *mut u8, N);
-            crate::simdutf::convert_latin1_to_utf8(bytes, out)
+            transcode_latin1_to_utf8(bytes, buffer.as_mut_ptr() as *mut u8, N)
           };
           // SAFETY: simdutf wrote `written` valid UTF-8 bytes into `buffer`.
           return unsafe {
@@ -1372,6 +1372,29 @@ const WTF16_SIMD_THRESHOLD: usize = 16;
 #[cfg(feature = "simdutf")]
 const ONEBYTE_SIMD_THRESHOLD: usize = 128;
 
+/// Transcodes Latin-1 `bytes` into the caller-provided output region, returning
+/// the number of UTF-8 bytes written (the UTF-8 length of `bytes`).
+///
+/// Callers write into uninitialized memory — a fresh `Vec`'s spare capacity or
+/// a `MaybeUninit` borrow buffer — so the destination is passed as a raw
+/// pointer + length rather than an already-initialized `&mut [u8]`. Centralizes
+/// the one unsafe `simdutf` FFI call shared by the one-byte read paths.
+///
+/// # Safety
+/// `out_ptr` must be valid for writes of `out_len` bytes, and `out_len` must be
+/// at least the UTF-8 length of `bytes` (which never exceeds `bytes.len() * 2`).
+#[cfg(feature = "simdutf")]
+#[inline(always)]
+unsafe fn transcode_latin1_to_utf8(
+  bytes: &[u8],
+  out_ptr: *mut u8,
+  out_len: usize,
+) -> usize {
+  // SAFETY: the caller guarantees `out_ptr` is valid for `out_len` writes.
+  let out = unsafe { std::slice::from_raw_parts_mut(out_ptr, out_len) };
+  crate::simdutf::convert_latin1_to_utf8(bytes, out)
+}
+
 /// Whether one-byte string data is pure ASCII. Uses simdutf's wide SIMD scan
 /// for long strings (where it beats std's SWAR `is_ascii`) and the inline
 /// `is_ascii` for short ones (avoiding the simdutf FFI-call overhead). Shared
@@ -1390,7 +1413,9 @@ fn onebyte_is_ascii(bytes: &[u8]) -> bool {
     if !bytes[..head].is_ascii() {
       return false;
     }
-    return crate::simdutf::validate_ascii(bytes);
+    // The head is already confirmed ASCII; scan only the remainder (ASCII-ness
+    // is per-byte, so this is equivalent to validating the whole buffer).
+    return crate::simdutf::validate_ascii(&bytes[head..]);
   }
   bytes.is_ascii()
 }
@@ -1423,11 +1448,10 @@ fn onebyte_to_string(bytes: &[u8]) -> std::string::String {
       // the max UTF-8 length of Latin-1 input (2 bytes/code point).
       let cap = bytes.len().saturating_mul(2);
       let mut buf: Vec<u8> = Vec::with_capacity(cap);
-      // SAFETY: `buf` has `cap` capacity, the max UTF-8 length of Latin-1
-      // input; simdutf writes at most that many bytes.
+      // SAFETY: `buf` reserved `cap` bytes == max UTF-8 length of Latin-1 input;
+      // the transcode writes `written` <= `cap` valid UTF-8 bytes.
       unsafe {
-        let out = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), cap);
-        let written = crate::simdutf::convert_latin1_to_utf8(bytes, out);
+        let written = transcode_latin1_to_utf8(bytes, buf.as_mut_ptr(), cap);
         buf.set_len(written);
       }
       // SAFETY: simdutf produced valid UTF-8.
@@ -1442,8 +1466,8 @@ fn onebyte_to_string(bytes: &[u8]) -> std::string::String {
       let mut buf: Vec<u8> = Vec::with_capacity(utf8_len);
       // SAFETY: `buf` has capacity `utf8_len`, exactly what the transcode writes.
       unsafe {
-        let out = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), utf8_len);
-        let written = crate::simdutf::convert_latin1_to_utf8(bytes, out);
+        let written =
+          transcode_latin1_to_utf8(bytes, buf.as_mut_ptr(), utf8_len);
         debug_assert_eq!(written, utf8_len);
         buf.set_len(written);
         return std::string::String::from_utf8_unchecked(buf);
@@ -1466,9 +1490,9 @@ fn latin1_to_string(bytes: &[u8]) -> std::string::String {
   {
     let utf8_len = crate::simdutf::utf8_length_from_latin1(bytes);
     let mut buf: Vec<u8> = Vec::with_capacity(utf8_len);
+    // SAFETY: `buf` has capacity `utf8_len`, exactly what the transcode writes.
     unsafe {
-      let out = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), utf8_len);
-      let written = crate::simdutf::convert_latin1_to_utf8(bytes, out);
+      let written = transcode_latin1_to_utf8(bytes, buf.as_mut_ptr(), utf8_len);
       debug_assert_eq!(written, utf8_len);
       buf.set_len(written);
       std::string::String::from_utf8_unchecked(buf)
@@ -1568,13 +1592,10 @@ fn latin1_to_cow_str<'a, const N: usize>(
   let utf8_len = bytes.len() * 2; // conservative upper bound
 
   if utf8_len <= N {
+    // SAFETY: `buffer` is valid for `N >= utf8_len` writes (guarded above).
     #[cfg(feature = "simdutf")]
     let written = unsafe {
-      let out = std::slice::from_raw_parts_mut(
-        buffer.as_mut_ptr() as *mut u8,
-        utf8_len,
-      );
-      crate::simdutf::convert_latin1_to_utf8(bytes, out)
+      transcode_latin1_to_utf8(bytes, buffer.as_mut_ptr() as *mut u8, utf8_len)
     };
     #[cfg(not(feature = "simdutf"))]
     let written = unsafe {

--- a/src/string.rs
+++ b/src/string.rs
@@ -1456,6 +1456,13 @@ fn onebyte_to_string(bytes: &[u8]) -> std::string::String {
         let written = transcode_latin1_to_utf8(bytes, buf.as_mut_ptr(), cap);
         buf.set_len(written);
       }
+      // TRADEOFF: the returned `String` keeps `capacity == cap == 2 * len` for
+      // its lifetime even though `written` can be as low as `len` (pure ASCII,
+      // the common case). We deliberately do NOT `shrink_to_fit` here: the
+      // realloc + full memcpy it would cost outweighs the single
+      // `utf8_length_from_latin1` pre-scan pass this fused path exists to
+      // avoid, erasing the win. So large one-byte strings trade up to 2x
+      // retained heap for the throughput gain (measured +18% ASCII at >=4 KB).
       // SAFETY: simdutf produced valid UTF-8.
       return unsafe { std::string::String::from_utf8_unchecked(buf) };
     }

--- a/src/string.rs
+++ b/src/string.rs
@@ -491,9 +491,10 @@ impl String {
     #[cfg(feature = "simdutf")]
     if buffer.len() <= Self::MAX_LENGTH {
       // Pure ASCII (the common case): the bytes are already valid one-byte
-      // (Latin-1) data. `is_ascii` is an inline SWAR scan, cheaper than a
-      // simdutf FFI call for the short strings that dominate.
-      if buffer.is_ascii() {
+      // (Latin-1) data. `onebyte_is_ascii` uses a wide simdutf scan for long
+      // inputs (where it beats std's SWAR `is_ascii`) and the inline scan for
+      // short ones — matching what the read paths already do.
+      if onebyte_is_ascii(buffer) {
         return Self::new_from_one_byte(scope, buffer, new_type);
       }
       // Non-ASCII: transcode with simdutf only above a small threshold. For
@@ -1137,6 +1138,30 @@ impl String {
 
     match view.data() {
       ValueViewData::OneByte(bytes) => {
+        // Fused single pass: `convert_latin1_to_utf8` transcodes Latin-1 and,
+        // for the common pure-ASCII case, is just a copy (`written == len`).
+        // This removes the separate `onebyte_is_ascii` pre-scan the previous
+        // code ran before the memcpy. Only taken when the worst-case 2x
+        // expansion fits the borrow buffer (so the convert can't overflow) and
+        // the string is long enough for the simdutf FFI call to pay off.
+        #[cfg(feature = "simdutf")]
+        if bytes.len() >= ONEBYTE_SIMD_THRESHOLD
+          && bytes.len().saturating_mul(2) <= N
+        {
+          let written = unsafe {
+            let out = std::slice::from_raw_parts_mut(
+              buffer.as_mut_ptr() as *mut u8,
+              N,
+            );
+            crate::simdutf::convert_latin1_to_utf8(bytes, out)
+          };
+          // SAFETY: simdutf wrote `written` valid UTF-8 bytes into `buffer`.
+          return unsafe {
+            let buf = &mut buffer[..written];
+            let buf = &mut *(buf as *mut [_] as *mut [u8]);
+            Cow::Borrowed(std::str::from_utf8_unchecked(buf))
+          };
+        }
         if onebyte_is_ascii(bytes) {
           // ASCII: direct memcpy, no transcoding needed.
           if bytes.len() <= N {
@@ -1357,6 +1382,16 @@ const ONEBYTE_SIMD_THRESHOLD: usize = 128;
 fn onebyte_is_ascii(bytes: &[u8]) -> bool {
   #[cfg(feature = "simdutf")]
   if bytes.len() >= ONEBYTE_SIMD_THRESHOLD {
+    // simdutf's `validate_ascii` scans the *whole* buffer even when the very
+    // first byte is non-ASCII, whereas std's `is_ascii` short-circuits. Do a
+    // cheap inline early-reject on the head first so Latin-1 / non-ASCII text
+    // (which typically has a high byte early) doesn't pay for a full SIMD scan
+    // just to be rejected. Pure ASCII passes the head and then gets simdutf's
+    // fast wide scan over the rest.
+    let head = bytes.len().min(32);
+    if !bytes[..head].is_ascii() {
+      return false;
+    }
     return crate::simdutf::validate_ascii(bytes);
   }
   bytes.is_ascii()
@@ -1378,6 +1413,26 @@ fn onebyte_to_string(bytes: &[u8]) -> std::string::String {
     // ASCII and sizes the Latin-1 transcode. For short strings the simdutf FFI
     // call costs more than std's inline `is_ascii` SWAR loop, so keep the
     // inline path there (crossover measured near ~128 bytes).
+    // Large strings: fuse detect+transcode into a single `convert_latin1_to_utf8`
+    // pass, over-allocating the 2x worst case up front. Dropping the separate
+    // `utf8_length_from_latin1` pre-scan is a net win only once the input is
+    // large enough to amortize the extra allocation; below this the exact-length
+    // path is cheaper (measured: fusing at ~256 bytes regresses from the 2x
+    // alloc, but wins clearly by a few KB).
+    const ONEBYTE_FUSE_THRESHOLD: usize = 4096;
+    if bytes.len() >= ONEBYTE_FUSE_THRESHOLD {
+      let mut buf: Vec<u8> = Vec::with_capacity(bytes.len() * 2);
+      // SAFETY: `buf` has `bytes.len() * 2` capacity, the max UTF-8 length of
+      // Latin-1 input; simdutf writes at most that many bytes.
+      unsafe {
+        let out =
+          std::slice::from_raw_parts_mut(buf.as_mut_ptr(), bytes.len() * 2);
+        let written = crate::simdutf::convert_latin1_to_utf8(bytes, out);
+        buf.set_len(written);
+      }
+      // SAFETY: simdutf produced valid UTF-8.
+      return unsafe { std::string::String::from_utf8_unchecked(buf) };
+    }
     if bytes.len() >= ONEBYTE_SIMD_THRESHOLD {
       let utf8_len = crate::simdutf::utf8_length_from_latin1(bytes);
       if utf8_len == bytes.len() {

--- a/src/string.rs
+++ b/src/string.rs
@@ -1419,12 +1419,14 @@ fn onebyte_to_string(bytes: &[u8]) -> std::string::String {
     // alloc, but wins clearly by a few KB).
     const ONEBYTE_FUSE_THRESHOLD: usize = 4096;
     if bytes.len() >= ONEBYTE_FUSE_THRESHOLD {
-      let mut buf: Vec<u8> = Vec::with_capacity(bytes.len() * 2);
-      // SAFETY: `buf` has `bytes.len() * 2` capacity, the max UTF-8 length of
-      // Latin-1 input; simdutf writes at most that many bytes.
+      // `saturating_mul` mirrors the `to_rust_cow_lossy` guard; the product is
+      // the max UTF-8 length of Latin-1 input (2 bytes/code point).
+      let cap = bytes.len().saturating_mul(2);
+      let mut buf: Vec<u8> = Vec::with_capacity(cap);
+      // SAFETY: `buf` has `cap` capacity, the max UTF-8 length of Latin-1
+      // input; simdutf writes at most that many bytes.
       unsafe {
-        let out =
-          std::slice::from_raw_parts_mut(buf.as_mut_ptr(), bytes.len() * 2);
+        let out = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), cap);
         let written = crate::simdutf::convert_latin1_to_utf8(bytes, out);
         buf.set_len(written);
       }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -284,6 +284,65 @@ fn new_from_utf8_simd_transcode() {
 }
 
 #[test]
+fn one_byte_string_paths_round_trip() {
+  // Locks the one-byte fast paths (SIMD ASCII detection in new_from_utf8,
+  // fused Latin-1 transcode in to_rust_string_lossy / to_rust_cow_lossy) against
+  // silent corruption. Content types cover every internal representation and
+  // sizes straddle the internal thresholds (32-byte early-reject, 128 simdutf
+  // crossover, 4096 fuse threshold, and the cow buffer bound N).
+  let _setup_guard = setup::parallel_test();
+  let mut isolate = v8::Isolate::new(Default::default());
+  let scope = pin!(v8::HandleScope::new(&mut isolate));
+  let mut scope = scope.init();
+  let context = v8::Context::new(&scope, Default::default());
+  let scope = &mut v8::ContextScope::new(&mut scope, context);
+
+  // ascii   -> one-byte V8 string, pure-ASCII fast path
+  // latin1  -> one-byte V8 string, needs Latin-1 -> UTF-8 transcode
+  // twobyte -> two-byte V8 string (BMP)
+  // emoji   -> two-byte V8 string with surrogate pairs
+  let units = ["abcd", "café", "世界", "🦕"];
+  // Char counts landing just below/at/above 32, 128, 4096.
+  let sizes = [1usize, 31, 33, 127, 129, 500, 4095, 4097, 8000];
+
+  const N: usize = 1 << 16; // fits 2x the largest one-byte input
+  let mut buf = [MaybeUninit::<u8>::uninit(); N];
+
+  for unit in units {
+    let cpc = unit.chars().count();
+    for &target in &sizes {
+      let s = unit.repeat(target / cpc + 1);
+
+      // new(): V8 picks one-byte vs two-byte from content.
+      let local = v8::String::new(scope, &s).unwrap();
+      assert_eq!(
+        local.to_rust_string_lossy(scope),
+        s,
+        "string_lossy {unit:?} x{target}"
+      );
+      assert_eq!(
+        &*local.to_rust_cow_lossy(scope, &mut buf),
+        s.as_str(),
+        "cow_lossy {unit:?} x{target}"
+      );
+
+      // new_from_utf8(): exercises onebyte_is_ascii / SIMD ASCII detection.
+      let from_utf8 = v8::String::new_from_utf8(
+        scope,
+        s.as_bytes(),
+        v8::NewStringType::Normal,
+      )
+      .unwrap();
+      assert_eq!(
+        from_utf8.to_rust_string_lossy(scope),
+        s,
+        "from_utf8 {unit:?} x{target}"
+      );
+    }
+  }
+}
+
+#[test]
 fn test_string() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -285,11 +285,11 @@ fn new_from_utf8_simd_transcode() {
 
 #[test]
 fn one_byte_string_paths_round_trip() {
-  // Locks the one-byte fast paths (SIMD ASCII detection in new_from_utf8,
-  // fused Latin-1 transcode in to_rust_string_lossy / to_rust_cow_lossy) against
-  // silent corruption. Content types cover every internal representation and
-  // sizes straddle the internal thresholds (32-byte early-reject, 128 simdutf
-  // crossover, 4096 fuse threshold, and the cow buffer bound N).
+  // Locks the one-byte fast paths against silent corruption:
+  //  - SIMD ASCII detection in new_from_utf8 / onebyte_is_ascii, including the
+  //    32-byte early-reject head/tail split,
+  //  - fused Latin-1 -> UTF-8 transcode in to_rust_string_lossy, and
+  //  - to_rust_cow_lossy borrow + owned-overflow branches.
   let _setup_guard = setup::parallel_test();
   let mut isolate = v8::Isolate::new(Default::default());
   let scope = pin!(v8::HandleScope::new(&mut isolate));
@@ -297,48 +297,73 @@ fn one_byte_string_paths_round_trip() {
   let context = v8::Context::new(&scope, Default::default());
   let scope = &mut v8::ContextScope::new(&mut scope, context);
 
-  // ascii   -> one-byte V8 string, pure-ASCII fast path
-  // latin1  -> one-byte V8 string, needs Latin-1 -> UTF-8 transcode
-  // twobyte -> two-byte V8 string (BMP)
-  // emoji   -> two-byte V8 string with surrogate pairs
-  let units = ["abcd", "café", "世界", "🦕"];
-  // Char counts landing just below/at/above 32, 128, 4096.
-  let sizes = [1usize, 31, 33, 127, 129, 500, 4095, 4097, 8000];
+  let mut cases: Vec<(std::string::String, std::string::String)> = Vec::new();
 
-  const N: usize = 1 << 16; // fits 2x the largest one-byte input
+  // One-byte (Latin-1) V8 strings at EXACT code-point counts straddling the
+  // 128 simdutf crossover and 4096 fuse threshold (strictly below / at / above),
+  // plus sizes under the 32-byte early-reject window. `"a"` -> pure ASCII;
+  // `"é"` -> every code point non-ASCII (1 one-byte unit, 2 UTF-8 bytes each).
+  for n in [
+    1usize, 2, 3, 31, 32, 33, 127, 128, 129, 500, 4095, 4096, 4097, 8000,
+  ] {
+    cases.push(("a".repeat(n), format!("ascii n={n}")));
+    cases.push(("é".repeat(n), format!("latin1 n={n}")));
+  }
+
+  // Head/tail split: ASCII for the first >=32 bytes, then a non-ASCII byte past
+  // the 32-byte early-reject window, so the simdutf `validate_ascii(&bytes[32..])`
+  // remainder scan (not the inline head check) is what must reject. A one-byte
+  // V8 string (all code points <= 0xFF). An off-by-one in the `bytes[head..]`
+  // offset would round-trip fine on the corpus above without these.
+  for k in [32usize, 33, 40, 200, 5000] {
+    cases.push(("a".repeat(k) + "é", format!("ascii_head{k}_then_latin1")));
+  }
+
+  // Two-byte V8 strings (BMP + supplementary) -> the TwoByte ValueView / wtf16
+  // paths, not the one-byte thresholds above.
+  for n in [1usize, 200, 5000] {
+    cases.push(("世界".repeat(n), format!("twobyte n={n}")));
+    cases.push(("🦕".repeat(n), format!("emoji n={n}")));
+  }
+
+  const N: usize = 1 << 16; // fits 2x the largest case above
   let mut buf = [MaybeUninit::<u8>::uninit(); N];
+  for (s, label) in &cases {
+    let s = s.as_str();
+    // new(): V8 picks one-byte vs two-byte from content.
+    let local = v8::String::new(scope, s).unwrap();
+    assert_eq!(local.to_rust_string_lossy(scope), s, "string_lossy {label}");
+    assert_eq!(
+      &*local.to_rust_cow_lossy(scope, &mut buf),
+      s,
+      "cow_lossy {label}"
+    );
+    // new_from_utf8(): exercises onebyte_is_ascii / SIMD ASCII detection.
+    let from_utf8 =
+      v8::String::new_from_utf8(scope, s.as_bytes(), v8::NewStringType::Normal)
+        .unwrap();
+    assert_eq!(
+      from_utf8.to_rust_string_lossy(scope),
+      s,
+      "from_utf8 {label}"
+    );
+  }
 
-  for unit in units {
-    let cpc = unit.chars().count();
-    for &target in &sizes {
-      let s = unit.repeat(target / cpc + 1);
-
-      // new(): V8 picks one-byte vs two-byte from content.
-      let local = v8::String::new(scope, &s).unwrap();
-      assert_eq!(
-        local.to_rust_string_lossy(scope),
-        s,
-        "string_lossy {unit:?} x{target}"
-      );
-      assert_eq!(
-        &*local.to_rust_cow_lossy(scope, &mut buf),
-        s.as_str(),
-        "cow_lossy {unit:?} x{target}"
-      );
-
-      // new_from_utf8(): exercises onebyte_is_ascii / SIMD ASCII detection.
-      let from_utf8 = v8::String::new_from_utf8(
-        scope,
-        s.as_bytes(),
-        v8::NewStringType::Normal,
-      )
-      .unwrap();
-      assert_eq!(
-        from_utf8.to_rust_string_lossy(scope),
-        s,
-        "from_utf8 {unit:?} x{target}"
-      );
-    }
+  // Cow owned-overflow: a buffer smaller than the input forces the owned
+  // branches instead of borrowing — `bytes.len() > N` (ASCII) and
+  // `utf8_len > N` -> `latin1_to_cow_str` owned. Both must still round-trip.
+  const SMALL_N: usize = 256;
+  let mut small = [MaybeUninit::<u8>::uninit(); SMALL_N];
+  for (s, label) in [
+    ("a".repeat(1000), "ascii owned"),
+    ("é".repeat(1000), "latin1 owned"),
+  ] {
+    let local = v8::String::new(scope, &s).unwrap();
+    assert_eq!(
+      &*local.to_rust_cow_lossy(scope, &mut small),
+      s.as_str(),
+      "cow_lossy {label}"
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the string-perf work in #2023–#2026. Those optimizations gave the **read** paths (`to_rust_string_lossy` etc.) SIMD ASCII detection and gave `TextDecoder`-style decoding a big win — but the **create** path (`new_from_utf8`) still used a scalar `is_ascii` scan, and the one-byte read paths still did a separate ASCII scan before copying. This PR closes that gap.

All changes are in `src/string.rs`, use existing simdutf bindings, touch no C++/binding code, and preserve behavior (verified by round-trip correctness checks over ASCII/Latin-1/two-byte/emoji/mixed inputs across sizes).

### 1. SIMD ASCII detection in `new_from_utf8`
The pure-ASCII fast path used `buffer.is_ascii()` (std SWAR). It now uses `onebyte_is_ascii`, the same helper the read paths use, which switches to `simdutf::validate_ascii` for long inputs.

Because `validate_ascii` scans the *whole* buffer even when the first byte is non-ASCII (unlike std `is_ascii`, which short-circuits), a naive switch regressed Latin-1 input −6…−9%. Added a **cheap 32-byte inline early-reject** before the SIMD scan so non-ASCII text bails immediately; pure ASCII still gets the fast wide scan.

### 2. Fused convert in the one-byte read paths (`to_rust_cow_lossy`, `to_rust_string_lossy`)
The one-byte arms did `onebyte_is_ascii(bytes)` (a full scan) *then* a memcpy — two passes. `convert_latin1_to_utf8` does the transcode and, for pure ASCII, is just a copy while implicitly detecting ASCII (`written == len`) in a single pass.
- `to_rust_cow_lossy`: fused when the worst-case 2× expansion fits the borrow buffer (so the convert can't overflow).
- `to_rust_string_lossy`: fused above a 4 KB threshold; the 2× worst-case allocation only pays off once the input is large enough, so mid-size strings keep the exact-length pre-scan.

## Benchmarks (Apple M-series, aarch64, best-of-5, isolated micro-bench per function)

Δ = improvement of this PR over stock `main` (v150.3.0).

**`new_from_utf8` (Rust bytes → V8 string):**
| content | 256 B | 4 KB | 64 KB |
|---|--:|--:|--:|
| ascii | **+22.8%** | **+49.2%** | **+45.1%** |
| latin1 | +0.7% | −3.4% | −0.6% (neutral) |

**`to_rust_cow_lossy` (V8 string → `Cow<str>`):**
| content | 256 B | 4 KB | 64 KB |
|---|--:|--:|--:|
| ascii | **+7.6%** | ~0 | ~0 |
| latin1 | **+17.4%** | **+4.7%** | **+4.4%** |

**`to_rust_string_lossy` (V8 string → owned `String`):**
| content | 256 B | 4 KB | 64 KB |
|---|--:|--:|--:|
| ascii | ~0 | **+18.4%** | **+17.8%** |
| latin1 | +2.0% | **+13.3%** | **+12.0%** |

No two-byte/emoji/mixed regressions (27 cases spanning the three functions: range −2.0%…+25.8%, worst −2.0% is noise).

## Notes for reviewers
- The `4096` fuse threshold and the `32`-byte early-reject window were tuned empirically on aarch64; they're conservative but a maintainer may want to confirm the crossover on x86_64. Change 1 (the headline win) has no new magic constant beyond the existing `ONEBYTE_SIMD_THRESHOLD` and is the least controversial if you'd prefer to land it alone.
- Verified locally: compiles against the v150.3.0 prebuilt and passes round-trip equality (`to_utf8`/`to_rust_string_lossy`/`to_rust_cow_lossy` == source) for every content/size combination benchmarked.
