### PR TITLE
feat: add macOS system ICU support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions: write-all
 
 jobs:
   build:
-    name: ${{ matrix.config.variant }} ${{ matrix.config.target }} ${{ matrix.config.v8_enable_pointer_compression && 'ptrcomp' || '' }} ${{ matrix.config.simdutf && 'simdutf' || '' }}
+    name: ${{ matrix.config.variant }} ${{ matrix.config.target }} ${{ matrix.config.v8_enable_pointer_compression && 'ptrcomp' || '' }} ${{ matrix.config.simdutf && 'simdutf' || '' }} ${{ matrix.config.system_icu && 'system_icu' || '' }}
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 180
     strategy:
@@ -210,6 +210,39 @@ jobs:
             simdutf: true
             cargo: cargo
 
+          # Deno's macOS builds use simdutf with the system ICU façade.
+          - os: macos-15-large
+            target: x86_64-apple-darwin
+            variant: debug
+            v8_enable_pointer_compression: false
+            simdutf: true
+            system_icu: true
+            cargo: cargo
+
+          - os: macos-15-large
+            target: x86_64-apple-darwin
+            variant: release
+            v8_enable_pointer_compression: false
+            simdutf: true
+            system_icu: true
+            cargo: cargo
+
+          - os: macos-15
+            target: aarch64-apple-darwin
+            variant: debug
+            v8_enable_pointer_compression: false
+            simdutf: true
+            system_icu: true
+            cargo: cargo
+
+          - os: macos-15
+            target: aarch64-apple-darwin
+            variant: release
+            v8_enable_pointer_compression: false
+            simdutf: true
+            system_icu: true
+            cargo: cargo
+
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
             target: x86_64-unknown-linux-gnu
             variant: debug
@@ -262,10 +295,10 @@ jobs:
     env:
       V8_FROM_SOURCE: true
       CARGO_VARIANT_FLAG: ${{ matrix.config.variant == 'release' && '--release' || '' }}
-      CARGO_FEATURE_FLAGS: ${{ format('{0} {1}', matrix.config.v8_enable_pointer_compression && '--features v8_enable_pointer_compression' || '', matrix.config.simdutf && '--features simdutf' || '') }}
+      CARGO_FEATURE_FLAGS: ${{ format('{0} {1} {2}', matrix.config.v8_enable_pointer_compression && '--features v8_enable_pointer_compression' || '', matrix.config.simdutf && '--features simdutf' || '', matrix.config.system_icu && '--features system_icu' || '') }}
       LIB_NAME: ${{ contains(matrix.config.target, 'windows') && 'rusty_v8' || 'librusty_v8' }}
       LIB_EXT: ${{ contains(matrix.config.target, 'windows') && 'lib' || 'a' }}
-      FEATURES_SUFFIX: ${{ format('{0}{1}', matrix.config.v8_enable_pointer_compression && '_ptrcomp' || '', matrix.config.simdutf && '_simdutf' || '') }}
+      FEATURES_SUFFIX: ${{ format('{0}{1}{2}', matrix.config.v8_enable_pointer_compression && '_ptrcomp' || '', matrix.config.simdutf && '_simdutf' || '', matrix.config.system_icu && '_system_icu' || '') }}
       RUSTFLAGS: -D warnings
 
     steps:
@@ -397,7 +430,7 @@ jobs:
             target/*/.*
             target/*/build
             target/*/deps
-          key: cargo1-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-${{ matrix.config.simdutf }}-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
+          key: cargo1-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-${{ matrix.config.simdutf }}-${{ matrix.config.system_icu }}-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
           restore-keys: cargo1-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-
 
       - name: Install and start sccache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ opt-level = 1
 default = ["use_custom_libcxx"]
 use_custom_libcxx = []
 simdutf = []
+system_icu = []
 v8_enable_pointer_compression = []
 v8_enable_sandbox = ["v8_enable_pointer_compression"]
 v8_enable_v8_checks = []

--- a/README.md
+++ b/README.md
@@ -267,6 +267,17 @@ $ V8_FROM_SOURCE=1 cargo build
 $ V8_FROM_SOURCE=1 cargo build --release
 ```
 
+## macOS system ICU
+
+The `system_icu` Cargo feature builds V8 against the ICU C API provided by
+macOS instead of bundling ICU code and data into the rusty_v8 archive. It has
+no effect on non-macOS targets, so cross-platform applications can enable the
+feature without changing their Linux or Windows builds.
+
+Prebuilt macOS archives are published for the `simdutf,system_icu` feature
+combination used by Deno. Other feature combinations can be built with
+`V8_FROM_SOURCE=1`.
+
 ## Experimental Features
 
 rusty_v8 includes experimental support for certain feature(s) that may be useful in security focused contexts but are not as well tested and do not undergo any sort of CI related testing or prebuilt archives. Due to their experimental status, these features require either ``V8_FROM_SOURCE=1`` to be set or the use of a custom-built archive of v8. 

--- a/build.rs
+++ b/build.rs
@@ -22,6 +22,7 @@ fn main() {
   println!("cargo:rerun-if-changed=.gn");
   println!("cargo:rerun-if-changed=BUILD.gn");
   println!("cargo:rerun-if-changed=src/binding.cc");
+  println!("cargo:rerun-if-changed=system_icu/BUILD.gn");
 
   // These are all the environment variables that we check. This is
   // probably more than what is needed, but missing an important
@@ -49,6 +50,7 @@ fn main() {
     "EXTRA_GN_ARGS",
     "PRINT_GN_ARGS",
     "CARGO_ENCODED_RUSTFLAGS",
+    "CARGO_FEATURE_SYSTEM_ICU",
   ];
   for env in envs {
     println!("cargo:rerun-if-env-changed={env}");
@@ -351,6 +353,10 @@ fn build_v8(is_asan: bool) {
     "rusty_v8_enable_simdutf={}",
     env::var("CARGO_FEATURE_SIMDUTF").is_ok()
   ));
+
+  if system_icu_enabled() {
+    gn_args.push(r#"v8_icu_path="//system_icu""#.to_string());
+  }
 
   // Fix GN's host_cpu detection when using x86_64 bins on Apple Silicon
   if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
@@ -688,6 +694,9 @@ fn prebuilt_features_suffix() -> String {
   if env::var("CARGO_FEATURE_SIMDUTF").is_ok() {
     features.push_str("_simdutf");
   }
+  if system_icu_enabled() {
+    features.push_str("_system_icu");
+  }
   features
 }
 
@@ -984,6 +993,10 @@ fn print_link_flags() {
   }
   let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
   let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+
+  if system_icu_enabled() {
+    println!("cargo:rustc-link-lib=dylib=icucore");
+  }
 
   if target_os == "windows" {
     println!("cargo:rustc-link-lib=dylib=winmm");
@@ -1367,6 +1380,11 @@ fn env_bool(key: &str) -> bool {
     env::var(key).unwrap_or_default().as_str(),
     "true" | "1" | "yes"
   )
+}
+
+fn system_icu_enabled() -> bool {
+  env::var("CARGO_CFG_TARGET_OS").is_ok_and(|target_os| target_os == "macos")
+    && env::var_os("CARGO_FEATURE_SYSTEM_ICU").is_some()
 }
 
 #[cfg(test)]

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -14,6 +14,7 @@
 #include "libplatform/libplatform.h"
 #include "support.h"
 #include "unicode/locid.h"
+#include "unicode/udata.h"
 #include "v8-callbacks.h"
 #include "v8-cppgc.h"
 #include "v8-fast-api-calls.h"
@@ -4277,9 +4278,15 @@ void v8__CompiledWasmModule__DELETE(v8::CompiledWasmModule* self) {
 
 extern "C" {
 
+int32_t icu_set_common_data_77(const uint8_t* data) {
+  UErrorCode error_code = U_ZERO_ERROR;
+  udata_setCommonData(data, &error_code);
+  return error_code;
+}
+
 size_t icu_get_default_locale(char* output, size_t output_len) {
-  const icu_77::Locale& default_locale = icu::Locale::getDefault();
-  icu_77::CheckedArrayByteSink sink(output, static_cast<uint32_t>(output_len));
+  const icu::Locale& default_locale = icu::Locale::getDefault();
+  icu::CheckedArrayByteSink sink(output, static_cast<uint32_t>(output_len));
   UErrorCode status = U_ZERO_ERROR;
   default_locale.toLanguageTag(sink, status);
   assert(status == U_ZERO_ERROR);

--- a/src/icu.rs
+++ b/src/icu.rs
@@ -5,7 +5,7 @@ use std::ffi::CString;
 unsafe extern "C" {
   fn icu_get_default_locale(output: *mut char, output_len: usize) -> usize;
   fn icu_set_default_locale(locale: *const char);
-  fn udata_setCommonData_77(this: *const u8, error_code: *mut i32);
+  fn icu_set_common_data_77(data: *const u8) -> i32;
 }
 
 /// This function bypasses the normal ICU data loading process and allows you to force ICU's system
@@ -43,10 +43,7 @@ unsafe extern "C" {
 // TODO(ry) Map error code to something useful.
 #[inline(always)]
 pub fn set_common_data_77(data: &'static [u8]) -> Result<(), i32> {
-  let mut error_code = 0i32;
-  unsafe {
-    udata_setCommonData_77(data.as_ptr(), &mut error_code);
-  }
+  let error_code = unsafe { icu_set_common_data_77(data.as_ptr()) };
   if error_code == 0 {
     Ok(())
   } else {

--- a/system_icu/BUILD.gn
+++ b/system_icu/BUILD.gn
@@ -1,0 +1,103 @@
+# Copyright 2018-2026 the Deno authors. MIT license.
+
+assert(is_mac, "The system ICU target is only supported on macOS")
+
+config("icu_config") {
+  defines = [
+    # V8's ICU initialization should use the data already loaded by
+    # libicucore instead of looking for an external icudtl.dat file.
+    "ICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_STATIC",
+
+    # Apple's ICU exports stable, unsuffixed entry points.
+    "U_DISABLE_RENAMING=1",
+
+    # Apple builds libicucore without ICU's custom C++ allocation operators.
+    "U_OVERRIDE_CXX_ALLOCATION=0",
+
+    # Keep V8's existing explicit `icu::` qualification. The ICU headers map
+    # this source-level name to v8_icu_compat when USING_SYSTEM_ICU is set, so
+    # none of our C++ symbols can bind to Apple's private ICU C++ ABI.
+    "U_USING_ICU_NAMESPACE=0",
+
+    "USING_SYSTEM_ICU=1",
+  ]
+
+  # The macOS SDK exposes ICU's C API headers, but V8 also uses the C++ API.
+  # Compile against the headers matching V8's vendored ICU revision while
+  # resolving their unsuffixed symbols from Apple's libicucore.
+  include_dirs = [
+    "include",
+    "//third_party/icu/source/common",
+    "//third_party/icu/source/i18n",
+  ]
+}
+
+# `v8_icu_path` is used both as a dependency label and as the location of the
+# `icu_config` config above, so the default target must match this directory's
+# name.
+source_set("system_icu") {
+  sources = [
+    "break_iterator.cc",
+    "calendar.cc",
+    "collator.cc",
+    "currency.cc",
+    "date_format.cc",
+    "date_time_pattern_generator.cc",
+    "display_names.cc",
+    "enumeration.cc",
+    "field_position.cc",
+    "formatted_value.cc",
+    "list_formatter.cc",
+    "locale_builder.cc",
+    "locale_availability.cc",
+    "locale_matcher.cc",
+    "measure_unit.cc",
+    "normalizer.cc",
+    "number_format.cc",
+    "number_formatter.cc",
+    "numbering_system.cc",
+    "plural_rules.cc",
+    "relative_date_time_formatter.cc",
+    "resource_bundle.cc",
+    "string_support.cc",
+    "system_icu.cc",
+    "time_zone.cc",
+    "unicode_set.cc",
+
+    # These are ABI-local C++ value/utility types. They contain no ICU data;
+    # keeping their upstream implementations lets V8 retain the exact class
+    # layouts and inline methods expected by its vendored headers.
+    "//third_party/icu/source/common/bytestream.cpp",
+    "//third_party/icu/source/common/bytesinkutil.cpp",
+    "//third_party/icu/source/common/stringpiece.cpp",
+    "//third_party/icu/source/common/unistr.cpp",
+    "//third_party/icu/source/common/uobject.cpp",
+  ]
+
+  defines = [ "U_COMMON_IMPLEMENTATION" ]
+
+  include_dirs = [
+    "include",
+    "//third_party/icu/source/common",
+    "//third_party/icu/source/i18n",
+  ]
+
+  # Match Chromium's bundled ICU warning/RTTI treatment for the small set of
+  # upstream utility sources compiled into the façade.
+  configs += [
+    "//build/config/compiler:chromium_code",
+    "//build/config/compiler:no_rtti",
+  ]
+  configs -= [
+    "//build/config/compiler:chromium_code",
+    "//build/config/compiler:no_rtti",
+  ]
+  configs += [
+    "//build/config/compiler:no_chromium_code",
+    "//build/config/compiler:rtti",
+    "//third_party/icu:icu_code",
+  ]
+
+  libs = [ "icucore" ]
+  public_configs = [ ":icu_config" ]
+}

--- a/system_icu/break_iterator.cc
+++ b/system_icu/break_iterator.cc
@@ -1,0 +1,86 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include "unicode/brkiter.h"
+
+U_NAMESPACE_BEGIN
+
+namespace {
+
+BreakIterator* OpenIterator(UBreakIteratorType type, const Locale& locale,
+                            UErrorCode& status) {
+  UBreakIterator* iterator =
+      ubrk_open(type, locale.getName(), nullptr, 0, &status);
+  if (iterator == nullptr) {
+    return nullptr;
+  }
+  return new BreakIterator(type, locale, iterator);
+}
+
+}  // namespace
+
+BreakIterator::BreakIterator(UBreakIteratorType type, const Locale& locale,
+                             UBreakIterator* iterator)
+    : type_(type), locale_(locale.getName()), iterator_(iterator), text_() {}
+
+BreakIterator::~BreakIterator() { ubrk_close(iterator_); }
+
+BreakIterator* BreakIterator::createCharacterInstance(const Locale& locale,
+                                                      UErrorCode& status) {
+  return OpenIterator(UBRK_CHARACTER, locale, status);
+}
+
+BreakIterator* BreakIterator::createWordInstance(const Locale& locale,
+                                                 UErrorCode& status) {
+  return OpenIterator(UBRK_WORD, locale, status);
+}
+
+BreakIterator* BreakIterator::createLineInstance(const Locale& locale,
+                                                 UErrorCode& status) {
+  return OpenIterator(UBRK_LINE, locale, status);
+}
+
+BreakIterator* BreakIterator::createSentenceInstance(const Locale& locale,
+                                                     UErrorCode& status) {
+  return OpenIterator(UBRK_SENTENCE, locale, status);
+}
+
+BreakIterator* BreakIterator::clone() const {
+  UErrorCode status = U_ZERO_ERROR;
+  Locale locale(locale_.c_str(), "", "", "");
+  BreakIterator* result = OpenIterator(type_, locale, status);
+  if (result != nullptr && !text_.isEmpty()) {
+    result->setText(text_);
+  }
+  return result;
+}
+
+void BreakIterator::setText(const UnicodeString& text) {
+  text_ = text;
+  UErrorCode status = U_ZERO_ERROR;
+  ubrk_setText(iterator_, reinterpret_cast<const UChar*>(text_.getBuffer()),
+               text_.length(), &status);
+}
+
+int32_t BreakIterator::first() { return ubrk_first(iterator_); }
+
+int32_t BreakIterator::next() { return ubrk_next(iterator_); }
+
+int32_t BreakIterator::current() const { return ubrk_current(iterator_); }
+
+int32_t BreakIterator::preceding(int32_t offset) {
+  return ubrk_preceding(iterator_, offset);
+}
+
+int32_t BreakIterator::following(int32_t offset) {
+  return ubrk_following(iterator_, offset);
+}
+
+UBool BreakIterator::isBoundary(int32_t offset) {
+  return ubrk_isBoundary(iterator_, offset);
+}
+
+int32_t BreakIterator::getRuleStatus() const {
+  return ubrk_getRuleStatus(iterator_);
+}
+
+U_NAMESPACE_END

--- a/system_icu/calendar.cc
+++ b/system_icu/calendar.cc
@@ -1,0 +1,166 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include "unicode/calendar.h"
+
+#include <cstring>
+#include <vector>
+
+#include "unicode/gregocal.h"
+
+U_NAMESPACE_BEGIN
+
+namespace {
+
+UnicodeString CalendarTimeZoneID(const UCalendar* calendar,
+                                 UErrorCode& status) {
+  int32_t length = ucal_getTimeZoneID(calendar, nullptr, 0, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return {};
+  }
+  status = U_ZERO_ERROR;
+  std::vector<UChar> buffer(length + 1);
+  length = ucal_getTimeZoneID(calendar, buffer.data(), buffer.size(), &status);
+  return U_SUCCESS(status)
+             ? UnicodeString(reinterpret_cast<const char16_t*>(buffer.data()),
+                             length)
+             : UnicodeString();
+}
+
+Calendar* WrapCalendar(UCalendar* calendar, const UnicodeString& time_zone_id) {
+  if (calendar == nullptr) {
+    return nullptr;
+  }
+  UErrorCode status = U_ZERO_ERROR;
+  const char* type = ucal_getType(calendar, &status);
+  if (type != nullptr && (std::strcmp(type, "gregorian") == 0 ||
+                          std::strcmp(type, "iso8601") == 0)) {
+    return new GregorianCalendar(calendar, time_zone_id);
+  }
+  return new Calendar(calendar, time_zone_id);
+}
+
+}  // namespace
+
+Calendar::Calendar(UCalendar* calendar, const UnicodeString& time_zone_id)
+    : calendar_(calendar), time_zone_(time_zone_id) {}
+
+Calendar::~Calendar() { ucal_close(calendar_); }
+
+Calendar* Calendar::createInstance(const Locale& locale, UErrorCode& status) {
+  UCalendar* calendar =
+      ucal_open(nullptr, 0, locale.getName(), UCAL_DEFAULT, &status);
+  if (calendar == nullptr) {
+    return nullptr;
+  }
+  UnicodeString id = CalendarTimeZoneID(calendar, status);
+  if (U_FAILURE(status)) {
+    ucal_close(calendar);
+    return nullptr;
+  }
+  return WrapCalendar(calendar, id);
+}
+
+Calendar* Calendar::createInstance(TimeZone* zone_to_adopt,
+                                   const Locale& locale, UErrorCode& status) {
+  UnicodeString id;
+  if (zone_to_adopt != nullptr) {
+    zone_to_adopt->getID(id);
+  }
+  UCalendar* calendar = ucal_open(
+      id.isEmpty() ? nullptr : reinterpret_cast<const UChar*>(id.getBuffer()),
+      id.length(), locale.getName(), UCAL_DEFAULT, &status);
+  delete zone_to_adopt;
+  return calendar == nullptr ? nullptr : WrapCalendar(calendar, id);
+}
+
+StringEnumeration* Calendar::getKeywordValuesForLocale(const char* keyword,
+                                                       const Locale& locale,
+                                                       UBool commonly_used,
+                                                       UErrorCode& status) {
+  UEnumeration* values = ucal_getKeywordValuesForLocale(
+      keyword, locale.getName(), commonly_used, &status);
+  return values == nullptr ? nullptr : new StringEnumeration(values);
+}
+
+Calendar* Calendar::clone() const {
+  UErrorCode status = U_ZERO_ERROR;
+  UCalendar* copy = ucal_clone(calendar_, &status);
+  UnicodeString id;
+  time_zone_.getID(id);
+  return U_FAILURE(status) ? nullptr : WrapCalendar(copy, id);
+}
+
+UClassID Calendar::getStaticClassID() {
+  static char class_id = 0;
+  return &class_id;
+}
+
+UClassID Calendar::getDynamicClassID() const { return getStaticClassID(); }
+
+const char* Calendar::getType() const {
+  UErrorCode status = U_ZERO_ERROR;
+  return ucal_getType(calendar_, &status);
+}
+
+Calendar::EDaysOfWeek Calendar::getFirstDayOfWeek() const {
+  return static_cast<EDaysOfWeek>(
+      ucal_getAttribute(calendar_, UCAL_FIRST_DAY_OF_WEEK));
+}
+
+UCalendarWeekdayType Calendar::getDayOfWeekType(UCalendarDaysOfWeek day,
+                                                UErrorCode& status) const {
+  return ucal_getDayOfWeekType(calendar_, day, &status);
+}
+
+void Calendar::setTime(UDate date, UErrorCode& status) {
+  ucal_setMillis(calendar_, date, &status);
+}
+
+void Calendar::setTimeInMillis(UDate date, UErrorCode& status) {
+  setTime(date, status);
+}
+
+void Calendar::setTimeZone(const TimeZone& zone) {
+  UnicodeString id;
+  zone.getID(id);
+  UErrorCode status = U_ZERO_ERROR;
+  ucal_setTimeZone(calendar_, reinterpret_cast<const UChar*>(id.getBuffer()),
+                   id.length(), &status);
+  if (U_SUCCESS(status)) {
+    time_zone_ = BasicTimeZone(id);
+  }
+}
+
+const TimeZone& Calendar::getTimeZone() const { return time_zone_; }
+
+GregorianCalendar::GregorianCalendar(UCalendar* calendar,
+                                     const UnicodeString& time_zone_id)
+    : Calendar(calendar, time_zone_id) {}
+
+GregorianCalendar::~GregorianCalendar() = default;
+
+GregorianCalendar* GregorianCalendar::clone() const {
+  UErrorCode status = U_ZERO_ERROR;
+  UCalendar* copy = ucal_clone(calendar_, &status);
+  if (U_FAILURE(status)) {
+    return nullptr;
+  }
+  UnicodeString id;
+  time_zone_.getID(id);
+  return new GregorianCalendar(copy, id);
+}
+
+UClassID GregorianCalendar::getStaticClassID() {
+  static char class_id = 0;
+  return &class_id;
+}
+
+UClassID GregorianCalendar::getDynamicClassID() const {
+  return getStaticClassID();
+}
+
+void GregorianCalendar::setGregorianChange(UDate date, UErrorCode& status) {
+  ucal_setGregorianChange(calendar_, date, &status);
+}
+
+U_NAMESPACE_END

--- a/system_icu/collator.cc
+++ b/system_icu/collator.cc
@@ -1,0 +1,88 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <vector>
+
+#include "unicode/coll.h"
+
+U_NAMESPACE_BEGIN
+
+Collator::Collator(UCollator* collator) : collator_(collator) {}
+
+Collator::~Collator() { ucol_close(collator_); }
+
+Collator* Collator::createInstance(const Locale& locale, UErrorCode& status) {
+  UCollator* collator = ucol_open(locale.getName(), &status);
+  return collator == nullptr ? nullptr : new Collator(collator);
+}
+
+const Locale* Collator::getAvailableLocales(int32_t& count) {
+  static const std::vector<Locale> locales = [] {
+    std::vector<Locale> result;
+    const int32_t available = ucol_countAvailable();
+    result.reserve(available);
+    for (int32_t index = 0; index < available; ++index) {
+      result.emplace_back(ucol_getAvailable(index), "", "", "");
+    }
+    return result;
+  }();
+  count = locales.size();
+  return locales.data();
+}
+
+StringEnumeration* Collator::getKeywordValues(const char* keyword,
+                                              UErrorCode& status) {
+  UEnumeration* values = ucol_getKeywordValues(keyword, &status);
+  return values == nullptr ? nullptr : new StringEnumeration(values);
+}
+
+StringEnumeration* Collator::getKeywordValuesForLocale(const char* keyword,
+                                                       const Locale& locale,
+                                                       UBool commonly_used,
+                                                       UErrorCode& status) {
+  UEnumeration* values = ucol_getKeywordValuesForLocale(
+      keyword, locale.getName(), commonly_used, &status);
+  return values == nullptr ? nullptr : new StringEnumeration(values);
+}
+
+UColAttributeValue Collator::getAttribute(UColAttribute attribute,
+                                          UErrorCode& status) const {
+  return ucol_getAttribute(collator_, attribute, &status);
+}
+
+void Collator::setAttribute(UColAttribute attribute, UColAttributeValue value,
+                            UErrorCode& status) {
+  ucol_setAttribute(collator_, attribute, value, &status);
+}
+
+void Collator::setStrength(ECollationStrength strength) {
+  ucol_setStrength(collator_, static_cast<UCollationStrength>(strength));
+}
+
+Collator::ECollationStrength Collator::getStrength() const {
+  return static_cast<ECollationStrength>(ucol_getStrength(collator_));
+}
+
+const char* Collator::getLocale(ULocDataLocaleType type,
+                                UErrorCode& status) const {
+  return ucol_getLocaleByType(collator_, type, &status);
+}
+
+UCollationResult Collator::compare(const UnicodeString& left,
+                                   const UnicodeString& right,
+                                   UErrorCode& status) const {
+  if (U_FAILURE(status)) {
+    return UCOL_EQUAL;
+  }
+  return ucol_strcoll(
+      collator_, reinterpret_cast<const UChar*>(left.getBuffer()),
+      left.length(), reinterpret_cast<const UChar*>(right.getBuffer()),
+      right.length());
+}
+
+UCollationResult Collator::compareUTF8(StringPiece left, StringPiece right,
+                                       UErrorCode& status) const {
+  return ucol_strcollUTF8(collator_, left.data(), left.length(), right.data(),
+                          right.length(), &status);
+}
+
+U_NAMESPACE_END

--- a/system_icu/currency.cc
+++ b/system_icu/currency.cc
@@ -1,0 +1,16 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include "unicode/ucurr.h"
+
+#undef ucurr_getDefaultFractionDigits
+
+extern "C" int32_t v8_icu_compat_ucurr_getDefaultFractionDigits(
+    const UChar* currency, UErrorCode* status) {
+  // CLDR restored two fraction digits for HUF after the data shipped by older
+  // supported macOS releases.
+  if (currency != nullptr && currency[0] == u'H' && currency[1] == u'U' &&
+      currency[2] == u'F') {
+    return 2;
+  }
+  return ucurr_getDefaultFractionDigits(currency, status);
+}

--- a/system_icu/date_format.cc
+++ b/system_icu/date_format.cc
@@ -1,0 +1,581 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "unicode/datefmt.h"
+#include "unicode/dtfmtsym.h"
+#include "unicode/dtitvfmt.h"
+#include "unicode/dtptngen.h"
+#include "unicode/smpdtfmt.h"
+
+U_NAMESPACE_BEGIN
+namespace {
+
+UnicodeString CalendarTimeZoneId(const UCalendar* calendar) {
+  UErrorCode status = U_ZERO_ERROR;
+  int32_t length = ucal_getTimeZoneID(calendar, nullptr, 0, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return {};
+  }
+  status = U_ZERO_ERROR;
+  std::vector<UChar> result(length + 1);
+  length = ucal_getTimeZoneID(calendar, result.data(), result.size(), &status);
+  return U_SUCCESS(status)
+             ? UnicodeString(reinterpret_cast<const char16_t*>(result.data()),
+                             length)
+             : UnicodeString();
+}
+
+Calendar* CloneCalendar(const UDateFormat* format) {
+  const UCalendar* source = udat_getCalendar(format);
+  if (source == nullptr) {
+    return nullptr;
+  }
+  UErrorCode status = U_ZERO_ERROR;
+  UCalendar* clone = ucal_clone(source, &status);
+  return U_SUCCESS(status) && clone != nullptr
+             ? new Calendar(clone, CalendarTimeZoneId(source))
+             : nullptr;
+}
+
+template <typename Format>
+UnicodeString& AppendFormatted(Format format, UnicodeString& result,
+                               UErrorCode& status) {
+  if (U_FAILURE(status)) {
+    return result;
+  }
+  int32_t length = format(nullptr, 0, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return result;
+  }
+  status = U_ZERO_ERROR;
+  std::vector<UChar> buffer(length + 1);
+  length = format(buffer.data(), buffer.size(), &status);
+  if (U_SUCCESS(status)) {
+    result.append(reinterpret_cast<const char16_t*>(buffer.data()), length);
+  }
+  return result;
+}
+
+UDateFormatStyle ToStyle(DateFormat::EStyle style) {
+  return static_cast<UDateFormatStyle>(style);
+}
+
+void NormalizeGmtZero(UnicodeString& value,
+                      FieldPositionIterator* positions = nullptr) {
+  std::u16string text(value.getBuffer(), value.length());
+  constexpr std::u16string_view kLongZero = u"GMT+00:00";
+  constexpr std::u16string_view kShortZero = u"GMT+0";
+  constexpr std::u16string_view kReplacement = u"GMT";
+
+  size_t start = 0;
+  while (start < text.size()) {
+    size_t found = text.find(kLongZero, start);
+    size_t length = kLongZero.size();
+    if (found == std::u16string::npos) {
+      found = text.find(kShortZero, start);
+      length = kShortZero.size();
+      if (found != std::u16string::npos && found + length < text.size() &&
+          (text[found + length] == u':' ||
+           (text[found + length] >= u'0' && text[found + length] <= u'9'))) {
+        start = found + length;
+        continue;
+      }
+    }
+    if (found == std::u16string::npos) {
+      break;
+    }
+    text.replace(found, length, kReplacement);
+    if (positions != nullptr) {
+      positions->adjustForReplacement(found, found + length,
+                                      kReplacement.size());
+    }
+    start = found + kReplacement.size();
+  }
+  value = UnicodeString(text.data(), text.size());
+}
+
+template <typename Format>
+UnicodeString& AppendNormalizedDate(Format format, UnicodeString& result,
+                                    FieldPositionIterator* positions,
+                                    UErrorCode& status) {
+  UnicodeString formatted;
+  AppendFormatted(format, formatted, status);
+  if (U_SUCCESS(status)) {
+    NormalizeGmtZero(formatted, positions);
+    result.append(formatted);
+  }
+  return result;
+}
+
+std::string CalendarType(const Locale& locale) {
+  UErrorCode status = U_ZERO_ERROR;
+  char calendar[ULOC_KEYWORD_AND_VALUES_CAPACITY] = {};
+  const int32_t length =
+      locale.getKeywordValue("calendar", calendar, sizeof(calendar), status);
+  return U_SUCCESS(status) && length > 0 ? std::string(calendar, length)
+                                         : std::string();
+}
+
+bool HasPatternField(const std::u16string& pattern, char16_t field) {
+  bool quoted = false;
+  for (size_t index = 0; index < pattern.size(); ++index) {
+    if (pattern[index] == u'\'') {
+      if (index + 1 < pattern.size() && pattern[index + 1] == u'\'') {
+        ++index;
+      } else {
+        quoted = !quoted;
+      }
+    } else if (!quoted && pattern[index] == field) {
+      return true;
+    }
+  }
+  return false;
+}
+
+UnicodeString AdjustDatePattern(const UnicodeString& input,
+                                const Locale& locale) {
+  std::u16string pattern(input.getBuffer(), input.length());
+  const std::string calendar = CalendarType(locale);
+  const bool japanese =
+      std::strcmp(locale.getLanguage(), "ja") == 0 && calendar == "japanese";
+  const bool chinese =
+      std::strcmp(locale.getLanguage(), "zh") == 0 && calendar == "chinese";
+  const bool arabic_islamic = std::strcmp(locale.getLanguage(), "ar") == 0 &&
+                              calendar.compare(0, 7, "islamic") == 0;
+  if (!japanese && !chinese && !arabic_islamic) {
+    return input;
+  }
+
+  const bool chinese_needs_related_year = chinese &&
+                                          HasPatternField(pattern, u'U') &&
+                                          !HasPatternField(pattern, u'r');
+  const bool chinese_numeric_date = chinese && HasPatternField(pattern, u'M') &&
+                                    HasPatternField(pattern, u'd');
+
+  std::u16string result;
+  result.reserve(pattern.size() + (chinese_needs_related_year ? 1 : 0));
+  bool quoted = false;
+  for (size_t index = 0; index < pattern.size();) {
+    const char16_t ch = pattern[index];
+    if (ch == u'\'') {
+      result += ch;
+      if (index + 1 < pattern.size() && pattern[index + 1] == u'\'') {
+        result += pattern[index + 1];
+        index += 2;
+      } else {
+        quoted = !quoted;
+        ++index;
+      }
+      continue;
+    }
+
+    if (!quoted && arabic_islamic && ch == u'\u060c') {
+      size_t next = index + 1;
+      while (next < pattern.size() && pattern[next] == u' ') {
+        ++next;
+      }
+      if (next < pattern.size() && pattern[next] == u'y') {
+        result += u' ';
+        index = next;
+        continue;
+      }
+    }
+
+    if (!quoted && japanese && ch == u' ' && !result.empty() &&
+        result.back() == u'\u65e5') {
+      size_t next = index + 1;
+      if (next < pattern.size() && pattern[next] == u'E') {
+        ++index;
+        continue;
+      }
+    }
+
+    if (!quoted && japanese && (ch == u'M' || ch == u'd')) {
+      size_t end = index + 1;
+      while (end < pattern.size() && pattern[end] == ch) {
+        ++end;
+      }
+      result.append(end - index == 2 ? 1 : end - index, ch);
+      index = end;
+      continue;
+    }
+
+    if (!quoted && chinese_needs_related_year && ch == u'U') {
+      result += u'r';
+    }
+    if (!quoted && chinese_numeric_date && ch == u'-') {
+      result += u'/';
+    } else {
+      result += ch;
+    }
+    ++index;
+  }
+  return UnicodeString(result.data(), result.size());
+}
+
+UDateFormat* AdjustStylePattern(UDateFormat* format, const Locale& locale,
+                                UErrorCode& status) {
+  if (format == nullptr || U_FAILURE(status)) {
+    return format;
+  }
+  UnicodeString pattern;
+  AppendFormatted(
+      [&](UChar* buffer, int32_t capacity, UErrorCode* error) {
+        return udat_toPattern(format, false, buffer, capacity, error);
+      },
+      pattern, status);
+  if (U_FAILURE(status)) {
+    return format;
+  }
+  UnicodeString adjusted = AdjustDatePattern(pattern, locale);
+  if (adjusted == pattern) {
+    return format;
+  }
+
+  UErrorCode replacement_status = U_ZERO_ERROR;
+  UDateFormat* replacement =
+      udat_open(UDAT_PATTERN, UDAT_PATTERN, locale.getName(), nullptr, 0,
+                reinterpret_cast<const UChar*>(adjusted.getBuffer()),
+                adjusted.length(), &replacement_status);
+  if (U_SUCCESS(replacement_status) && replacement != nullptr) {
+    udat_close(format);
+    return replacement;
+  }
+  return format;
+}
+
+}  // namespace
+
+DateFormat::DateFormat(UDateFormat* format, const Locale& locale)
+    : format_(format), calendar_(CloneCalendar(format)), locale_(locale) {}
+
+DateFormat::~DateFormat() {
+  delete calendar_;
+  udat_close(format_);
+}
+
+DateFormat* DateFormat::clone() const {
+  UErrorCode status = U_ZERO_ERROR;
+  UDateFormat* copy = udat_clone(format_, &status);
+  return U_SUCCESS(status) && copy != nullptr
+             ? new SimpleDateFormat(copy, locale_)
+             : nullptr;
+}
+
+DateFormat* DateFormat::createTimeInstance(EStyle style, const Locale& locale) {
+  UErrorCode status = U_ZERO_ERROR;
+  UDateFormat* format = udat_open(ToStyle(style), UDAT_NONE, locale.getName(),
+                                  nullptr, 0, nullptr, 0, &status);
+  return U_SUCCESS(status) && format != nullptr
+             ? new SimpleDateFormat(format, locale)
+             : nullptr;
+}
+
+DateFormat* DateFormat::createDateInstance(EStyle style, const Locale& locale) {
+  UErrorCode status = U_ZERO_ERROR;
+  UDateFormat* format = nullptr;
+  if (std::strcmp(locale.getLanguage(), "ja") == 0 &&
+      CalendarType(locale) == "japanese") {
+    const char* pattern = nullptr;
+    switch (style) {
+      case kFull:
+        pattern = "Gy年M月d日EEEE";
+        break;
+      case kLong:
+      case kMedium:
+        pattern = "Gy年M月d日";
+        break;
+      case kShort:
+        pattern = "GGGGGy/M/d";
+        break;
+      default:
+        break;
+    }
+    if (pattern != nullptr) {
+      UnicodeString unicode_pattern = UnicodeString::fromUTF8(pattern);
+      format =
+          udat_open(UDAT_PATTERN, UDAT_PATTERN, locale.getName(), nullptr, 0,
+                    reinterpret_cast<const UChar*>(unicode_pattern.getBuffer()),
+                    unicode_pattern.length(), &status);
+    }
+  }
+  if (format == nullptr && U_SUCCESS(status)) {
+    format = udat_open(UDAT_NONE, ToStyle(style), locale.getName(), nullptr, 0,
+                       nullptr, 0, &status);
+  }
+  format = AdjustStylePattern(format, locale, status);
+  return U_SUCCESS(status) && format != nullptr
+             ? new SimpleDateFormat(format, locale)
+             : nullptr;
+}
+
+DateFormat* DateFormat::createDateTimeInstance(EStyle date_style,
+                                               EStyle time_style,
+                                               const Locale& locale) {
+  UErrorCode status = U_ZERO_ERROR;
+  UDateFormat* format =
+      udat_open(ToStyle(time_style), ToStyle(date_style), locale.getName(),
+                nullptr, 0, nullptr, 0, &status);
+  format = AdjustStylePattern(format, locale, status);
+  return U_SUCCESS(status) && format != nullptr
+             ? new SimpleDateFormat(format, locale)
+             : nullptr;
+}
+
+DateFormat* DateFormat::createInstanceForSkeleton(const UnicodeString& skeleton,
+                                                  const Locale& locale,
+                                                  UErrorCode& status) {
+  std::unique_ptr<DateTimePatternGenerator> generator(
+      DateTimePatternGenerator::createInstance(locale, status));
+  if (generator == nullptr || U_FAILURE(status)) {
+    return nullptr;
+  }
+  UnicodeString pattern =
+      generator->getBestPattern(skeleton, UDATPG_MATCH_NO_OPTIONS, status);
+  return U_SUCCESS(status) ? new SimpleDateFormat(pattern, locale, status)
+                           : nullptr;
+}
+
+UnicodeString& DateFormat::format(UDate date, UnicodeString& result) const {
+  UErrorCode status = U_ZERO_ERROR;
+  return AppendNormalizedDate(
+      [&](UChar* buffer, int32_t capacity, UErrorCode* error) {
+        return udat_format(format_, date, buffer, capacity, nullptr, error);
+      },
+      result, nullptr, status);
+}
+
+UnicodeString& DateFormat::format(UDate date, UnicodeString& result,
+                                  FieldPositionIterator* positions,
+                                  UErrorCode& status) const {
+  UFieldPositionIterator* iterator =
+      positions != nullptr ? positions->prepareForFormat(status) : nullptr;
+  return AppendNormalizedDate(
+      [&](UChar* buffer, int32_t capacity, UErrorCode* error) {
+        return udat_formatForFields(format_, date, buffer, capacity, iterator,
+                                    error);
+      },
+      result, positions, status);
+}
+
+UnicodeString& DateFormat::format(Calendar& calendar, UnicodeString& result,
+                                  FieldPositionIterator* positions,
+                                  UErrorCode& status) const {
+  UFieldPositionIterator* iterator =
+      positions != nullptr ? positions->prepareForFormat(status) : nullptr;
+  return AppendNormalizedDate(
+      [&](UChar* buffer, int32_t capacity, UErrorCode* error) {
+        return udat_formatCalendarForFields(format_, calendar.toUCalendar(),
+                                            buffer, capacity, iterator, error);
+      },
+      result, positions, status);
+}
+
+void DateFormat::setTimeZone(const TimeZone& zone) {
+  if (calendar_ == nullptr) {
+    return;
+  }
+  calendar_->setTimeZone(zone);
+  udat_setCalendar(format_, calendar_->toUCalendar());
+}
+
+void DateFormat::adoptCalendar(Calendar* calendar) {
+  if (calendar == nullptr) {
+    return;
+  }
+  udat_setCalendar(format_, calendar->toUCalendar());
+  delete calendar_;
+  calendar_ = calendar;
+}
+
+SimpleDateFormat::SimpleDateFormat(const UnicodeString& pattern,
+                                   const Locale& locale, UErrorCode& status)
+    : DateFormat(
+          [&]() {
+            UnicodeString adjusted = AdjustDatePattern(pattern, locale);
+            return udat_open(
+                UDAT_PATTERN, UDAT_PATTERN, locale.getName(), nullptr, 0,
+                reinterpret_cast<const UChar*>(adjusted.getBuffer()),
+                adjusted.length(), &status);
+          }(),
+          locale) {}
+
+SimpleDateFormat::SimpleDateFormat(UDateFormat* format, const Locale& locale)
+    : DateFormat(format, locale) {}
+
+SimpleDateFormat::~SimpleDateFormat() = default;
+
+SimpleDateFormat* SimpleDateFormat::clone() const {
+  UErrorCode status = U_ZERO_ERROR;
+  UDateFormat* copy = udat_clone(format_, &status);
+  return U_SUCCESS(status) && copy != nullptr
+             ? new SimpleDateFormat(copy, locale_)
+             : nullptr;
+}
+
+UnicodeString& SimpleDateFormat::toPattern(UnicodeString& result) const {
+  UErrorCode status = U_ZERO_ERROR;
+  return AppendFormatted(
+      [&](UChar* buffer, int32_t capacity, UErrorCode* error) {
+        return udat_toPattern(format_, false, buffer, capacity, error);
+      },
+      result, status);
+}
+
+const Locale& SimpleDateFormat::getSmpFmtLocale() const { return locale_; }
+
+FormattedDateInterval::FormattedDateInterval() : result_(nullptr) {}
+
+FormattedDateInterval::FormattedDateInterval(UFormattedDateInterval* result)
+    : result_(result) {}
+
+FormattedDateInterval::FormattedDateInterval(
+    FormattedDateInterval&& other) noexcept
+    : result_(other.result_) {
+  other.result_ = nullptr;
+}
+
+FormattedDateInterval& FormattedDateInterval::operator=(
+    FormattedDateInterval&& other) noexcept {
+  if (this != &other) {
+    udtitvfmt_closeResult(result_);
+    result_ = other.result_;
+    other.result_ = nullptr;
+  }
+  return *this;
+}
+
+FormattedDateInterval::~FormattedDateInterval() {
+  udtitvfmt_closeResult(result_);
+}
+
+const UFormattedValue* FormattedDateInterval::asUFormattedValue(
+    UErrorCode& status) const {
+  return result_ != nullptr ? udtitvfmt_resultAsValue(result_, &status)
+                            : nullptr;
+}
+
+DateIntervalFormat::DateIntervalFormat(std::u16string skeleton,
+                                       std::string locale,
+                                       std::u16string time_zone,
+                                       UErrorCode& status)
+    : format_(nullptr),
+      skeleton_(std::move(skeleton)),
+      locale_(std::move(locale)),
+      time_zone_(std::move(time_zone)) {
+  reopen(status);
+}
+
+DateIntervalFormat::~DateIntervalFormat() { udtitvfmt_close(format_); }
+
+DateIntervalFormat* DateIntervalFormat::createInstance(
+    const UnicodeString& skeleton, const Locale& locale, UErrorCode& status) {
+  auto* result = new DateIntervalFormat(
+      std::u16string(skeleton.getBuffer(), skeleton.length()), locale.getName(),
+      {}, status);
+  if (U_FAILURE(status) || result->format_ == nullptr) {
+    delete result;
+    return nullptr;
+  }
+  return result;
+}
+
+void DateIntervalFormat::reopen(UErrorCode& status) {
+  if (U_FAILURE(status)) {
+    return;
+  }
+  UDateIntervalFormat* replacement = udtitvfmt_open(
+      locale_.c_str(), reinterpret_cast<const UChar*>(skeleton_.data()),
+      skeleton_.size(),
+      time_zone_.empty() ? nullptr
+                         : reinterpret_cast<const UChar*>(time_zone_.data()),
+      time_zone_.size(), &status);
+  if (U_SUCCESS(status) && replacement != nullptr) {
+    udtitvfmt_close(format_);
+    format_ = replacement;
+  }
+}
+
+DateIntervalFormat* DateIntervalFormat::clone() const {
+  UErrorCode status = U_ZERO_ERROR;
+  auto* result = new DateIntervalFormat(skeleton_, locale_, time_zone_, status);
+  if (U_FAILURE(status) || result->format_ == nullptr) {
+    delete result;
+    return nullptr;
+  }
+  return result;
+}
+
+void DateIntervalFormat::setTimeZone(const TimeZone& zone) {
+  UnicodeString id;
+  zone.getID(id);
+  time_zone_.assign(id.getBuffer(), id.length());
+  UErrorCode status = U_ZERO_ERROR;
+  reopen(status);
+}
+
+FormattedDateInterval DateIntervalFormat::formatToValue(
+    Calendar& from, Calendar& to, UErrorCode& status) const {
+  UFormattedDateInterval* result = udtitvfmt_openResult(&status);
+  if (U_SUCCESS(status) && result != nullptr) {
+    udtitvfmt_formatCalendarToResult(format_, from.toUCalendar(),
+                                     to.toUCalendar(), result, &status);
+  }
+  if (U_FAILURE(status)) {
+    udtitvfmt_closeResult(result);
+    result = nullptr;
+  }
+  return FormattedDateInterval(result);
+}
+
+DateFormatSymbols::DateFormatSymbols(const Locale& locale, UErrorCode& status)
+    : locale_(locale) {
+  UDateTimePatternGenerator* generator = udatpg_open(locale.getName(), &status);
+  udatpg_close(generator);
+}
+
+DateFormatSymbols::~DateFormatSymbols() = default;
+
+UnicodeString& DateFormatSymbols::getTimeSeparatorString(
+    UnicodeString& result) const {
+  UErrorCode status = U_ZERO_ERROR;
+  std::unique_ptr<DateTimePatternGenerator> generator(
+      DateTimePatternGenerator::createInstance(locale_, status));
+  UnicodeString pattern;
+  if (generator != nullptr) {
+    pattern = generator->getBestPattern(UnicodeString::fromUTF8("Hm"),
+                                        UDATPG_MATCH_NO_OPTIONS, status);
+  }
+
+  int32_t hour_end = -1;
+  int32_t minute_start = -1;
+  for (int32_t i = 0; i < pattern.length(); ++i) {
+    char16_t ch = pattern[i];
+    if (ch == u'H' || ch == u'h' || ch == u'K' || ch == u'k') {
+      hour_end = i + 1;
+    } else if (ch == u'm' && hour_end >= 0) {
+      minute_start = i;
+      break;
+    }
+  }
+  if (hour_end >= 0 && minute_start > hour_end) {
+    for (int32_t i = hour_end; i < minute_start; ++i) {
+      char16_t ch = pattern[i];
+      if (ch != u' ' && ch != u'\'' && ch != u'\u200f' && ch != u'\u061c') {
+        result.append(ch);
+      }
+    }
+  }
+  if (result.isEmpty()) {
+    result.append(u':');
+  }
+  return result;
+}
+
+U_NAMESPACE_END

--- a/system_icu/date_time_pattern_generator.cc
+++ b/system_icu/date_time_pattern_generator.cc
@@ -1,0 +1,93 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <vector>
+
+#include "unicode/dtptngen.h"
+
+U_NAMESPACE_BEGIN
+namespace {
+
+template <typename Get>
+UnicodeString GetString(Get get, UErrorCode& status) {
+  if (U_FAILURE(status)) {
+    return {};
+  }
+  int32_t length = get(nullptr, 0, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return {};
+  }
+  status = U_ZERO_ERROR;
+  std::vector<UChar> result(length + 1);
+  length = get(result.data(), result.size(), &status);
+  return U_SUCCESS(status)
+             ? UnicodeString(reinterpret_cast<const char16_t*>(result.data()),
+                             length)
+             : UnicodeString();
+}
+
+}  // namespace
+
+DateTimePatternGenerator::DateTimePatternGenerator(
+    UDateTimePatternGenerator* generator)
+    : generator_(generator) {}
+
+DateTimePatternGenerator::~DateTimePatternGenerator() {
+  udatpg_close(generator_);
+}
+
+DateTimePatternGenerator* DateTimePatternGenerator::createInstance(
+    const Locale& locale, UErrorCode& status) {
+  UDateTimePatternGenerator* generator = udatpg_open(locale.getName(), &status);
+  return U_SUCCESS(status) && generator != nullptr
+             ? new DateTimePatternGenerator(generator)
+             : nullptr;
+}
+
+DateTimePatternGenerator* DateTimePatternGenerator::clone() const {
+  UErrorCode status = U_ZERO_ERROR;
+  UDateTimePatternGenerator* copy = udatpg_clone(generator_, &status);
+  return U_SUCCESS(status) && copy != nullptr
+             ? new DateTimePatternGenerator(copy)
+             : nullptr;
+}
+
+UnicodeString DateTimePatternGenerator::getBestPattern(
+    const UnicodeString& skeleton, UDateTimePatternMatchOptions options,
+    UErrorCode& status) {
+  return GetString(
+      [&](UChar* result, int32_t capacity, UErrorCode* error) {
+        return udatpg_getBestPatternWithOptions(
+            generator_, reinterpret_cast<const UChar*>(skeleton.getBuffer()),
+            skeleton.length(), options, result, capacity, error);
+      },
+      status);
+}
+
+UnicodeString DateTimePatternGenerator::staticGetSkeleton(
+    const UnicodeString& pattern, UErrorCode& status) {
+  return GetString(
+      [&](UChar* result, int32_t capacity, UErrorCode* error) {
+        return udatpg_getSkeleton(
+            nullptr, reinterpret_cast<const UChar*>(pattern.getBuffer()),
+            pattern.length(), result, capacity, error);
+      },
+      status);
+}
+
+UDateFormatHourCycle DateTimePatternGenerator::getDefaultHourCycle(
+    UErrorCode& status) const {
+  return udatpg_getDefaultHourCycle(generator_, &status);
+}
+
+UnicodeString DateTimePatternGenerator::getFieldDisplayName(
+    UDateTimePatternField field, UDateTimePGDisplayWidth width) const {
+  UErrorCode status = U_ZERO_ERROR;
+  return GetString(
+      [&](UChar* result, int32_t capacity, UErrorCode* error) {
+        return udatpg_getFieldDisplayName(generator_, field, width, result,
+                                          capacity, error);
+      },
+      status);
+}
+
+U_NAMESPACE_END

--- a/system_icu/display_names.cc
+++ b/system_icu/display_names.cc
@@ -1,0 +1,86 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <vector>
+
+#include "unicode/locdspnm.h"
+
+U_NAMESPACE_BEGIN
+namespace {
+
+template <typename Get>
+UnicodeString& GetDisplayName(Get get, UnicodeString& result) {
+  UErrorCode status = U_ZERO_ERROR;
+  int32_t length = get(nullptr, 0, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    result.setToBogus();
+    return result;
+  }
+  status = U_ZERO_ERROR;
+  std::vector<UChar> buffer(length + 1);
+  length = get(buffer.data(), buffer.size(), &status);
+  if (U_SUCCESS(status)) {
+    result =
+        UnicodeString(reinterpret_cast<const char16_t*>(buffer.data()), length);
+  } else {
+    result.setToBogus();
+  }
+  return result;
+}
+
+}  // namespace
+
+LocaleDisplayNames::LocaleDisplayNames(ULocaleDisplayNames* names,
+                                       const Locale& locale)
+    : names_(names), locale_(locale) {}
+
+LocaleDisplayNames::~LocaleDisplayNames() { uldn_close(names_); }
+
+LocaleDisplayNames* LocaleDisplayNames::createInstance(
+    const Locale& locale, UDisplayContext* contexts, int32_t length) {
+  UErrorCode status = U_ZERO_ERROR;
+  ULocaleDisplayNames* names =
+      uldn_openForContext(locale.getName(), contexts, length, &status);
+  if (U_FAILURE(status) || names == nullptr) {
+    return nullptr;
+  }
+  return new LocaleDisplayNames(names, Locale(uldn_getLocale(names)));
+}
+
+UnicodeString& LocaleDisplayNames::localeDisplayName(
+    const char* locale, UnicodeString& result) const {
+  return GetDisplayName(
+      [&](UChar* buffer, int32_t capacity, UErrorCode* status) {
+        return uldn_localeDisplayName(names_, locale, buffer, capacity, status);
+      },
+      result);
+}
+
+UnicodeString& LocaleDisplayNames::scriptDisplayName(
+    const char* script, UnicodeString& result) const {
+  return GetDisplayName(
+      [&](UChar* buffer, int32_t capacity, UErrorCode* status) {
+        return uldn_scriptDisplayName(names_, script, buffer, capacity, status);
+      },
+      result);
+}
+
+UnicodeString& LocaleDisplayNames::regionDisplayName(
+    const char* region, UnicodeString& result) const {
+  return GetDisplayName(
+      [&](UChar* buffer, int32_t capacity, UErrorCode* status) {
+        return uldn_regionDisplayName(names_, region, buffer, capacity, status);
+      },
+      result);
+}
+
+UnicodeString& LocaleDisplayNames::keyValueDisplayName(
+    const char* key, const char* value, UnicodeString& result) const {
+  return GetDisplayName(
+      [&](UChar* buffer, int32_t capacity, UErrorCode* status) {
+        return uldn_keyValueDisplayName(names_, key, value, buffer, capacity,
+                                        status);
+      },
+      result);
+}
+
+U_NAMESPACE_END

--- a/system_icu/enumeration.cc
+++ b/system_icu/enumeration.cc
@@ -1,0 +1,25 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include "unicode/strenum.h"
+
+U_NAMESPACE_BEGIN
+
+StringEnumeration::StringEnumeration(UEnumeration* enumeration)
+    : enumeration_(enumeration) {}
+
+StringEnumeration::~StringEnumeration() { uenum_close(enumeration_); }
+
+const char* StringEnumeration::next(int32_t* result_length,
+                                    UErrorCode& status) {
+  return uenum_next(enumeration_, result_length, &status);
+}
+
+int32_t StringEnumeration::count(UErrorCode& status) const {
+  return uenum_count(enumeration_, &status);
+}
+
+void StringEnumeration::reset(UErrorCode& status) {
+  uenum_reset(enumeration_, &status);
+}
+
+U_NAMESPACE_END

--- a/system_icu/field_position.cc
+++ b/system_icu/field_position.cc
@@ -1,0 +1,112 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <mutex>
+#include <vector>
+
+#include "unicode/fpositer.h"
+
+U_NAMESPACE_BEGIN
+
+FieldPosition::~FieldPosition() = default;
+
+struct FieldPositionIterator::State {
+  struct Entry {
+    int32_t field;
+    int32_t begin;
+    int32_t end;
+  };
+
+  ~State() { ufieldpositer_close(iterator); }
+
+  UFieldPositionIterator* iterator = nullptr;
+  std::vector<Entry> entries;
+  bool exhausted = false;
+  std::mutex mutex;
+};
+
+FieldPositionIterator::FieldPositionIterator()
+    : state_(std::make_shared<State>()), index_(0) {
+  UErrorCode status = U_ZERO_ERROR;
+  state_->iterator = ufieldpositer_open(&status);
+}
+
+FieldPositionIterator::FieldPositionIterator(const FieldPositionIterator& other)
+    : state_(other.state_), index_(other.index_) {}
+
+FieldPositionIterator& FieldPositionIterator::operator=(
+    const FieldPositionIterator& other) {
+  state_ = other.state_;
+  index_ = other.index_;
+  return *this;
+}
+
+FieldPositionIterator::~FieldPositionIterator() = default;
+
+UFieldPositionIterator* FieldPositionIterator::prepareForFormat(
+    UErrorCode& status) {
+  if (U_FAILURE(status) || state_->iterator == nullptr) {
+    if (U_SUCCESS(status)) {
+      status = U_MEMORY_ALLOCATION_ERROR;
+    }
+    return nullptr;
+  }
+  std::lock_guard<std::mutex> lock(state_->mutex);
+  state_->entries.clear();
+  state_->exhausted = false;
+  index_ = 0;
+  return state_->iterator;
+}
+
+void FieldPositionIterator::adjustForReplacement(int32_t begin, int32_t end,
+                                                 int32_t replacement_length) {
+  std::lock_guard<std::mutex> lock(state_->mutex);
+  while (!state_->exhausted) {
+    int32_t entry_begin = 0;
+    int32_t entry_end = 0;
+    int32_t field =
+        ufieldpositer_next(state_->iterator, &entry_begin, &entry_end);
+    if (field < 0) {
+      state_->exhausted = true;
+    } else {
+      state_->entries.push_back({field, entry_begin, entry_end});
+    }
+  }
+
+  const int32_t delta = replacement_length - (end - begin);
+  for (State::Entry& entry : state_->entries) {
+    if (entry.begin >= end) {
+      entry.begin += delta;
+    } else if (entry.begin > begin) {
+      entry.begin = begin;
+    }
+    if (entry.end >= end) {
+      entry.end += delta;
+    } else if (entry.end > begin) {
+      entry.end = begin + replacement_length;
+    }
+  }
+}
+
+UBool FieldPositionIterator::next(FieldPosition& position) {
+  std::lock_guard<std::mutex> lock(state_->mutex);
+  if (index_ == state_->entries.size() && !state_->exhausted) {
+    int32_t begin = 0;
+    int32_t end = 0;
+    int32_t field = ufieldpositer_next(state_->iterator, &begin, &end);
+    if (field < 0) {
+      state_->exhausted = true;
+    } else {
+      state_->entries.push_back({field, begin, end});
+    }
+  }
+  if (index_ >= state_->entries.size()) {
+    return false;
+  }
+  const State::Entry& entry = state_->entries[index_++];
+  position.setField(entry.field);
+  position.setBeginIndex(entry.begin);
+  position.setEndIndex(entry.end);
+  return true;
+}
+
+U_NAMESPACE_END

--- a/system_icu/formatted_value.cc
+++ b/system_icu/formatted_value.cc
@@ -1,0 +1,94 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include "unicode/formattedvalue.h"
+
+U_NAMESPACE_BEGIN
+
+ConstrainedFieldPosition::ConstrainedFieldPosition()
+    : field_position_(nullptr) {
+  UErrorCode status = U_ZERO_ERROR;
+  field_position_ = ucfpos_open(&status);
+}
+
+ConstrainedFieldPosition::~ConstrainedFieldPosition() {
+  ucfpos_close(field_position_);
+}
+
+void ConstrainedFieldPosition::reset() {
+  UErrorCode status = U_ZERO_ERROR;
+  ucfpos_reset(field_position_, &status);
+}
+
+void ConstrainedFieldPosition::constrainCategory(int32_t category) {
+  UErrorCode status = U_ZERO_ERROR;
+  ucfpos_constrainCategory(field_position_, category, &status);
+}
+
+void ConstrainedFieldPosition::constrainField(int32_t category, int32_t field) {
+  UErrorCode status = U_ZERO_ERROR;
+  ucfpos_constrainField(field_position_, category, field, &status);
+}
+
+int32_t ConstrainedFieldPosition::getCategory() const {
+  UErrorCode status = U_ZERO_ERROR;
+  return ucfpos_getCategory(field_position_, &status);
+}
+
+int32_t ConstrainedFieldPosition::getField() const {
+  UErrorCode status = U_ZERO_ERROR;
+  return ucfpos_getField(field_position_, &status);
+}
+
+int32_t ConstrainedFieldPosition::getStart() const {
+  UErrorCode status = U_ZERO_ERROR;
+  int32_t start = 0;
+  int32_t limit = 0;
+  ucfpos_getIndexes(field_position_, &start, &limit, &status);
+  return start;
+}
+
+int32_t ConstrainedFieldPosition::getLimit() const {
+  UErrorCode status = U_ZERO_ERROR;
+  int32_t start = 0;
+  int32_t limit = 0;
+  ucfpos_getIndexes(field_position_, &start, &limit, &status);
+  return limit;
+}
+
+FormattedValue::~FormattedValue() = default;
+
+UnicodeString CFormattedValue::toString(UErrorCode& status) const {
+  const UFormattedValue* value = asUFormattedValue(status);
+  if (value == nullptr || U_FAILURE(status)) {
+    return {};
+  }
+  int32_t length = 0;
+  const UChar* string = ufmtval_getString(value, &length, &status);
+  return U_SUCCESS(status)
+             ? UnicodeString(reinterpret_cast<const char16_t*>(string), length)
+             : UnicodeString();
+}
+
+UnicodeString CFormattedValue::toTempString(UErrorCode& status) const {
+  return toString(status);
+}
+
+Appendable& CFormattedValue::appendTo(Appendable& appendable,
+                                      UErrorCode& status) const {
+  UnicodeString string = toString(status);
+  if (U_SUCCESS(status) &&
+      !appendable.appendString(string.getBuffer(), string.length())) {
+    status = U_MEMORY_ALLOCATION_ERROR;
+  }
+  return appendable;
+}
+
+UBool CFormattedValue::nextPosition(ConstrainedFieldPosition& field_position,
+                                    UErrorCode& status) const {
+  const UFormattedValue* value = asUFormattedValue(status);
+  return value != nullptr &&
+         ufmtval_nextPosition(
+             value, field_position.toUConstrainedFieldPosition(), &status);
+}
+
+U_NAMESPACE_END

--- a/system_icu/include/unicode/basictz.h
+++ b/system_icu/include/unicode/basictz.h
@@ -1,0 +1,32 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_BASIC_TIME_ZONE_H_
+#define V8_SYSTEM_ICU_BASIC_TIME_ZONE_H_
+
+#include "unicode/timezone.h"
+#include "unicode/tztrans.h"
+
+U_NAMESPACE_BEGIN
+
+class BasicTimeZone : public TimeZone {
+ public:
+  explicit BasicTimeZone(const UnicodeString& id);
+  BasicTimeZone(const BasicTimeZone& other);
+  virtual ~BasicTimeZone();
+
+  virtual BasicTimeZone* clone() const;
+
+  void getOffsetFromLocal(UDate date,
+                          UTimeZoneLocalOption non_existing_time_opt,
+                          UTimeZoneLocalOption duplicated_time_opt,
+                          int32_t& raw_offset, int32_t& dst_offset,
+                          UErrorCode& status) const;
+  UBool getNextTransition(UDate base, UBool inclusive,
+                          TimeZoneTransition& result) const;
+  UBool getPreviousTransition(UDate base, UBool inclusive,
+                              TimeZoneTransition& result) const;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_BASIC_TIME_ZONE_H_

--- a/system_icu/include/unicode/brkiter.h
+++ b/system_icu/include/unicode/brkiter.h
@@ -1,0 +1,64 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_BREAKITERATOR_H_
+#define V8_SYSTEM_ICU_BREAKITERATOR_H_
+
+#include <string>
+
+#include "unicode/locid.h"
+#include "unicode/ubrk.h"
+#include "unicode/unistr.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class BreakIterator : public UMemory {
+ public:
+  static constexpr int32_t DONE = UBRK_DONE;
+
+  virtual ~BreakIterator();
+
+  BreakIterator(UBreakIteratorType type, const Locale& locale,
+                UBreakIterator* iterator);
+
+  static BreakIterator* createCharacterInstance(const Locale& locale,
+                                                UErrorCode& status);
+  static BreakIterator* createWordInstance(const Locale& locale,
+                                           UErrorCode& status);
+  static BreakIterator* createLineInstance(const Locale& locale,
+                                           UErrorCode& status);
+  static BreakIterator* createSentenceInstance(const Locale& locale,
+                                               UErrorCode& status);
+
+  BreakIterator* clone() const;
+  void setText(const UnicodeString& text);
+
+  int32_t first();
+  int32_t next();
+  int32_t current() const;
+  int32_t preceding(int32_t offset);
+  int32_t following(int32_t offset);
+  UBool isBoundary(int32_t offset);
+  int32_t getRuleStatus() const;
+
+  class TextView {
+   public:
+    explicit TextView(int32_t length) : length_(length) {}
+    int32_t getLength() const { return length_; }
+
+   private:
+    int32_t length_;
+  };
+
+  TextView getText() const { return TextView(text_.length()); }
+
+ private:
+  UBreakIteratorType type_;
+  std::string locale_;
+  UBreakIterator* iterator_;
+  UnicodeString text_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_BREAKITERATOR_H_

--- a/system_icu/include/unicode/calendar.h
+++ b/system_icu/include/unicode/calendar.h
@@ -1,0 +1,59 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_CALENDAR_H_
+#define V8_SYSTEM_ICU_CALENDAR_H_
+
+#include "unicode/basictz.h"
+#include "unicode/locid.h"
+#include "unicode/strenum.h"
+#include "unicode/ucal.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class Calendar : public UObject {
+ public:
+  enum EDaysOfWeek {
+    SUNDAY = UCAL_SUNDAY,
+    MONDAY = UCAL_MONDAY,
+    TUESDAY = UCAL_TUESDAY,
+    WEDNESDAY = UCAL_WEDNESDAY,
+    THURSDAY = UCAL_THURSDAY,
+    FRIDAY = UCAL_FRIDAY,
+    SATURDAY = UCAL_SATURDAY,
+  };
+
+  Calendar(UCalendar* calendar, const UnicodeString& time_zone_id);
+  virtual ~Calendar();
+
+  static Calendar* createInstance(const Locale& locale, UErrorCode& status);
+  static Calendar* createInstance(TimeZone* zone_to_adopt, const Locale& locale,
+                                  UErrorCode& status);
+  static StringEnumeration* getKeywordValuesForLocale(const char* keyword,
+                                                      const Locale& locale,
+                                                      UBool commonly_used,
+                                                      UErrorCode& status);
+
+  virtual Calendar* clone() const;
+  virtual UClassID getDynamicClassID() const override;
+  static UClassID getStaticClassID();
+
+  const char* getType() const;
+  EDaysOfWeek getFirstDayOfWeek() const;
+  UCalendarWeekdayType getDayOfWeekType(UCalendarDaysOfWeek day,
+                                        UErrorCode& status) const;
+  void setTime(UDate date, UErrorCode& status);
+  void setTimeInMillis(UDate date, UErrorCode& status);
+  void setTimeZone(const TimeZone& zone);
+  const TimeZone& getTimeZone() const;
+
+  UCalendar* toUCalendar() const { return calendar_; }
+
+ protected:
+  UCalendar* calendar_;
+  BasicTimeZone time_zone_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_CALENDAR_H_

--- a/system_icu/include/unicode/coll.h
+++ b/system_icu/include/unicode/coll.h
@@ -1,0 +1,65 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_COLLATOR_H_
+#define V8_SYSTEM_ICU_COLLATOR_H_
+
+#include "unicode/locid.h"
+#include "unicode/strenum.h"
+#include "unicode/stringpiece.h"
+#include "unicode/ucol.h"
+#include "unicode/unistr.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class Collator : public UMemory {
+ public:
+  enum EComparisonResult {
+    LESS = UCOL_LESS,
+    EQUAL = UCOL_EQUAL,
+    GREATER = UCOL_GREATER,
+  };
+
+  enum ECollationStrength {
+    PRIMARY = UCOL_PRIMARY,
+    SECONDARY = UCOL_SECONDARY,
+    TERTIARY = UCOL_TERTIARY,
+    QUATERNARY = UCOL_QUATERNARY,
+    IDENTICAL = UCOL_IDENTICAL,
+  };
+
+  explicit Collator(UCollator* collator);
+  virtual ~Collator();
+
+  static Collator* createInstance(const Locale& locale, UErrorCode& status);
+  static const Locale* getAvailableLocales(int32_t& count);
+  static StringEnumeration* getKeywordValues(const char* keyword,
+                                             UErrorCode& status);
+  static StringEnumeration* getKeywordValuesForLocale(const char* keyword,
+                                                      const Locale& locale,
+                                                      UBool commonly_used,
+                                                      UErrorCode& status);
+
+  UColAttributeValue getAttribute(UColAttribute attribute,
+                                  UErrorCode& status) const;
+  void setAttribute(UColAttribute attribute, UColAttributeValue value,
+                    UErrorCode& status);
+  void setStrength(ECollationStrength strength);
+  ECollationStrength getStrength() const;
+  const char* getLocale(ULocDataLocaleType type, UErrorCode& status) const;
+
+  UCollationResult compare(const UnicodeString& left,
+                           const UnicodeString& right,
+                           UErrorCode& status) const;
+  UCollationResult compareUTF8(StringPiece left, StringPiece right,
+                               UErrorCode& status) const;
+
+  UCollator* toUCollator() const { return collator_; }
+
+ private:
+  UCollator* collator_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_COLLATOR_H_

--- a/system_icu/include/unicode/currunit.h
+++ b/system_icu/include/unicode/currunit.h
@@ -1,0 +1,27 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_CURRENCY_UNIT_H_
+#define V8_SYSTEM_ICU_CURRENCY_UNIT_H_
+
+#include "unicode/measunit.h"
+#include "unicode/unistr.h"
+
+U_NAMESPACE_BEGIN
+
+class CurrencyUnit : public MeasureUnit {
+ public:
+  CurrencyUnit();
+  CurrencyUnit(ConstChar16Ptr iso_code, UErrorCode& status);
+  CurrencyUnit(const CurrencyUnit& other);
+  CurrencyUnit& operator=(const CurrencyUnit& other);
+  virtual ~CurrencyUnit();
+
+  const char16_t* getISOCurrency() const { return iso_code_; }
+
+ private:
+  char16_t iso_code_[4];
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_CURRENCY_UNIT_H_

--- a/system_icu/include/unicode/datefmt.h
+++ b/system_icu/include/unicode/datefmt.h
@@ -1,0 +1,63 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_DATE_FORMAT_H_
+#define V8_SYSTEM_ICU_DATE_FORMAT_H_
+
+#include "unicode/calendar.h"
+#include "unicode/fpositer.h"
+#include "unicode/locid.h"
+#include "unicode/udat.h"
+#include "unicode/unistr.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class DateFormat : public UObject {
+ public:
+  enum EStyle {
+    kFull = 0,
+    kLong = 1,
+    kMedium = 2,
+    kShort = 3,
+    kNone = -1,
+    kDefault = kMedium,
+  };
+
+  virtual ~DateFormat();
+  virtual DateFormat* clone() const;
+
+  static DateFormat* createTimeInstance(
+      EStyle style = kDefault, const Locale& locale = Locale::getDefault());
+  static DateFormat* createDateInstance(
+      EStyle style = kDefault, const Locale& locale = Locale::getDefault());
+  static DateFormat* createDateTimeInstance(
+      EStyle date_style = kDefault, EStyle time_style = kDefault,
+      const Locale& locale = Locale::getDefault());
+  static DateFormat* createInstanceForSkeleton(const UnicodeString& skeleton,
+                                               const Locale& locale,
+                                               UErrorCode& status);
+
+  UnicodeString& format(UDate date, UnicodeString& result) const;
+  UnicodeString& format(UDate date, UnicodeString& result,
+                        FieldPositionIterator* positions,
+                        UErrorCode& status) const;
+  UnicodeString& format(Calendar& calendar, UnicodeString& result,
+                        FieldPositionIterator* positions,
+                        UErrorCode& status) const;
+
+  const Calendar* getCalendar() const { return calendar_; }
+  const TimeZone& getTimeZone() const { return calendar_->getTimeZone(); }
+  void adoptCalendar(Calendar* calendar);
+  void setTimeZone(const TimeZone& zone);
+
+ protected:
+  DateFormat(UDateFormat* format, const Locale& locale);
+
+  UDateFormat* format_;
+  Calendar* calendar_;
+  Locale locale_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_DATE_FORMAT_H_

--- a/system_icu/include/unicode/decimfmt.h
+++ b/system_icu/include/unicode/decimfmt.h
@@ -1,0 +1,23 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_DECIMAL_FORMAT_H_
+#define V8_SYSTEM_ICU_DECIMAL_FORMAT_H_
+
+#include "unicode/numfmt.h"
+
+U_NAMESPACE_BEGIN
+
+class DecimalFormat : public NumberFormat {
+ public:
+  explicit DecimalFormat(UNumberFormat* formatter);
+  virtual ~DecimalFormat();
+
+  virtual UClassID getDynamicClassID() const override;
+  static UClassID getStaticClassID();
+
+  void setMinimumGroupingDigits(int32_t value);
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_DECIMAL_FORMAT_H_

--- a/system_icu/include/unicode/dtfmtsym.h
+++ b/system_icu/include/unicode/dtfmtsym.h
@@ -1,0 +1,25 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_DATE_FORMAT_SYMBOLS_H_
+#define V8_SYSTEM_ICU_DATE_FORMAT_SYMBOLS_H_
+
+#include "unicode/locid.h"
+#include "unicode/unistr.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class DateFormatSymbols final : public UObject {
+ public:
+  DateFormatSymbols(const Locale& locale, UErrorCode& status);
+  virtual ~DateFormatSymbols();
+
+  UnicodeString& getTimeSeparatorString(UnicodeString& result) const;
+
+ private:
+  Locale locale_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_DATE_FORMAT_SYMBOLS_H_

--- a/system_icu/include/unicode/dtitvfmt.h
+++ b/system_icu/include/unicode/dtitvfmt.h
@@ -1,0 +1,57 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_DATE_INTERVAL_FORMAT_H_
+#define V8_SYSTEM_ICU_DATE_INTERVAL_FORMAT_H_
+
+#include <string>
+
+#include "unicode/calendar.h"
+#include "unicode/formattedvalue.h"
+#include "unicode/locid.h"
+#include "unicode/udateintervalformat.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class FormattedDateInterval : public UMemory, public CFormattedValue {
+ public:
+  FormattedDateInterval();
+  explicit FormattedDateInterval(UFormattedDateInterval* result);
+  FormattedDateInterval(FormattedDateInterval&& other) noexcept;
+  FormattedDateInterval& operator=(FormattedDateInterval&& other) noexcept;
+  virtual ~FormattedDateInterval() override;
+
+ protected:
+  virtual const UFormattedValue* asUFormattedValue(
+      UErrorCode& status) const override;
+
+ private:
+  UFormattedDateInterval* result_;
+};
+
+class DateIntervalFormat : public UObject {
+ public:
+  static DateIntervalFormat* createInstance(const UnicodeString& skeleton,
+                                            const Locale& locale,
+                                            UErrorCode& status);
+  virtual ~DateIntervalFormat();
+
+  DateIntervalFormat* clone() const;
+  void setTimeZone(const TimeZone& zone);
+  FormattedDateInterval formatToValue(Calendar& from, Calendar& to,
+                                      UErrorCode& status) const;
+
+ private:
+  DateIntervalFormat(std::u16string skeleton, std::string locale,
+                     std::u16string time_zone, UErrorCode& status);
+  void reopen(UErrorCode& status);
+
+  UDateIntervalFormat* format_;
+  std::u16string skeleton_;
+  std::string locale_;
+  std::u16string time_zone_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_DATE_INTERVAL_FORMAT_H_

--- a/system_icu/include/unicode/dtptngen.h
+++ b/system_icu/include/unicode/dtptngen.h
@@ -1,0 +1,38 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_DATE_TIME_PATTERN_GENERATOR_H_
+#define V8_SYSTEM_ICU_DATE_TIME_PATTERN_GENERATOR_H_
+
+#include "unicode/locid.h"
+#include "unicode/udatpg.h"
+#include "unicode/unistr.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class DateTimePatternGenerator : public UObject {
+ public:
+  static DateTimePatternGenerator* createInstance(const Locale& locale,
+                                                  UErrorCode& status);
+  static UnicodeString staticGetSkeleton(const UnicodeString& pattern,
+                                         UErrorCode& status);
+
+  virtual ~DateTimePatternGenerator();
+  DateTimePatternGenerator* clone() const;
+
+  UnicodeString getBestPattern(const UnicodeString& skeleton,
+                               UDateTimePatternMatchOptions options,
+                               UErrorCode& status);
+  UDateFormatHourCycle getDefaultHourCycle(UErrorCode& status) const;
+  UnicodeString getFieldDisplayName(UDateTimePatternField field,
+                                    UDateTimePGDisplayWidth width) const;
+
+ private:
+  explicit DateTimePatternGenerator(UDateTimePatternGenerator* generator);
+
+  UDateTimePatternGenerator* generator_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_DATE_TIME_PATTERN_GENERATOR_H_

--- a/system_icu/include/unicode/fieldpos.h
+++ b/system_icu/include/unicode/fieldpos.h
@@ -1,0 +1,38 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_FIELD_POSITION_H_
+#define V8_SYSTEM_ICU_FIELD_POSITION_H_
+
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class FieldPosition : public UObject {
+ public:
+  enum {
+    DONT_CARE = -1,
+  };
+
+  FieldPosition() : field_(DONT_CARE), begin_index_(0), end_index_(0) {}
+  explicit FieldPosition(int32_t field)
+      : field_(field), begin_index_(0), end_index_(0) {}
+  FieldPosition(const FieldPosition&) = default;
+  FieldPosition& operator=(const FieldPosition&) = default;
+  virtual ~FieldPosition();
+
+  int32_t getField() const { return field_; }
+  int32_t getBeginIndex() const { return begin_index_; }
+  int32_t getEndIndex() const { return end_index_; }
+  void setField(int32_t value) { field_ = value; }
+  void setBeginIndex(int32_t value) { begin_index_ = value; }
+  void setEndIndex(int32_t value) { end_index_ = value; }
+
+ private:
+  int32_t field_;
+  int32_t begin_index_;
+  int32_t end_index_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_FIELD_POSITION_H_

--- a/system_icu/include/unicode/fmtable.h
+++ b/system_icu/include/unicode/fmtable.h
@@ -1,0 +1,34 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_FORMATTABLE_H_
+#define V8_SYSTEM_ICU_FORMATTABLE_H_
+
+#include <string>
+
+#include "unicode/stringpiece.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class Formattable : public UObject {
+ public:
+  Formattable();
+  explicit Formattable(double value);
+  Formattable(StringPiece decimal, UErrorCode& status);
+  Formattable(const Formattable& other);
+  Formattable& operator=(const Formattable& other);
+  virtual ~Formattable();
+
+  bool isDecimal() const { return is_decimal_; }
+  double getDouble() const { return double_value_; }
+  const std::string& getDecimal() const { return decimal_value_; }
+
+ private:
+  bool is_decimal_;
+  double double_value_;
+  std::string decimal_value_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_FORMATTABLE_H_

--- a/system_icu/include/unicode/formattedvalue.h
+++ b/system_icu/include/unicode/formattedvalue.h
@@ -1,0 +1,63 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_FORMATTED_VALUE_H_
+#define V8_SYSTEM_ICU_FORMATTED_VALUE_H_
+
+#include "unicode/appendable.h"
+#include "unicode/uformattedvalue.h"
+#include "unicode/unistr.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class ConstrainedFieldPosition : public UMemory {
+ public:
+  ConstrainedFieldPosition();
+  ~ConstrainedFieldPosition();
+
+  void reset();
+  void constrainCategory(int32_t category);
+  void constrainField(int32_t category, int32_t field);
+
+  int32_t getCategory() const;
+  int32_t getField() const;
+  int32_t getStart() const;
+  int32_t getLimit() const;
+
+  UConstrainedFieldPosition* toUConstrainedFieldPosition() const {
+    return field_position_;
+  }
+
+ private:
+  UConstrainedFieldPosition* field_position_;
+};
+
+class FormattedValue {
+ public:
+  virtual ~FormattedValue();
+
+  virtual UnicodeString toString(UErrorCode& status) const = 0;
+  virtual UnicodeString toTempString(UErrorCode& status) const = 0;
+  virtual Appendable& appendTo(Appendable& appendable,
+                               UErrorCode& status) const = 0;
+  virtual UBool nextPosition(ConstrainedFieldPosition& field_position,
+                             UErrorCode& status) const = 0;
+};
+
+class CFormattedValue : public FormattedValue {
+ public:
+  virtual UnicodeString toString(UErrorCode& status) const override;
+  virtual UnicodeString toTempString(UErrorCode& status) const override;
+  virtual Appendable& appendTo(Appendable& appendable,
+                               UErrorCode& status) const override;
+  virtual UBool nextPosition(ConstrainedFieldPosition& field_position,
+                             UErrorCode& status) const override;
+
+ protected:
+  virtual const UFormattedValue* asUFormattedValue(
+      UErrorCode& status) const = 0;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_FORMATTED_VALUE_H_

--- a/system_icu/include/unicode/fpositer.h
+++ b/system_icu/include/unicode/fpositer.h
@@ -1,0 +1,33 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_FIELD_POSITION_ITERATOR_H_
+#define V8_SYSTEM_ICU_FIELD_POSITION_ITERATOR_H_
+
+#include <memory>
+
+#include "unicode/fieldpos.h"
+#include "unicode/ufieldpositer.h"
+
+U_NAMESPACE_BEGIN
+
+class FieldPositionIterator : public UObject {
+ public:
+  FieldPositionIterator();
+  FieldPositionIterator(const FieldPositionIterator& other);
+  FieldPositionIterator& operator=(const FieldPositionIterator& other);
+  virtual ~FieldPositionIterator();
+
+  UBool next(FieldPosition& position);
+  UFieldPositionIterator* prepareForFormat(UErrorCode& status);
+  void adjustForReplacement(int32_t begin, int32_t end,
+                            int32_t replacement_length);
+
+ private:
+  struct State;
+  std::shared_ptr<State> state_;
+  size_t index_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_FIELD_POSITION_ITERATOR_H_

--- a/system_icu/include/unicode/gregocal.h
+++ b/system_icu/include/unicode/gregocal.h
@@ -1,0 +1,24 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_GREGORIAN_CALENDAR_H_
+#define V8_SYSTEM_ICU_GREGORIAN_CALENDAR_H_
+
+#include "unicode/calendar.h"
+
+U_NAMESPACE_BEGIN
+
+class GregorianCalendar : public Calendar {
+ public:
+  GregorianCalendar(UCalendar* calendar, const UnicodeString& time_zone_id);
+  virtual ~GregorianCalendar();
+
+  GregorianCalendar* clone() const override;
+  virtual UClassID getDynamicClassID() const override;
+  static UClassID getStaticClassID();
+
+  void setGregorianChange(UDate date, UErrorCode& status);
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_GREGORIAN_CALENDAR_H_

--- a/system_icu/include/unicode/listformatter.h
+++ b/system_icu/include/unicode/listformatter.h
@@ -1,0 +1,48 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_LIST_FORMATTER_H_
+#define V8_SYSTEM_ICU_LIST_FORMATTER_H_
+
+#include "unicode/formattedvalue.h"
+#include "unicode/locid.h"
+#include "unicode/ulistformatter.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class FormattedList : public UMemory, public CFormattedValue {
+ public:
+  FormattedList();
+  explicit FormattedList(UFormattedList* result);
+  FormattedList(FormattedList&& other) noexcept;
+  FormattedList& operator=(FormattedList&& other) noexcept;
+  virtual ~FormattedList() override;
+
+ protected:
+  virtual const UFormattedValue* asUFormattedValue(
+      UErrorCode& status) const override;
+
+ private:
+  UFormattedList* result_;
+};
+
+class ListFormatter : public UObject {
+ public:
+  explicit ListFormatter(UListFormatter* formatter);
+  virtual ~ListFormatter();
+
+  static ListFormatter* createInstance(const Locale& locale,
+                                       UListFormatterType type,
+                                       UListFormatterWidth width,
+                                       UErrorCode& status);
+  FormattedList formatStringsToValue(const UnicodeString items[],
+                                     int32_t item_count,
+                                     UErrorCode& status) const;
+
+ private:
+  UListFormatter* formatter_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_LIST_FORMATTER_H_

--- a/system_icu/include/unicode/localebuilder.h
+++ b/system_icu/include/unicode/localebuilder.h
@@ -1,0 +1,39 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_LOCALEBUILDER_H_
+#define V8_SYSTEM_ICU_LOCALEBUILDER_H_
+
+#include <string>
+
+#include "unicode/locid.h"
+#include "unicode/stringpiece.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class LocaleBuilder : public UObject {
+ public:
+  LocaleBuilder();
+  virtual ~LocaleBuilder();
+
+  LocaleBuilder& setLocale(const Locale& locale);
+  LocaleBuilder& setLanguageTag(StringPiece tag);
+  LocaleBuilder& setLanguage(StringPiece language);
+  LocaleBuilder& setScript(StringPiece script);
+  LocaleBuilder& setRegion(StringPiece region);
+  LocaleBuilder& setVariant(StringPiece variant);
+  LocaleBuilder& setUnicodeLocaleKeyword(StringPiece key, StringPiece value);
+  LocaleBuilder& clearExtensions();
+
+  Locale build(UErrorCode& status);
+
+ private:
+  void setComponent(StringPiece value, int component);
+
+  std::string locale_id_;
+  UErrorCode error_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_LOCALEBUILDER_H_

--- a/system_icu/include/unicode/localematcher.h
+++ b/system_icu/include/unicode/localematcher.h
@@ -1,0 +1,78 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_LOCALE_MATCHER_H_
+#define V8_SYSTEM_ICU_LOCALE_MATCHER_H_
+
+#include <vector>
+
+#include "unicode/locid.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class LocaleMatcher : public UMemory {
+ public:
+  class Result : public UMemory {
+   public:
+    Result(Result&& other) noexcept;
+    Result& operator=(Result&& other) noexcept;
+    ~Result();
+
+    int32_t getSupportedIndex() const { return supported_index_; }
+    int32_t getDesiredIndex() const { return desired_index_; }
+    Locale makeResolvedLocale(UErrorCode& status) const;
+
+   private:
+    Result(const Locale& desired, const Locale& supported,
+           int32_t desired_index, int32_t supported_index, bool has_desired,
+           bool has_supported);
+
+    Locale desired_;
+    Locale supported_;
+    int32_t desired_index_;
+    int32_t supported_index_;
+    bool has_desired_;
+    bool has_supported_;
+
+    friend class LocaleMatcher;
+  };
+
+  class Builder : public UMemory {
+   public:
+    Builder();
+    ~Builder();
+
+    Builder& addSupportedLocale(const Locale& locale);
+    Builder& setDefaultLocale(const Locale* locale);
+    LocaleMatcher build(UErrorCode& status) const;
+
+   private:
+    std::vector<Locale> supported_;
+    Locale default_;
+    bool has_default_;
+  };
+
+  LocaleMatcher(LocaleMatcher&& other) noexcept;
+  LocaleMatcher& operator=(LocaleMatcher&& other) noexcept;
+  ~LocaleMatcher();
+
+  Result getBestMatchResult(const Locale& desired, UErrorCode& status) const;
+  Result getBestMatchResult(Locale::Iterator& desired,
+                            UErrorCode& status) const;
+
+ private:
+  LocaleMatcher(const std::vector<Locale>& supported,
+                const Locale& default_locale, bool has_default);
+
+  Result match(const Locale& desired, int32_t desired_index) const;
+
+  std::vector<Locale> supported_;
+  Locale default_;
+  bool has_default_;
+
+  friend class Builder;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_LOCALE_MATCHER_H_

--- a/system_icu/include/unicode/locdspnm.h
+++ b/system_icu/include/unicode/locdspnm.h
@@ -1,0 +1,39 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_LOCALE_DISPLAY_NAMES_H_
+#define V8_SYSTEM_ICU_LOCALE_DISPLAY_NAMES_H_
+
+#include "unicode/locid.h"
+#include "unicode/uldnames.h"
+#include "unicode/unistr.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class LocaleDisplayNames : public UObject {
+ public:
+  static LocaleDisplayNames* createInstance(const Locale& locale,
+                                            UDisplayContext* contexts,
+                                            int32_t length);
+  virtual ~LocaleDisplayNames();
+
+  const Locale& getLocale() const { return locale_; }
+  UnicodeString& localeDisplayName(const char* locale,
+                                   UnicodeString& result) const;
+  UnicodeString& scriptDisplayName(const char* script,
+                                   UnicodeString& result) const;
+  UnicodeString& regionDisplayName(const char* region,
+                                   UnicodeString& result) const;
+  UnicodeString& keyValueDisplayName(const char* key, const char* value,
+                                     UnicodeString& result) const;
+
+ private:
+  LocaleDisplayNames(ULocaleDisplayNames* names, const Locale& locale);
+
+  ULocaleDisplayNames* names_;
+  Locale locale_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_LOCALE_DISPLAY_NAMES_H_

--- a/system_icu/include/unicode/locid.h
+++ b/system_icu/include/unicode/locid.h
@@ -1,0 +1,9 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_LOCALE_ID_OVERLAY_H_
+#define V8_SYSTEM_ICU_LOCALE_ID_OVERLAY_H_
+
+#include_next "unicode/locid.h"
+#include "unicode/uloc_compat.h"
+
+#endif  // V8_SYSTEM_ICU_LOCALE_ID_OVERLAY_H_

--- a/system_icu/include/unicode/measunit.h
+++ b/system_icu/include/unicode/measunit.h
@@ -1,0 +1,54 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_MEASURE_UNIT_H_
+#define V8_SYSTEM_ICU_MEASURE_UNIT_H_
+
+#include <string>
+
+#include "unicode/uobject.h"
+#include "unicode/utypes.h"
+
+U_NAMESPACE_BEGIN
+
+class MeasureUnit : public UObject {
+ public:
+  MeasureUnit();
+  MeasureUnit(const MeasureUnit& other);
+  MeasureUnit(MeasureUnit&& other) noexcept;
+  MeasureUnit& operator=(const MeasureUnit& other);
+  MeasureUnit& operator=(MeasureUnit&& other) noexcept;
+  virtual ~MeasureUnit();
+
+  MeasureUnit(const char* type, const char* subtype);
+
+  virtual bool operator==(const UObject& other) const;
+  bool operator!=(const UObject& other) const { return !(*this == other); }
+
+  const char* getType() const;
+  const char* getSubtype() const;
+  const char* getIdentifier() const;
+
+  static int32_t getAvailable(MeasureUnit* destination, int32_t capacity,
+                              UErrorCode& status);
+
+  static MeasureUnit getPercent();
+  static MeasureUnit getPermille();
+  static MeasureUnit getYear();
+  static MeasureUnit getMonth();
+  static MeasureUnit getWeek();
+  static MeasureUnit getDay();
+  static MeasureUnit getHour();
+  static MeasureUnit getMinute();
+  static MeasureUnit getSecond();
+  static MeasureUnit getMillisecond();
+  static MeasureUnit getMicrosecond();
+  static MeasureUnit getNanosecond();
+
+ private:
+  std::string type_;
+  std::string subtype_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_MEASURE_UNIT_H_

--- a/system_icu/include/unicode/normalizer2.h
+++ b/system_icu/include/unicode/normalizer2.h
@@ -1,0 +1,33 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_NORMALIZER2_H_
+#define V8_SYSTEM_ICU_NORMALIZER2_H_
+
+#include "unicode/unistr.h"
+#include "unicode/unorm2.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class Normalizer2 : public UMemory {
+ public:
+  static const Normalizer2* getInstance(const char* package_name,
+                                        const char* name,
+                                        UNormalization2Mode mode,
+                                        UErrorCode& status);
+
+  int32_t spanQuickCheckYes(const UnicodeString& input,
+                            UErrorCode& status) const;
+  UnicodeString& normalizeSecondAndAppend(UnicodeString& first,
+                                          const UnicodeString& second,
+                                          UErrorCode& status) const;
+
+ private:
+  explicit Normalizer2(const UNormalizer2* normalizer);
+
+  const UNormalizer2* normalizer_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_NORMALIZER2_H_

--- a/system_icu/include/unicode/numberformatter.h
+++ b/system_icu/include/unicode/numberformatter.h
@@ -1,0 +1,305 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_NUMBER_FORMATTER_H_
+#define V8_SYSTEM_ICU_NUMBER_FORMATTER_H_
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "unicode/formattedvalue.h"
+#include "unicode/locid.h"
+#include "unicode/measunit.h"
+#include "unicode/numsys.h"
+#include "unicode/stringpiece.h"
+#include "unicode/uformattednumber.h"
+#include "unicode/unum.h"
+#include "unicode/unumberformatter.h"
+
+U_NAMESPACE_BEGIN
+namespace number {
+
+namespace impl {
+
+struct NumberFormatterOptions {
+  std::string raw_skeleton;
+  std::string locale;
+  std::string numbering_system;
+  std::string unit_type;
+  std::string unit;
+  std::string per_unit;
+  std::string precision;
+  std::string notation;
+  std::string rounding_mode;
+  std::string grouping;
+  std::string sign;
+  int32_t integer_width = 0;
+  int32_t unit_width = UNUM_UNIT_WIDTH_SHORT;
+  int32_t scale = 0;
+  bool has_unit_width = false;
+  bool has_scale = false;
+};
+
+struct NumberFormatterState;
+
+UnicodeString BuildSkeleton(const NumberFormatterOptions& options,
+                            UErrorCode& status);
+const char* RoundingModeStem(UNumberFormatRoundingMode mode);
+const char* GroupingStem(UNumberGroupingStrategy grouping);
+const char* SignStem(UNumberSignDisplay sign);
+const char* UnitWidthStem(UNumberUnitWidth width);
+
+}  // namespace impl
+
+class Notation {
+ public:
+  static Notation simple();
+  static Notation scientific();
+  static Notation engineering();
+  static Notation compactShort();
+  static Notation compactLong();
+
+  const std::string& stem() const { return stem_; }
+
+ private:
+  explicit Notation(const char* stem) : stem_(stem) {}
+  std::string stem_;
+};
+
+class Precision {
+ public:
+  static Precision unlimited();
+  static class FractionPrecision minMaxFraction(int32_t minimum,
+                                                int32_t maximum);
+  static Precision minMaxSignificantDigits(int32_t minimum, int32_t maximum);
+  static class IncrementPrecision incrementExact(uint64_t mantissa,
+                                                 int16_t magnitude);
+
+  Precision trailingZeroDisplay(UNumberTrailingZeroDisplay display) const;
+
+  const std::string& stem() const { return stem_; }
+
+  explicit Precision(std::string stem) : stem_(std::move(stem)) {}
+
+ protected:
+  std::string stem_;
+};
+
+class FractionPrecision : public Precision {
+ public:
+  explicit FractionPrecision(std::string stem) : Precision(std::move(stem)) {}
+
+  Precision withSignificantDigits(int32_t minimum, int32_t maximum,
+                                  UNumberRoundingPriority priority) const;
+};
+
+class IncrementPrecision : public Precision {
+ public:
+  explicit IncrementPrecision(std::string stem) : Precision(std::move(stem)) {}
+
+  Precision withMinFraction(int32_t minimum) const;
+};
+
+class IntegerWidth {
+ public:
+  static IntegerWidth zeroFillTo(int32_t minimum);
+
+  int32_t minimum() const { return minimum_; }
+
+ private:
+  explicit IntegerWidth(int32_t minimum) : minimum_(minimum) {}
+  int32_t minimum_;
+};
+
+class Scale {
+ public:
+  static Scale powerOfTen(int32_t power);
+
+  int32_t power() const { return power_; }
+
+ private:
+  explicit Scale(int32_t power) : power_(power) {}
+  int32_t power_;
+};
+
+class UnlocalizedNumberFormatter;
+class LocalizedNumberFormatter;
+
+template <typename Derived>
+class NumberFormatterSettings {
+ public:
+  Derived adoptSymbols(NumberingSystem* numbering_system) const {
+    Derived result(static_cast<const Derived&>(*this));
+    if (numbering_system != nullptr) {
+      result.options_.numbering_system = numbering_system->getName();
+    }
+    delete numbering_system;
+    result.clearHandle();
+    return result;
+  }
+
+  Derived unit(const MeasureUnit& unit) const {
+    Derived result(static_cast<const Derived&>(*this));
+    result.options_.unit_type = unit.getType();
+    result.options_.unit = unit.getIdentifier();
+    result.clearHandle();
+    return result;
+  }
+
+  Derived perUnit(const MeasureUnit& unit) const {
+    Derived result(static_cast<const Derived&>(*this));
+    result.options_.per_unit = unit.getIdentifier();
+    result.clearHandle();
+    return result;
+  }
+
+  Derived unitWidth(UNumberUnitWidth width) const {
+    Derived result(static_cast<const Derived&>(*this));
+    result.options_.unit_width = width;
+    result.options_.has_unit_width = true;
+    result.clearHandle();
+    return result;
+  }
+
+  Derived notation(const Notation& notation) const {
+    Derived result(static_cast<const Derived&>(*this));
+    result.options_.notation = notation.stem();
+    result.clearHandle();
+    return result;
+  }
+
+  Derived precision(const Precision& precision) const {
+    Derived result(static_cast<const Derived&>(*this));
+    result.options_.precision = precision.stem();
+    result.clearHandle();
+    return result;
+  }
+
+  Derived integerWidth(const IntegerWidth& width) const {
+    Derived result(static_cast<const Derived&>(*this));
+    result.options_.integer_width = width.minimum();
+    result.clearHandle();
+    return result;
+  }
+
+  Derived roundingMode(UNumberFormatRoundingMode mode) const {
+    Derived result(static_cast<const Derived&>(*this));
+    result.options_.rounding_mode = impl::RoundingModeStem(mode);
+    result.clearHandle();
+    return result;
+  }
+
+  Derived grouping(UNumberGroupingStrategy grouping) const {
+    Derived result(static_cast<const Derived&>(*this));
+    result.options_.grouping = impl::GroupingStem(grouping);
+    result.clearHandle();
+    return result;
+  }
+
+  Derived sign(UNumberSignDisplay sign) const {
+    Derived result(static_cast<const Derived&>(*this));
+    result.options_.sign = impl::SignStem(sign);
+    result.clearHandle();
+    return result;
+  }
+
+  Derived scale(const Scale& scale) const {
+    Derived result(static_cast<const Derived&>(*this));
+    result.options_.scale = scale.power();
+    result.options_.has_scale = true;
+    result.clearHandle();
+    return result;
+  }
+
+  UnicodeString toSkeleton(UErrorCode& status) const {
+    return impl::BuildSkeleton(options_, status);
+  }
+
+ protected:
+  NumberFormatterSettings() = default;
+  explicit NumberFormatterSettings(const impl::NumberFormatterOptions& options)
+      : options_(options) {}
+
+  impl::NumberFormatterOptions options_;
+
+  friend class UnlocalizedNumberFormatter;
+  friend class LocalizedNumberFormatter;
+};
+
+class FormattedNumber : public UMemory, public CFormattedValue {
+ public:
+  FormattedNumber();
+  FormattedNumber(UFormattedNumber* result, bool use_fullwidth_yen);
+  FormattedNumber(FormattedNumber&& other) noexcept;
+  FormattedNumber& operator=(FormattedNumber&& other) noexcept;
+  virtual ~FormattedNumber() override;
+
+  const UFormattedNumber* toUFormattedNumber() const { return result_; }
+  virtual UnicodeString toString(UErrorCode& status) const override;
+
+ protected:
+  virtual const UFormattedValue* asUFormattedValue(
+      UErrorCode& status) const override;
+
+ private:
+  UFormattedNumber* result_;
+  bool use_fullwidth_yen_;
+};
+
+class LocalizedNumberFormatter
+    : public NumberFormatterSettings<LocalizedNumberFormatter>,
+      public UMemory {
+ public:
+  LocalizedNumberFormatter();
+  LocalizedNumberFormatter(const LocalizedNumberFormatter& other);
+  LocalizedNumberFormatter(LocalizedNumberFormatter&& other) noexcept;
+  LocalizedNumberFormatter& operator=(const LocalizedNumberFormatter& other);
+  LocalizedNumberFormatter& operator=(
+      LocalizedNumberFormatter&& other) noexcept;
+  ~LocalizedNumberFormatter();
+
+  FormattedNumber formatInt(int64_t value, UErrorCode& status) const;
+  FormattedNumber formatDouble(double value, UErrorCode& status) const;
+  FormattedNumber formatDecimal(StringPiece value, UErrorCode& status) const;
+
+  void clearHandle();
+
+ private:
+  explicit LocalizedNumberFormatter(
+      const impl::NumberFormatterOptions& options);
+  UNumberFormatter* getFormatter(UErrorCode& status) const;
+
+  mutable std::shared_ptr<impl::NumberFormatterState> state_;
+
+  friend class UnlocalizedNumberFormatter;
+};
+
+class UnlocalizedNumberFormatter
+    : public NumberFormatterSettings<UnlocalizedNumberFormatter> {
+ public:
+  UnlocalizedNumberFormatter() = default;
+
+  LocalizedNumberFormatter locale(const Locale& locale) const;
+  void clearHandle() {}
+
+ private:
+  explicit UnlocalizedNumberFormatter(
+      const impl::NumberFormatterOptions& options)
+      : NumberFormatterSettings(options) {}
+
+  friend class NumberFormatter;
+};
+
+class NumberFormatter {
+ public:
+  static UnlocalizedNumberFormatter forSkeleton(const UnicodeString& skeleton,
+                                                UParseError& parse_error,
+                                                UErrorCode& status);
+};
+
+}  // namespace number
+U_NAMESPACE_END
+
+#include "unicode/ucurr_compat.h"
+
+#endif  // V8_SYSTEM_ICU_NUMBER_FORMATTER_H_

--- a/system_icu/include/unicode/numberrangeformatter.h
+++ b/system_icu/include/unicode/numberrangeformatter.h
@@ -1,0 +1,79 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_NUMBER_RANGE_FORMATTER_H_
+#define V8_SYSTEM_ICU_NUMBER_RANGE_FORMATTER_H_
+
+#include <string>
+
+#include "unicode/fmtable.h"
+#include "unicode/formattedvalue.h"
+#include "unicode/numberformatter.h"
+#include "unicode/unumberrangeformatter.h"
+
+U_NAMESPACE_BEGIN
+namespace number {
+
+class FormattedNumberRange : public UMemory, public CFormattedValue {
+ public:
+  FormattedNumberRange();
+  FormattedNumberRange(UFormattedNumberRange* result, bool use_fullwidth_yen);
+  FormattedNumberRange(FormattedNumberRange&& other) noexcept;
+  FormattedNumberRange& operator=(FormattedNumberRange&& other) noexcept;
+  virtual ~FormattedNumberRange() override;
+
+  const UFormattedNumberRange* toUFormattedNumberRange() const {
+    return result_;
+  }
+  virtual UnicodeString toString(UErrorCode& status) const override;
+
+ protected:
+  virtual const UFormattedValue* asUFormattedValue(
+      UErrorCode& status) const override;
+
+ private:
+  UFormattedNumberRange* result_;
+  bool use_fullwidth_yen_;
+};
+
+class LocalizedNumberRangeFormatter {
+ public:
+  LocalizedNumberRangeFormatter();
+  LocalizedNumberRangeFormatter(const LocalizedNumberRangeFormatter& other);
+  LocalizedNumberRangeFormatter(LocalizedNumberRangeFormatter&& other) noexcept;
+  LocalizedNumberRangeFormatter& operator=(
+      const LocalizedNumberRangeFormatter& other);
+  LocalizedNumberRangeFormatter& operator=(
+      LocalizedNumberRangeFormatter&& other) noexcept;
+  ~LocalizedNumberRangeFormatter();
+
+  FormattedNumberRange formatFormattableRange(const Formattable& first,
+                                              const Formattable& second,
+                                              UErrorCode& status) const;
+
+ private:
+  LocalizedNumberRangeFormatter(std::u16string skeleton, std::string locale);
+
+  std::u16string skeleton_;
+  std::string locale_;
+
+  friend class UnlocalizedNumberRangeFormatter;
+};
+
+class UnlocalizedNumberRangeFormatter {
+ public:
+  UnlocalizedNumberRangeFormatter() = default;
+
+  UnlocalizedNumberRangeFormatter numberFormatterBoth(
+      UnlocalizedNumberFormatter&& formatter) const;
+  LocalizedNumberRangeFormatter locale(const Locale& locale) const;
+
+ private:
+  std::u16string skeleton_;
+};
+
+class NumberRangeFormatter {};
+
+}  // namespace number
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_NUMBER_RANGE_FORMATTER_H_

--- a/system_icu/include/unicode/numfmt.h
+++ b/system_icu/include/unicode/numfmt.h
@@ -1,0 +1,33 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_NUMBER_FORMAT_H_
+#define V8_SYSTEM_ICU_NUMBER_FORMAT_H_
+
+#include "unicode/locid.h"
+#include "unicode/unum.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class NumberFormat : public UObject {
+ public:
+  explicit NumberFormat(UNumberFormat* formatter);
+  virtual ~NumberFormat();
+
+  static NumberFormat* createInstance(const Locale& locale,
+                                      UNumberFormatStyle style,
+                                      UErrorCode& status);
+
+  virtual UClassID getDynamicClassID() const override;
+  static UClassID getStaticClassID();
+
+  UNumberFormat* toUNumberFormat() const { return formatter_; }
+  UNumberFormat* orphanUNumberFormat();
+
+ protected:
+  UNumberFormat* formatter_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_NUMBER_FORMAT_H_

--- a/system_icu/include/unicode/numsys.h
+++ b/system_icu/include/unicode/numsys.h
@@ -1,0 +1,37 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_NUMBERING_SYSTEM_H_
+#define V8_SYSTEM_ICU_NUMBERING_SYSTEM_H_
+
+#include "unicode/locid.h"
+#include "unicode/strenum.h"
+#include "unicode/unumsys.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+constexpr const size_t kInternalNumSysNameCapacity = 8;
+
+class NumberingSystem : public UMemory {
+ public:
+  explicit NumberingSystem(UNumberingSystem* numbering_system);
+  virtual ~NumberingSystem();
+
+  static NumberingSystem* createInstance(const Locale& locale,
+                                         UErrorCode& status);
+  static NumberingSystem* createInstanceByName(const char* name,
+                                               UErrorCode& status);
+  static StringEnumeration* getAvailableNames(UErrorCode& status);
+
+  const char* getName() const;
+  UBool isAlgorithmic() const;
+
+  UNumberingSystem* toUNumberingSystem() const { return numbering_system_; }
+
+ private:
+  UNumberingSystem* numbering_system_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_NUMBERING_SYSTEM_H_

--- a/system_icu/include/unicode/plurrule.h
+++ b/system_icu/include/unicode/plurrule.h
@@ -1,0 +1,37 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_PLURAL_RULES_H_
+#define V8_SYSTEM_ICU_PLURAL_RULES_H_
+
+#include "unicode/locid.h"
+#include "unicode/numberformatter.h"
+#include "unicode/numberrangeformatter.h"
+#include "unicode/strenum.h"
+#include "unicode/uobject.h"
+#include "unicode/upluralrules.h"
+
+U_NAMESPACE_BEGIN
+
+class PluralRules : public UObject {
+ public:
+  static PluralRules* forLocale(const Locale& locale, UPluralType type,
+                                UErrorCode& status);
+  static StringEnumeration* getAvailableLocales(UErrorCode& status);
+
+  virtual ~PluralRules();
+
+  UnicodeString select(const number::FormattedNumber& number,
+                       UErrorCode& status) const;
+  UnicodeString select(const number::FormattedNumberRange& range,
+                       UErrorCode& status) const;
+  StringEnumeration* getKeywords(UErrorCode& status) const;
+
+ private:
+  explicit PluralRules(UPluralRules* rules);
+
+  UPluralRules* rules_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_PLURAL_RULES_H_

--- a/system_icu/include/unicode/reldatefmt.h
+++ b/system_icu/include/unicode/reldatefmt.h
@@ -1,0 +1,55 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_RELATIVE_DATE_TIME_FORMATTER_H_
+#define V8_SYSTEM_ICU_RELATIVE_DATE_TIME_FORMATTER_H_
+
+#include "unicode/formattedvalue.h"
+#include "unicode/locid.h"
+#include "unicode/numfmt.h"
+#include "unicode/uobject.h"
+#include "unicode/ureldatefmt.h"
+
+U_NAMESPACE_BEGIN
+
+class FormattedRelativeDateTime : public UMemory, public CFormattedValue {
+ public:
+  FormattedRelativeDateTime();
+  explicit FormattedRelativeDateTime(UFormattedRelativeDateTime* result);
+  FormattedRelativeDateTime(FormattedRelativeDateTime&& other) noexcept;
+  FormattedRelativeDateTime& operator=(
+      FormattedRelativeDateTime&& other) noexcept;
+  virtual ~FormattedRelativeDateTime() override;
+
+ protected:
+  virtual const UFormattedValue* asUFormattedValue(
+      UErrorCode& status) const override;
+
+ private:
+  UFormattedRelativeDateTime* result_;
+};
+
+class RelativeDateTimeFormatter : public UObject {
+ public:
+  RelativeDateTimeFormatter(const Locale& locale,
+                            NumberFormat* number_format_to_adopt,
+                            UDateRelativeDateTimeFormatterStyle style,
+                            UDisplayContext capitalization_context,
+                            UErrorCode& status);
+  virtual ~RelativeDateTimeFormatter();
+
+  FormattedRelativeDateTime formatNumericToValue(double offset,
+                                                 URelativeDateTimeUnit unit,
+                                                 UErrorCode& status) const;
+  FormattedRelativeDateTime formatToValue(double offset,
+                                          URelativeDateTimeUnit unit,
+                                          UErrorCode& status) const;
+  UDateRelativeDateTimeFormatterStyle getFormatStyle() const;
+
+ private:
+  URelativeDateTimeFormatter* formatter_;
+  UDateRelativeDateTimeFormatterStyle style_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_RELATIVE_DATE_TIME_FORMATTER_H_

--- a/system_icu/include/unicode/smpdtfmt.h
+++ b/system_icu/include/unicode/smpdtfmt.h
@@ -1,0 +1,28 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_SIMPLE_DATE_FORMAT_H_
+#define V8_SYSTEM_ICU_SIMPLE_DATE_FORMAT_H_
+
+#include "unicode/datefmt.h"
+
+U_NAMESPACE_BEGIN
+
+class SimpleDateFormat : public DateFormat {
+ public:
+  SimpleDateFormat(const UnicodeString& pattern, const Locale& locale,
+                   UErrorCode& status);
+  virtual ~SimpleDateFormat() override;
+
+  virtual SimpleDateFormat* clone() const override;
+  UnicodeString& toPattern(UnicodeString& result) const;
+  const Locale& getSmpFmtLocale() const;
+
+ private:
+  SimpleDateFormat(UDateFormat* format, const Locale& locale);
+
+  friend class DateFormat;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_SIMPLE_DATE_FORMAT_H_

--- a/system_icu/include/unicode/strenum.h
+++ b/system_icu/include/unicode/strenum.h
@@ -1,0 +1,28 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_STRINGENUMERATION_H_
+#define V8_SYSTEM_ICU_STRINGENUMERATION_H_
+
+#include "unicode/uenum.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class StringEnumeration : public UMemory {
+ public:
+  explicit StringEnumeration(UEnumeration* enumeration);
+  virtual ~StringEnumeration();
+
+  const char* next(int32_t* result_length, UErrorCode& status);
+  int32_t count(UErrorCode& status) const;
+  void reset(UErrorCode& status);
+
+  UEnumeration* toUEnumeration() const { return enumeration_; }
+
+ private:
+  UEnumeration* enumeration_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_STRINGENUMERATION_H_

--- a/system_icu/include/unicode/timezone.h
+++ b/system_icu/include/unicode/timezone.h
@@ -1,0 +1,62 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_TIME_ZONE_H_
+#define V8_SYSTEM_ICU_TIME_ZONE_H_
+
+#include "unicode/strenum.h"
+#include "unicode/ucal.h"
+#include "unicode/unistr.h"
+#include "unicode/uobject.h"
+
+U_NAMESPACE_BEGIN
+
+class TimeZone : public UObject {
+ public:
+  enum EDisplayType {
+    SHORT = 1,
+    LONG = 2,
+    SHORT_GENERIC = 3,
+    LONG_GENERIC = 4,
+    SHORT_GMT = 5,
+    LONG_GMT = 6,
+    SHORT_COMMONLY_USED = 7,
+    GENERIC_LOCATION = 8,
+  };
+
+  explicit TimeZone(const UnicodeString& id);
+  TimeZone(const TimeZone& other);
+  TimeZone& operator=(const TimeZone& other);
+  virtual ~TimeZone();
+
+  virtual TimeZone* clone() const;
+  virtual bool operator==(const TimeZone& other) const;
+
+  static TimeZone* createTimeZone(const UnicodeString& id);
+  static TimeZone* createDefault();
+  static TimeZone* detectHostTimeZone();
+  static void adoptDefault(TimeZone* zone);
+  static const TimeZone* getGMT();
+
+  static StringEnumeration* createEnumeration();
+  static StringEnumeration* createTimeZoneIDEnumeration(
+      USystemTimeZoneType zone_type, const char* region,
+      const int32_t* raw_offset, UErrorCode& status);
+  static UnicodeString& getCanonicalID(const UnicodeString& id,
+                                       UnicodeString& canonical,
+                                       UErrorCode& status);
+
+  UnicodeString& getID(UnicodeString& id) const;
+  void getDisplayName(UBool daylight, EDisplayType style,
+                      UnicodeString& result) const;
+  virtual void getOffset(UDate date, UBool local, int32_t& raw_offset,
+                         int32_t& dst_offset, UErrorCode& status) const;
+
+ protected:
+  UCalendar* openCalendar(UErrorCode& status) const;
+
+  UnicodeString id_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_TIME_ZONE_H_

--- a/system_icu/include/unicode/tztrans.h
+++ b/system_icu/include/unicode/tztrans.h
@@ -1,0 +1,23 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_TIME_ZONE_TRANSITION_H_
+#define V8_SYSTEM_ICU_TIME_ZONE_TRANSITION_H_
+
+#include "unicode/utypes.h"
+
+U_NAMESPACE_BEGIN
+
+class TimeZoneTransition {
+ public:
+  TimeZoneTransition() : time_(0) {}
+
+  UDate getTime() const { return time_; }
+  void setTime(UDate time) { time_ = time; }
+
+ private:
+  UDate time_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_TIME_ZONE_TRANSITION_H_

--- a/system_icu/include/unicode/ucurr.h
+++ b/system_icu/include/unicode/ucurr.h
@@ -1,0 +1,9 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_UCURR_OVERLAY_H_
+#define V8_SYSTEM_ICU_UCURR_OVERLAY_H_
+
+#include_next "unicode/ucurr.h"
+#include "unicode/ucurr_compat.h"
+
+#endif  // V8_SYSTEM_ICU_UCURR_OVERLAY_H_

--- a/system_icu/include/unicode/ucurr_compat.h
+++ b/system_icu/include/unicode/ucurr_compat.h
@@ -1,0 +1,16 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_UCURR_COMPAT_H_
+#define V8_SYSTEM_ICU_UCURR_COMPAT_H_
+
+#include "unicode/utypes.h"
+
+#if defined(USING_SYSTEM_ICU)
+U_CAPI int32_t U_EXPORT2 v8_icu_compat_ucurr_getDefaultFractionDigits(
+    const UChar* currency, UErrorCode* status);
+
+#define ucurr_getDefaultFractionDigits \
+  v8_icu_compat_ucurr_getDefaultFractionDigits
+#endif
+
+#endif  // V8_SYSTEM_ICU_UCURR_COMPAT_H_

--- a/system_icu/include/unicode/uloc_compat.h
+++ b/system_icu/include/unicode/uloc_compat.h
@@ -1,0 +1,13 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_ULOC_COMPAT_H_
+#define V8_SYSTEM_ICU_ULOC_COMPAT_H_
+
+#if defined(USING_SYSTEM_ICU)
+U_CAPI UEnumeration* U_EXPORT2 v8_icu_compat_uloc_openAvailableByType(
+    ULocAvailableType type, UErrorCode* status);
+
+#define uloc_openAvailableByType v8_icu_compat_uloc_openAvailableByType
+#endif
+
+#endif  // V8_SYSTEM_ICU_ULOC_COMPAT_H_

--- a/system_icu/include/unicode/uniset.h
+++ b/system_icu/include/unicode/uniset.h
@@ -1,0 +1,51 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_UNICODESET_H_
+#define V8_SYSTEM_ICU_UNICODESET_H_
+
+#include "unicode/uset.h"
+#include "unicode/utypes.h"
+
+U_NAMESPACE_BEGIN
+
+class UnicodeString;
+
+// Source-compatible subset of ICU's C++ UnicodeSet used by V8. The object is
+// entirely ours; only its opaque USet handle crosses into libicucore.
+class UnicodeSet final {
+ public:
+  UnicodeSet();
+  UnicodeSet(UChar32 start, UChar32 end);
+  UnicodeSet(const UnicodeString& pattern, UErrorCode& status);
+  UnicodeSet(const UnicodeSet& other);
+  ~UnicodeSet();
+
+  UnicodeSet& operator=(const UnicodeSet& other);
+
+  UnicodeSet& set(UChar32 start, UChar32 end);
+  UnicodeSet& add(UChar32 code_point);
+  UnicodeSet& add(UChar32 start, UChar32 end);
+  UnicodeSet& removeAll(const UnicodeSet& other);
+  UnicodeSet& closeOver(int32_t attributes);
+  UnicodeSet& applyIntPropertyValue(UProperty property, int32_t value,
+                                    UErrorCode& status);
+  UnicodeSet& complement();
+  UnicodeSet& removeAllStrings();
+  UnicodeSet& freeze();
+
+  bool contains(UChar32 code_point) const;
+  bool isEmpty() const;
+  bool hasStrings() const;
+  int32_t size() const;
+  int32_t getRangeCount() const;
+  UChar32 getRangeStart(int32_t index) const;
+  UChar32 getRangeEnd(int32_t index) const;
+
+ private:
+  friend class UnicodeSetIterator;
+  USet* set_;
+};
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_UNICODESET_H_

--- a/system_icu/include/unicode/ures.h
+++ b/system_icu/include/unicode/ures.h
@@ -1,0 +1,18 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_URES_OVERLAY_H_
+#define V8_SYSTEM_ICU_URES_OVERLAY_H_
+
+#include_next "unicode/ures.h"
+
+#if defined(USING_SYSTEM_ICU)
+U_CAPI UResourceBundle* U_EXPORT2 v8_icu_compat_ures_open(
+    const char* package_name, const char* locale, UErrorCode* status);
+
+// Apple exposes ICU's locale resources through the default package but does
+// not expose ICU's versioned "icudtNNl-coll" package name. Keep V8's resource
+// validation source-compatible and translate that package in the façade.
+#define ures_open v8_icu_compat_ures_open
+#endif
+
+#endif  // V8_SYSTEM_ICU_URES_OVERLAY_H_

--- a/system_icu/include/unicode/usetiter.h
+++ b/system_icu/include/unicode/usetiter.h
@@ -1,0 +1,35 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_UNICODESETITERATOR_H_
+#define V8_SYSTEM_ICU_UNICODESETITERATOR_H_
+
+#include "unicode/uniset.h"
+#include "unicode/unistr.h"
+
+U_NAMESPACE_BEGIN
+
+class UnicodeSetIterator final {
+ public:
+  explicit UnicodeSetIterator(const UnicodeSet& set);
+  ~UnicodeSetIterator();
+
+  UnicodeSetIterator& skipToStrings();
+  UBool next();
+  const UnicodeString& getString();
+
+ private:
+  const UnicodeSet* set_;
+  int32_t string_index_;
+  bool strings_only_;
+  UnicodeString current_;
+};
+
+inline UnicodeSetIterator& UnicodeSetIterator::skipToStrings() {
+  strings_only_ = true;
+  string_index_ = 0;
+  return *this;
+}
+
+U_NAMESPACE_END
+
+#endif  // V8_SYSTEM_ICU_UNICODESETITERATOR_H_

--- a/system_icu/include/unicode/uversion.h
+++ b/system_icu/include/unicode/uversion.h
@@ -1,0 +1,36 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#ifndef V8_SYSTEM_ICU_UVERSION_OVERLAY_H_
+#define V8_SYSTEM_ICU_UVERSION_OVERLAY_H_
+
+#include_next "unicode/uversion.h"
+
+#if defined(__cplusplus) && defined(USING_SYSTEM_ICU)
+// Keep all C++ façade symbols in a namespace that cannot bind to Apple's
+// private ICU C++ ABI. The C entry points remain unsuffixed because
+// U_DISABLE_RENAMING is set by the system ICU build config.
+#undef U_ICU_NAMESPACE
+#define U_ICU_NAMESPACE v8_icu_compat
+
+#undef U_NAMESPACE_BEGIN
+#undef U_NAMESPACE_END
+#undef U_NAMESPACE_USE
+#undef U_NAMESPACE_QUALIFIER
+#define U_NAMESPACE_BEGIN namespace U_ICU_NAMESPACE {
+#define U_NAMESPACE_END }
+#define U_NAMESPACE_USE using namespace U_ICU_NAMESPACE;
+#define U_NAMESPACE_QUALIFIER U_ICU_NAMESPACE::
+
+namespace U_ICU_NAMESPACE {}
+
+// V8 consistently spells the public namespace `icu`. A macro is necessary
+// here because the upstream header has already declared an empty namespace
+// with that name, which prevents creating a namespace alias.
+#define icu U_ICU_NAMESPACE
+
+#ifndef U_FORCE_HIDE_DRAFT_API
+namespace U_HEADER_ONLY_NAMESPACE {}
+#endif
+#endif
+
+#endif  // V8_SYSTEM_ICU_UVERSION_OVERLAY_H_

--- a/system_icu/list_formatter.cc
+++ b/system_icu/list_formatter.cc
@@ -1,0 +1,69 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <utility>
+#include <vector>
+
+#include "unicode/listformatter.h"
+
+U_NAMESPACE_BEGIN
+
+FormattedList::FormattedList() : result_(nullptr) {}
+
+FormattedList::FormattedList(UFormattedList* result) : result_(result) {}
+
+FormattedList::FormattedList(FormattedList&& other) noexcept
+    : result_(std::exchange(other.result_, nullptr)) {}
+
+FormattedList& FormattedList::operator=(FormattedList&& other) noexcept {
+  if (this != &other) {
+    ulistfmt_closeResult(result_);
+    result_ = std::exchange(other.result_, nullptr);
+  }
+  return *this;
+}
+
+FormattedList::~FormattedList() { ulistfmt_closeResult(result_); }
+
+const UFormattedValue* FormattedList::asUFormattedValue(
+    UErrorCode& status) const {
+  if (result_ == nullptr) {
+    status = U_INVALID_STATE_ERROR;
+    return nullptr;
+  }
+  return ulistfmt_resultAsValue(result_, &status);
+}
+
+ListFormatter::ListFormatter(UListFormatter* formatter)
+    : formatter_(formatter) {}
+
+ListFormatter::~ListFormatter() { ulistfmt_close(formatter_); }
+
+ListFormatter* ListFormatter::createInstance(const Locale& locale,
+                                             UListFormatterType type,
+                                             UListFormatterWidth width,
+                                             UErrorCode& status) {
+  UListFormatter* formatter =
+      ulistfmt_openForType(locale.getName(), type, width, &status);
+  return formatter == nullptr ? nullptr : new ListFormatter(formatter);
+}
+
+FormattedList ListFormatter::formatStringsToValue(const UnicodeString items[],
+                                                  int32_t item_count,
+                                                  UErrorCode& status) const {
+  UFormattedList* result = ulistfmt_openResult(&status);
+  if (result == nullptr) {
+    return {};
+  }
+
+  std::vector<const UChar*> strings(item_count);
+  std::vector<int32_t> lengths(item_count);
+  for (int32_t index = 0; index < item_count; ++index) {
+    strings[index] = reinterpret_cast<const UChar*>(items[index].getBuffer());
+    lengths[index] = items[index].length();
+  }
+  ulistfmt_formatStringsToResult(formatter_, strings.data(), lengths.data(),
+                                 item_count, result, &status);
+  return FormattedList(result);
+}
+
+U_NAMESPACE_END

--- a/system_icu/locale_availability.cc
+++ b/system_icu/locale_availability.cc
@@ -1,0 +1,73 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <array>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "unicode/uenum.h"
+#include "unicode/uloc.h"
+
+namespace {
+
+struct AvailableLocales {
+  std::once_flag initialized;
+  std::vector<std::string> storage;
+  std::vector<const char*> pointers;
+  UErrorCode status = U_ZERO_ERROR;
+};
+
+std::array<AvailableLocales, ULOC_AVAILABLE_COUNT> available_locales;
+
+}  // namespace
+
+extern "C" UEnumeration* v8_icu_compat_uloc_openAvailableByType(
+    ULocAvailableType type, UErrorCode* status) {
+  if (U_FAILURE(*status) || type < ULOC_AVAILABLE_DEFAULT ||
+      type >= ULOC_AVAILABLE_COUNT) {
+    if (U_SUCCESS(*status)) {
+      *status = U_ILLEGAL_ARGUMENT_ERROR;
+    }
+    return nullptr;
+  }
+
+  AvailableLocales& cache = available_locales[type];
+  std::call_once(cache.initialized, [&]() {
+    UEnumeration* system_locales =
+        uloc_openAvailableByType(type, &cache.status);
+    if (U_FAILURE(cache.status) || system_locales == nullptr) {
+      return;
+    }
+    int32_t count = uenum_count(system_locales, &cache.status);
+    if (U_SUCCESS(cache.status) && count > 0) {
+      cache.storage.reserve(count);
+    }
+    const char* locale = nullptr;
+    while (U_SUCCESS(cache.status) &&
+           (locale = uenum_next(system_locales, nullptr, &cache.status)) !=
+               nullptr) {
+      // Chromium's ICU data filters out Lojban as a service locale. Apple's
+      // system data includes it, even though most V8 Intl services have no
+      // matching locale data.
+      if (std::strcmp(locale, "jbo") != 0) {
+        cache.storage.emplace_back(locale);
+      }
+    }
+    uenum_close(system_locales);
+    if (U_SUCCESS(cache.status)) {
+      cache.pointers.reserve(cache.storage.size());
+      for (const std::string& value : cache.storage) {
+        cache.pointers.push_back(value.c_str());
+      }
+    }
+  });
+
+  if (U_FAILURE(cache.status)) {
+    *status = cache.status;
+    return nullptr;
+  }
+  return uenum_openCharStringsEnumeration(
+      cache.pointers.data(), static_cast<int32_t>(cache.pointers.size()),
+      status);
+}

--- a/system_icu/locale_builder.cc
+++ b/system_icu/locale_builder.cc
@@ -1,0 +1,266 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <string>
+
+#include "unicode/localebuilder.h"
+#include "unicode/uloc.h"
+
+U_NAMESPACE_BEGIN
+namespace {
+
+enum Component {
+  kLanguage,
+  kScript,
+  kRegion,
+  kVariant,
+};
+
+bool AllChars(const std::string& value, bool (*predicate)(unsigned char)) {
+  return std::all_of(value.begin(), value.end(), [predicate](char ch) {
+    return predicate(static_cast<unsigned char>(ch));
+  });
+}
+
+bool IsAlpha(unsigned char ch) { return std::isalpha(ch) != 0; }
+
+bool IsDigit(unsigned char ch) { return std::isdigit(ch) != 0; }
+
+bool IsAlphaNumeric(unsigned char ch) { return std::isalnum(ch) != 0; }
+
+bool IsValidVariant(const std::string& value) {
+  size_t start = 0;
+  while (start < value.size()) {
+    const size_t end = value.find_first_of("-_", start);
+    const size_t length =
+        (end == std::string::npos ? value.size() : end) - start;
+    const std::string subtag = value.substr(start, length);
+    if (!AllChars(subtag, IsAlphaNumeric) ||
+        !((length >= 5 && length <= 8) ||
+          (length == 4 && IsDigit(subtag[0])))) {
+      return false;
+    }
+    if (end == std::string::npos) {
+      return true;
+    }
+    start = end + 1;
+  }
+  return value.empty();
+}
+
+bool IsValidComponent(const std::string& value, int component) {
+  if (value.empty()) {
+    return true;
+  }
+  switch (component) {
+    case kLanguage:
+      return AllChars(value, IsAlpha) &&
+             ((value.size() >= 2 && value.size() <= 3) ||
+              (value.size() >= 5 && value.size() <= 8));
+    case kScript:
+      return value.size() == 4 && AllChars(value, IsAlpha);
+    case kRegion:
+      return (value.size() == 2 && AllChars(value, IsAlpha)) ||
+             (value.size() == 3 && AllChars(value, IsDigit));
+    case kVariant:
+      return IsValidVariant(value);
+  }
+  return false;
+}
+
+template <typename Get>
+std::string GetComponent(const std::string& locale, Get get) {
+  UErrorCode status = U_ZERO_ERROR;
+  std::array<char, ULOC_FULLNAME_CAPACITY> stack_buffer = {};
+  int32_t length =
+      get(locale.c_str(), stack_buffer.data(), stack_buffer.size(), &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR) {
+    return U_SUCCESS(status) ? std::string(stack_buffer.data(), length)
+                             : std::string();
+  }
+  status = U_ZERO_ERROR;
+  std::string result(length + 1, '\0');
+  length = get(locale.c_str(), result.data(), result.size(), &status);
+  return U_SUCCESS(status) ? std::string(result.data(), length) : std::string();
+}
+
+std::string Language(const std::string& locale) {
+  return GetComponent(locale, uloc_getLanguage);
+}
+
+std::string Script(const std::string& locale) {
+  return GetComponent(locale, uloc_getScript);
+}
+
+std::string Region(const std::string& locale) {
+  return GetComponent(locale, uloc_getCountry);
+}
+
+std::string Variant(const std::string& locale) {
+  return GetComponent(locale, uloc_getVariant);
+}
+
+std::string Extensions(const std::string& locale) {
+  const size_t separator = locale.find('@');
+  return separator == std::string::npos ? std::string()
+                                        : locale.substr(separator);
+}
+
+}  // namespace
+
+LocaleBuilder::LocaleBuilder() : locale_id_(), error_(U_ZERO_ERROR) {}
+
+LocaleBuilder::~LocaleBuilder() = default;
+
+LocaleBuilder& LocaleBuilder::setLocale(const Locale& locale) {
+  if (locale.isBogus()) {
+    error_ = U_ILLEGAL_ARGUMENT_ERROR;
+  } else {
+    locale_id_ = locale.getName();
+  }
+  return *this;
+}
+
+LocaleBuilder& LocaleBuilder::setLanguageTag(StringPiece tag) {
+  UErrorCode status = U_ZERO_ERROR;
+  Locale locale = Locale::forLanguageTag(tag, status);
+  if (U_FAILURE(status)) {
+    error_ = status;
+  } else {
+    locale_id_ = locale.getName();
+  }
+  return *this;
+}
+
+LocaleBuilder& LocaleBuilder::setLanguage(StringPiece language) {
+  setComponent(language, kLanguage);
+  return *this;
+}
+
+LocaleBuilder& LocaleBuilder::setScript(StringPiece script) {
+  setComponent(script, kScript);
+  return *this;
+}
+
+LocaleBuilder& LocaleBuilder::setRegion(StringPiece region) {
+  setComponent(region, kRegion);
+  return *this;
+}
+
+LocaleBuilder& LocaleBuilder::setVariant(StringPiece variant) {
+  setComponent(variant, kVariant);
+  return *this;
+}
+
+LocaleBuilder& LocaleBuilder::setUnicodeLocaleKeyword(StringPiece key,
+                                                      StringPiece value) {
+  if (U_FAILURE(error_)) {
+    return *this;
+  }
+  const std::string unicode_key(key.data(), key.length());
+  const std::string unicode_value(value.data(), value.length());
+  const char* legacy_key = uloc_toLegacyKey(unicode_key.c_str());
+  const char* legacy_value =
+      unicode_value.empty()
+          ? ""
+          : uloc_toLegacyType(unicode_key.c_str(), unicode_value.c_str());
+  if (legacy_key == nullptr || legacy_value == nullptr) {
+    error_ = U_ILLEGAL_ARGUMENT_ERROR;
+    return *this;
+  }
+
+  int32_t capacity = std::max<int32_t>(
+      ULOC_FULLNAME_CAPACITY,
+      locale_id_.size() + unicode_key.size() + unicode_value.size() + 32);
+  for (;;) {
+    std::string result(capacity, '\0');
+    std::copy(locale_id_.begin(), locale_id_.end(), result.begin());
+    UErrorCode status = U_ZERO_ERROR;
+    const int32_t length = uloc_setKeywordValue(
+        legacy_key, legacy_value, result.data(), result.size(), &status);
+    if (status == U_BUFFER_OVERFLOW_ERROR) {
+      capacity = length + 1;
+      continue;
+    }
+    if (U_FAILURE(status)) {
+      error_ = status;
+    } else {
+      locale_id_.assign(result.data(), length);
+    }
+    return *this;
+  }
+}
+
+void LocaleBuilder::setComponent(StringPiece value, int component) {
+  if (U_FAILURE(error_)) {
+    return;
+  }
+  std::string replacement(value.data(), value.length());
+  if (!IsValidComponent(replacement, component)) {
+    error_ = U_ILLEGAL_ARGUMENT_ERROR;
+    return;
+  }
+  const std::string extensions = Extensions(locale_id_);
+  std::string language = Language(locale_id_);
+  std::string script = Script(locale_id_);
+  std::string region = Region(locale_id_);
+  std::string variant = Variant(locale_id_);
+  switch (component) {
+    case kLanguage:
+      language = std::move(replacement);
+      break;
+    case kScript:
+      script = std::move(replacement);
+      break;
+    case kRegion:
+      region = std::move(replacement);
+      break;
+    case kVariant:
+      variant = std::move(replacement);
+      break;
+  }
+
+  if (language.empty() &&
+      (!script.empty() || !region.empty() || !variant.empty())) {
+    language = "und";
+  }
+  locale_id_ = language;
+  if (!script.empty()) {
+    locale_id_ += "_" + script;
+  }
+  if (!region.empty()) {
+    locale_id_ += "_" + region;
+  }
+  if (!variant.empty()) {
+    locale_id_ += "_" + variant;
+  }
+  locale_id_ += extensions;
+}
+
+LocaleBuilder& LocaleBuilder::clearExtensions() {
+  const size_t separator = locale_id_.find('@');
+  if (separator != std::string::npos) {
+    locale_id_.erase(separator);
+  }
+  return *this;
+}
+
+Locale LocaleBuilder::build(UErrorCode& status) {
+  if (U_FAILURE(status)) {
+    return Locale("", "", "", "");
+  }
+  if (U_FAILURE(error_)) {
+    status = error_;
+    return Locale("", "", "", "");
+  }
+
+  Locale locale(locale_id_.c_str(), "", "", "");
+  if (locale.isBogus()) {
+    status = U_ILLEGAL_ARGUMENT_ERROR;
+  }
+  return locale;
+}
+
+U_NAMESPACE_END

--- a/system_icu/locale_matcher.cc
+++ b/system_icu/locale_matcher.cc
@@ -1,0 +1,203 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <cctype>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "unicode/localematcher.h"
+#include "unicode/uenum.h"
+#include "unicode/uloc.h"
+
+U_NAMESPACE_BEGIN
+
+namespace {
+
+size_t FindExtension(const std::string& tag) {
+  for (size_t index = 0; index + 2 < tag.size(); ++index) {
+    if (tag[index] == '-' && tag[index + 2] == '-' &&
+        std::isalnum(static_cast<unsigned char>(tag[index + 1]))) {
+      return index;
+    }
+  }
+  return std::string::npos;
+}
+
+Locale AddDesiredExtensions(const Locale& supported, const Locale& desired,
+                            UErrorCode& status) {
+  std::string desired_tag = desired.toLanguageTag<std::string>(status);
+  if (U_FAILURE(status)) {
+    return supported;
+  }
+  const size_t extension = FindExtension(desired_tag);
+  if (extension == std::string::npos) {
+    return supported;
+  }
+
+  std::string result = supported.toLanguageTag<std::string>(status);
+  if (U_FAILURE(status)) {
+    return supported;
+  }
+  result.append(desired_tag, extension);
+  return Locale::forLanguageTag(result, status);
+}
+
+int32_t MatchIndex(const Locale& desired,
+                   const std::vector<Locale>& supported) {
+  if (supported.empty()) {
+    return -1;
+  }
+  std::vector<const char*> names;
+  names.reserve(supported.size());
+  for (const Locale& locale : supported) {
+    names.push_back(locale.getName());
+  }
+  UErrorCode status = U_ZERO_ERROR;
+  UEnumeration* available = uenum_openCharStringsEnumeration(
+      names.data(), static_cast<int32_t>(names.size()), &status);
+  if (U_FAILURE(status) || available == nullptr) {
+    return -1;
+  }
+
+  char matched[ULOC_FULLNAME_CAPACITY] = {};
+  UAcceptResult result = ULOC_ACCEPT_FAILED;
+  const char* desired_names[] = {desired.getName()};
+  uloc_acceptLanguage(matched, sizeof(matched), &result, desired_names, 1,
+                      available, &status);
+  uenum_close(available);
+  if (U_FAILURE(status) || result == ULOC_ACCEPT_FAILED) {
+    return -1;
+  }
+
+  for (int32_t index = 0; index < static_cast<int32_t>(supported.size());
+       ++index) {
+    if (std::strcmp(matched, supported[index].getName()) == 0) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+}  // namespace
+
+LocaleMatcher::Result::Result(const Locale& desired, const Locale& supported,
+                              int32_t desired_index, int32_t supported_index,
+                              bool has_desired, bool has_supported)
+    : desired_(desired),
+      supported_(supported),
+      desired_index_(desired_index),
+      supported_index_(supported_index),
+      has_desired_(has_desired),
+      has_supported_(has_supported) {}
+
+LocaleMatcher::Result::Result(Result&& other) noexcept = default;
+
+LocaleMatcher::Result& LocaleMatcher::Result::operator=(
+    Result&& other) noexcept = default;
+
+LocaleMatcher::Result::~Result() = default;
+
+Locale LocaleMatcher::Result::makeResolvedLocale(UErrorCode& status) const {
+  if (U_FAILURE(status)) {
+    return Locale();
+  }
+  // The desired locale carries the Unicode and transformed extensions which
+  // must survive resolution. Its likely-subtag match has already selected a
+  // supported locale before this point.
+  if (has_desired_ && supported_index_ >= 0) {
+    return AddDesiredExtensions(supported_, desired_, status);
+  }
+  return has_supported_ ? supported_ : Locale::getRoot();
+}
+
+LocaleMatcher::Builder::Builder() : default_(), has_default_(false) {}
+
+LocaleMatcher::Builder::~Builder() = default;
+
+LocaleMatcher::Builder& LocaleMatcher::Builder::addSupportedLocale(
+    const Locale& locale) {
+  supported_.push_back(locale);
+  return *this;
+}
+
+LocaleMatcher::Builder& LocaleMatcher::Builder::setDefaultLocale(
+    const Locale* locale) {
+  if (locale == nullptr) {
+    has_default_ = false;
+  } else {
+    default_ = *locale;
+    has_default_ = true;
+  }
+  return *this;
+}
+
+LocaleMatcher LocaleMatcher::Builder::build(UErrorCode& status) const {
+  if (U_FAILURE(status)) {
+    return LocaleMatcher({}, default_, has_default_);
+  }
+  return LocaleMatcher(supported_, default_, has_default_);
+}
+
+LocaleMatcher::LocaleMatcher(const std::vector<Locale>& supported,
+                             const Locale& default_locale, bool has_default)
+    : supported_(supported),
+      default_(default_locale),
+      has_default_(has_default) {}
+
+LocaleMatcher::LocaleMatcher(LocaleMatcher&& other) noexcept = default;
+
+LocaleMatcher& LocaleMatcher::operator=(LocaleMatcher&& other) noexcept =
+    default;
+
+LocaleMatcher::~LocaleMatcher() = default;
+
+LocaleMatcher::Result LocaleMatcher::match(const Locale& desired,
+                                           int32_t desired_index) const {
+  const int32_t best_index = MatchIndex(desired, supported_);
+  if (best_index >= 0) {
+    return Result(desired, supported_[best_index], desired_index, best_index,
+                  true, true);
+  }
+  if (has_default_) {
+    return Result(desired, default_, desired_index, -1, true, true);
+  }
+  if (!supported_.empty()) {
+    return Result(desired, supported_.front(), desired_index, -1, true, true);
+  }
+  return Result(desired, Locale::getRoot(), desired_index, -1, true, false);
+}
+
+LocaleMatcher::Result LocaleMatcher::getBestMatchResult(
+    const Locale& desired, UErrorCode& status) const {
+  if (U_FAILURE(status)) {
+    return Result(Locale::getRoot(), Locale::getRoot(), -1, -1, false, false);
+  }
+  return match(desired, 0);
+}
+
+LocaleMatcher::Result LocaleMatcher::getBestMatchResult(
+    Locale::Iterator& desired, UErrorCode& status) const {
+  if (U_FAILURE(status)) {
+    return Result(Locale::getRoot(), Locale::getRoot(), -1, -1, false, false);
+  }
+
+  int32_t index = 0;
+  while (desired.hasNext()) {
+    const Locale& locale = desired.next();
+    Result result = match(locale, index++);
+    if (result.getSupportedIndex() >= 0) {
+      return result;
+    }
+  }
+
+  if (has_default_) {
+    return Result(Locale::getRoot(), default_, -1, -1, false, true);
+  }
+  if (!supported_.empty()) {
+    return Result(Locale::getRoot(), supported_.front(), -1, -1, false, true);
+  }
+  return Result(Locale::getRoot(), Locale::getRoot(), -1, -1, false, false);
+}
+
+U_NAMESPACE_END

--- a/system_icu/measure_unit.cc
+++ b/system_icu/measure_unit.cc
@@ -1,0 +1,141 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <algorithm>
+#include <iterator>
+
+#include "unicode/currunit.h"
+#include "unicode/measunit.h"
+
+U_NAMESPACE_BEGIN
+
+namespace {
+
+constexpr const char* kSanctionedUnits[] = {
+    "acre",        "bit",         "byte",        "celsius",
+    "centimeter",  "day",         "degree",      "fahrenheit",
+    "fluid-ounce", "foot",        "gallon",      "gigabit",
+    "gigabyte",    "gram",        "hectare",     "hour",
+    "inch",        "kilobit",     "kilobyte",    "kilogram",
+    "kilometer",   "liter",       "megabit",     "megabyte",
+    "meter",       "microsecond", "mile",        "mile-scandinavian",
+    "millimeter",  "milliliter",  "millisecond", "minute",
+    "month",       "nanosecond",  "ounce",       "percent",
+    "petabyte",    "pound",       "second",      "stone",
+    "terabit",     "terabyte",    "week",        "yard",
+    "year",
+};
+
+}  // namespace
+
+MeasureUnit::MeasureUnit() : type_("none"), subtype_() {}
+
+MeasureUnit::MeasureUnit(const char* type, const char* subtype)
+    : type_(type), subtype_(subtype) {}
+
+MeasureUnit::MeasureUnit(const MeasureUnit& other) = default;
+
+MeasureUnit::MeasureUnit(MeasureUnit&& other) noexcept = default;
+
+MeasureUnit& MeasureUnit::operator=(const MeasureUnit& other) = default;
+
+MeasureUnit& MeasureUnit::operator=(MeasureUnit&& other) noexcept = default;
+
+MeasureUnit::~MeasureUnit() = default;
+
+bool MeasureUnit::operator==(const UObject& other) const {
+  const auto& unit = static_cast<const MeasureUnit&>(other);
+  return type_ == unit.type_ && subtype_ == unit.subtype_;
+}
+
+const char* MeasureUnit::getType() const { return type_.c_str(); }
+
+const char* MeasureUnit::getSubtype() const { return subtype_.c_str(); }
+
+const char* MeasureUnit::getIdentifier() const { return subtype_.c_str(); }
+
+int32_t MeasureUnit::getAvailable(MeasureUnit* destination, int32_t capacity,
+                                  UErrorCode& status) {
+  if (U_FAILURE(status)) {
+    return 0;
+  }
+
+  const int32_t count = std::size(kSanctionedUnits);
+  if (destination == nullptr || capacity < count) {
+    status = U_BUFFER_OVERFLOW_ERROR;
+    return count;
+  }
+
+  for (int32_t index = 0; index < count; ++index) {
+    destination[index] = MeasureUnit(
+        kSanctionedUnits[index] == std::string("percent") ? "concentr" : "unit",
+        kSanctionedUnits[index]);
+  }
+  return count;
+}
+
+MeasureUnit MeasureUnit::getPercent() {
+  return MeasureUnit("concentr", "percent");
+}
+
+MeasureUnit MeasureUnit::getPermille() {
+  return MeasureUnit("concentr", "permille");
+}
+
+MeasureUnit MeasureUnit::getYear() { return MeasureUnit("duration", "year"); }
+
+MeasureUnit MeasureUnit::getMonth() { return MeasureUnit("duration", "month"); }
+
+MeasureUnit MeasureUnit::getWeek() { return MeasureUnit("duration", "week"); }
+
+MeasureUnit MeasureUnit::getDay() { return MeasureUnit("duration", "day"); }
+
+MeasureUnit MeasureUnit::getHour() { return MeasureUnit("duration", "hour"); }
+
+MeasureUnit MeasureUnit::getMinute() {
+  return MeasureUnit("duration", "minute");
+}
+
+MeasureUnit MeasureUnit::getSecond() {
+  return MeasureUnit("duration", "second");
+}
+
+MeasureUnit MeasureUnit::getMillisecond() {
+  return MeasureUnit("duration", "millisecond");
+}
+
+MeasureUnit MeasureUnit::getMicrosecond() {
+  return MeasureUnit("duration", "microsecond");
+}
+
+MeasureUnit MeasureUnit::getNanosecond() {
+  return MeasureUnit("duration", "nanosecond");
+}
+
+CurrencyUnit::CurrencyUnit()
+    : MeasureUnit("currency", "XXX"), iso_code_{u'X', u'X', u'X', 0} {}
+
+CurrencyUnit::CurrencyUnit(ConstChar16Ptr iso_code, UErrorCode& status)
+    : MeasureUnit(), iso_code_{} {
+  const char16_t* code = iso_code;
+  char ascii_code[4] = {};
+  if (code == nullptr) {
+    code = u"XXX";
+  }
+  for (int index = 0; index < 3; ++index) {
+    if (code[index] > 0x7f) {
+      status = U_ILLEGAL_ARGUMENT_ERROR;
+      return;
+    }
+    ascii_code[index] = static_cast<char>(code[index]);
+    iso_code_[index] = code[index];
+  }
+  *static_cast<MeasureUnit*>(this) = MeasureUnit("currency", ascii_code);
+}
+
+CurrencyUnit::CurrencyUnit(const CurrencyUnit& other) = default;
+
+CurrencyUnit& CurrencyUnit::operator=(const CurrencyUnit& other) = default;
+
+CurrencyUnit::~CurrencyUnit() = default;
+
+U_NAMESPACE_END

--- a/system_icu/normalizer.cc
+++ b/system_icu/normalizer.cc
@@ -1,0 +1,68 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <cstring>
+#include <vector>
+
+#include "unicode/normalizer2.h"
+
+U_NAMESPACE_BEGIN
+
+Normalizer2::Normalizer2(const UNormalizer2* normalizer)
+    : normalizer_(normalizer) {}
+
+const Normalizer2* Normalizer2::getInstance(const char* package_name,
+                                            const char* name,
+                                            UNormalization2Mode mode,
+                                            UErrorCode& status) {
+  const UNormalizer2* normalizer =
+      unorm2_getInstance(package_name, name, mode, &status);
+  // ICU owns the C singleton. V8 obtains only four process-lifetime
+  // normalizers, so keeping the tiny corresponding C++ views is intentional.
+  return normalizer == nullptr ? nullptr : new Normalizer2(normalizer);
+}
+
+int32_t Normalizer2::spanQuickCheckYes(const UnicodeString& input,
+                                       UErrorCode& status) const {
+  return unorm2_spanQuickCheckYes(
+      normalizer_, reinterpret_cast<const UChar*>(input.getBuffer()),
+      input.length(), &status);
+}
+
+UnicodeString& Normalizer2::normalizeSecondAndAppend(
+    UnicodeString& first, const UnicodeString& second,
+    UErrorCode& status) const {
+  if (U_FAILURE(status)) {
+    return first;
+  }
+
+  const int32_t first_length = first.length();
+  const int32_t second_length = second.length();
+  int32_t capacity = first_length + second_length + 32;
+  std::vector<UChar> buffer(capacity);
+  std::memcpy(buffer.data(), first.getBuffer(),
+              first_length * sizeof(char16_t));
+
+  int32_t length = unorm2_normalizeSecondAndAppend(
+      normalizer_, buffer.data(), first_length, capacity,
+      reinterpret_cast<const UChar*>(second.getBuffer()), second_length,
+      &status);
+  if (status == U_BUFFER_OVERFLOW_ERROR) {
+    status = U_ZERO_ERROR;
+    capacity = length + 1;
+    buffer.resize(capacity);
+    std::memcpy(buffer.data(), first.getBuffer(),
+                first_length * sizeof(char16_t));
+    length = unorm2_normalizeSecondAndAppend(
+        normalizer_, buffer.data(), first_length, capacity,
+        reinterpret_cast<const UChar*>(second.getBuffer()), second_length,
+        &status);
+  }
+
+  if (U_SUCCESS(status)) {
+    first.remove();
+    first.append(reinterpret_cast<const char16_t*>(buffer.data()), length);
+  }
+  return first;
+}
+
+U_NAMESPACE_END

--- a/system_icu/number_format.cc
+++ b/system_icu/number_format.cc
@@ -1,0 +1,49 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <utility>
+
+#include "unicode/decimfmt.h"
+#include "unicode/numfmt.h"
+
+U_NAMESPACE_BEGIN
+
+NumberFormat::NumberFormat(UNumberFormat* formatter) : formatter_(formatter) {}
+
+NumberFormat::~NumberFormat() { unum_close(formatter_); }
+
+NumberFormat* NumberFormat::createInstance(const Locale& locale,
+                                           UNumberFormatStyle style,
+                                           UErrorCode& status) {
+  UNumberFormat* formatter =
+      unum_open(style, nullptr, 0, locale.getName(), nullptr, &status);
+  return formatter == nullptr ? nullptr : new DecimalFormat(formatter);
+}
+
+UClassID NumberFormat::getStaticClassID() {
+  static char class_id = 0;
+  return &class_id;
+}
+
+UClassID NumberFormat::getDynamicClassID() const { return getStaticClassID(); }
+
+UNumberFormat* NumberFormat::orphanUNumberFormat() {
+  return std::exchange(formatter_, nullptr);
+}
+
+DecimalFormat::DecimalFormat(UNumberFormat* formatter)
+    : NumberFormat(formatter) {}
+
+DecimalFormat::~DecimalFormat() = default;
+
+UClassID DecimalFormat::getStaticClassID() {
+  static char class_id = 0;
+  return &class_id;
+}
+
+UClassID DecimalFormat::getDynamicClassID() const { return getStaticClassID(); }
+
+void DecimalFormat::setMinimumGroupingDigits(int32_t value) {
+  unum_setAttribute(formatter_, UNUM_MINIMUM_GROUPING_DIGITS, value);
+}
+
+U_NAMESPACE_END

--- a/system_icu/number_formatter.cc
+++ b/system_icu/number_formatter.cc
@@ -1,0 +1,536 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <charconv>
+#include <cmath>
+#include <cstdio>
+#include <mutex>
+#include <utility>
+
+#include "unicode/numberformatter.h"
+#include "unicode/numberrangeformatter.h"
+
+U_NAMESPACE_BEGIN
+
+Formattable::Formattable()
+    : is_decimal_(false), double_value_(0), decimal_value_() {}
+
+Formattable::Formattable(double value)
+    : is_decimal_(false), double_value_(value), decimal_value_() {}
+
+Formattable::Formattable(StringPiece decimal, UErrorCode& status)
+    : is_decimal_(true),
+      double_value_(0),
+      decimal_value_(decimal.data(), decimal.length()) {
+  if (decimal.empty()) {
+    status = U_INVALID_FORMAT_ERROR;
+  }
+}
+
+Formattable::Formattable(const Formattable& other) = default;
+
+Formattable& Formattable::operator=(const Formattable& other) = default;
+
+Formattable::~Formattable() = default;
+
+namespace number {
+namespace impl {
+
+struct NumberFormatterState {
+  explicit NumberFormatterState(const NumberFormatterOptions& options)
+      : options(options) {}
+  ~NumberFormatterState() { unumf_close(formatter); }
+
+  NumberFormatterOptions options;
+  std::once_flag once;
+  UNumberFormatter* formatter = nullptr;
+  UErrorCode status = U_ZERO_ERROR;
+};
+
+namespace {
+
+void AppendToken(std::string& skeleton, const std::string& token) {
+  if (token.empty()) {
+    return;
+  }
+  if (!skeleton.empty()) {
+    skeleton += ' ';
+  }
+  skeleton += token;
+}
+
+std::string ScaleStem(int32_t power) {
+  if (power == 0) {
+    return "scale/1";
+  }
+  if (power > 0) {
+    return "scale/1" + std::string(power, '0');
+  }
+  return "scale/0." + std::string(-power - 1, '0') + "1";
+}
+
+bool IsJapaneseLocale(const std::string& locale) {
+  return locale == "ja" ||
+         (locale.size() > 2 &&
+          (locale[2] == '_' || locale[2] == '-' || locale[2] == '@') &&
+          locale.compare(0, 2, "ja") == 0);
+}
+
+bool ShouldUseFullwidthYen(const NumberFormatterOptions& options) {
+  if (!IsJapaneseLocale(options.locale)) {
+    return false;
+  }
+  if (options.unit_type == "currency" && options.unit == "JPY") {
+    return true;
+  }
+  return options.raw_skeleton.find("currency/JPY") != std::string::npos;
+}
+
+UnicodeString UseFullwidthYen(UnicodeString result) {
+  for (int32_t i = 0; i < result.length(); ++i) {
+    if (result.charAt(i) == 0x00a5) {
+      result.setCharAt(i, 0xffe5);
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+UnicodeString BuildSkeleton(const NumberFormatterOptions& options,
+                            UErrorCode& status) {
+  if (U_FAILURE(status)) {
+    return {};
+  }
+  if (!options.raw_skeleton.empty()) {
+    return UnicodeString::fromUTF8(options.raw_skeleton);
+  }
+
+  std::string skeleton;
+  if (!options.numbering_system.empty()) {
+    AppendToken(skeleton, "numbering-system/" + options.numbering_system);
+  }
+  if (!options.unit.empty()) {
+    if (options.unit_type == "currency") {
+      AppendToken(skeleton, "currency/" + options.unit);
+    } else if (options.unit == "percent") {
+      AppendToken(skeleton, "percent");
+    } else {
+      std::string unit = options.unit;
+      if (!options.per_unit.empty()) {
+        unit += "-per-" + options.per_unit;
+      }
+      AppendToken(skeleton, "unit/" + unit);
+    }
+  }
+  AppendToken(skeleton, options.notation);
+  AppendToken(skeleton, options.precision);
+  AppendToken(skeleton, options.rounding_mode);
+  if (options.integer_width > 0) {
+    AppendToken(skeleton,
+                "integer-width/*" + std::string(options.integer_width, '0'));
+  }
+  AppendToken(skeleton, options.grouping);
+  AppendToken(skeleton, options.sign);
+  if (options.has_unit_width) {
+    AppendToken(
+        skeleton,
+        UnitWidthStem(static_cast<UNumberUnitWidth>(options.unit_width)));
+  }
+  if (options.has_scale) {
+    AppendToken(skeleton, ScaleStem(options.scale));
+  }
+  return UnicodeString::fromUTF8(skeleton);
+}
+
+const char* RoundingModeStem(UNumberFormatRoundingMode mode) {
+  switch (mode) {
+    case UNUM_ROUND_CEILING:
+      return "rounding-mode-ceiling";
+    case UNUM_ROUND_FLOOR:
+      return "rounding-mode-floor";
+    case UNUM_ROUND_DOWN:
+      return "rounding-mode-down";
+    case UNUM_ROUND_UP:
+      return "rounding-mode-up";
+    case UNUM_ROUND_HALFEVEN:
+      return "rounding-mode-half-even";
+    case UNUM_ROUND_HALFDOWN:
+      return "rounding-mode-half-down";
+    case UNUM_ROUND_HALFUP:
+      return "rounding-mode-half-up";
+    case UNUM_ROUND_HALF_CEILING:
+      return "rounding-mode-half-ceiling";
+    case UNUM_ROUND_HALF_FLOOR:
+      return "rounding-mode-half-floor";
+    default:
+      return "";
+  }
+}
+
+const char* GroupingStem(UNumberGroupingStrategy grouping) {
+  switch (grouping) {
+    case UNUM_GROUPING_OFF:
+      return "group-off";
+    case UNUM_GROUPING_MIN2:
+      return "group-min2";
+    case UNUM_GROUPING_ON_ALIGNED:
+      return "group-on-aligned";
+    case UNUM_GROUPING_THOUSANDS:
+      return "group-thousands";
+    default:
+      return "";
+  }
+}
+
+const char* SignStem(UNumberSignDisplay sign) {
+  switch (sign) {
+    case UNUM_SIGN_NEVER:
+      return "sign-never";
+    case UNUM_SIGN_ALWAYS:
+      return "sign-always";
+    case UNUM_SIGN_EXCEPT_ZERO:
+      return "sign-except-zero";
+    case UNUM_SIGN_NEGATIVE:
+      return "sign-negative";
+    case UNUM_SIGN_ACCOUNTING:
+      return "sign-accounting";
+    case UNUM_SIGN_ACCOUNTING_ALWAYS:
+      return "sign-accounting-always";
+    case UNUM_SIGN_ACCOUNTING_EXCEPT_ZERO:
+      return "sign-accounting-except-zero";
+    case UNUM_SIGN_ACCOUNTING_NEGATIVE:
+      return "sign-accounting-negative";
+    default:
+      return "";
+  }
+}
+
+const char* UnitWidthStem(UNumberUnitWidth width) {
+  switch (width) {
+    case UNUM_UNIT_WIDTH_NARROW:
+      return "unit-width-narrow";
+    case UNUM_UNIT_WIDTH_FULL_NAME:
+      return "unit-width-full-name";
+    case UNUM_UNIT_WIDTH_ISO_CODE:
+      return "unit-width-iso-code";
+    case UNUM_UNIT_WIDTH_HIDDEN:
+      return "unit-width-hidden";
+    default:
+      return "";
+  }
+}
+
+}  // namespace impl
+
+Notation Notation::simple() { return Notation(""); }
+
+Notation Notation::scientific() { return Notation("scientific"); }
+
+Notation Notation::engineering() { return Notation("engineering"); }
+
+Notation Notation::compactShort() { return Notation("compact-short"); }
+
+Notation Notation::compactLong() { return Notation("compact-long"); }
+
+Precision Precision::unlimited() { return Precision(""); }
+
+FractionPrecision Precision::minMaxFraction(int32_t minimum, int32_t maximum) {
+  if (maximum == 0) {
+    return FractionPrecision("precision-integer");
+  }
+  return FractionPrecision("." + std::string(minimum, '0') +
+                           std::string(maximum - minimum, '#'));
+}
+
+Precision Precision::minMaxSignificantDigits(int32_t minimum, int32_t maximum) {
+  return Precision(std::string(minimum, '@') +
+                   std::string(maximum - minimum, '#'));
+}
+
+IncrementPrecision Precision::incrementExact(uint64_t mantissa,
+                                             int16_t magnitude) {
+  std::string digits = std::to_string(mantissa);
+  std::string value;
+  if (magnitude >= 0) {
+    value = digits + std::string(magnitude, '0');
+  } else {
+    const int32_t decimal_places = -magnitude;
+    if (decimal_places >= static_cast<int32_t>(digits.size())) {
+      value = "0." + std::string(decimal_places - digits.size(), '0') + digits;
+    } else {
+      value = digits;
+      value.insert(value.size() - decimal_places, 1, '.');
+    }
+  }
+  return IncrementPrecision("precision-increment/" + value);
+}
+
+Precision Precision::trailingZeroDisplay(
+    UNumberTrailingZeroDisplay display) const {
+  return display == UNUM_TRAILING_ZERO_HIDE_IF_WHOLE ? Precision(stem_ + "/w")
+                                                     : *this;
+}
+
+Precision FractionPrecision::withSignificantDigits(
+    int32_t minimum, int32_t maximum, UNumberRoundingPriority priority) const {
+  const char priority_char =
+      priority == UNUM_ROUNDING_PRIORITY_RELAXED ? 'r' : 's';
+  return Precision(stem_ + "/" + std::string(minimum, '@') +
+                   std::string(maximum - minimum, '#') + priority_char);
+}
+
+Precision IncrementPrecision::withMinFraction(int32_t minimum) const {
+  const size_t dot = stem_.find('.');
+  const size_t existing = dot == std::string::npos ? 0 : stem_.size() - dot - 1;
+  if (existing >= static_cast<size_t>(minimum)) {
+    return *this;
+  }
+  return Precision(stem_ + std::string(minimum - existing, '0'));
+}
+
+IntegerWidth IntegerWidth::zeroFillTo(int32_t minimum) {
+  return IntegerWidth(minimum);
+}
+
+Scale Scale::powerOfTen(int32_t power) { return Scale(power); }
+
+FormattedNumber::FormattedNumber()
+    : result_(nullptr), use_fullwidth_yen_(false) {}
+
+FormattedNumber::FormattedNumber(UFormattedNumber* result,
+                                 bool use_fullwidth_yen)
+    : result_(result), use_fullwidth_yen_(use_fullwidth_yen) {}
+
+FormattedNumber::FormattedNumber(FormattedNumber&& other) noexcept
+    : result_(std::exchange(other.result_, nullptr)),
+      use_fullwidth_yen_(other.use_fullwidth_yen_) {}
+
+FormattedNumber& FormattedNumber::operator=(FormattedNumber&& other) noexcept {
+  if (this != &other) {
+    unumf_closeResult(result_);
+    result_ = std::exchange(other.result_, nullptr);
+    use_fullwidth_yen_ = other.use_fullwidth_yen_;
+  }
+  return *this;
+}
+
+FormattedNumber::~FormattedNumber() { unumf_closeResult(result_); }
+
+UnicodeString FormattedNumber::toString(UErrorCode& status) const {
+  UnicodeString result = CFormattedValue::toString(status);
+  return use_fullwidth_yen_ ? impl::UseFullwidthYen(std::move(result)) : result;
+}
+
+const UFormattedValue* FormattedNumber::asUFormattedValue(
+    UErrorCode& status) const {
+  if (result_ == nullptr) {
+    status = U_INVALID_STATE_ERROR;
+    return nullptr;
+  }
+  return unumf_resultAsValue(result_, &status);
+}
+
+LocalizedNumberFormatter::LocalizedNumberFormatter() = default;
+
+LocalizedNumberFormatter::LocalizedNumberFormatter(
+    const impl::NumberFormatterOptions& options)
+    : NumberFormatterSettings(options),
+      state_(std::make_shared<impl::NumberFormatterState>(options)) {}
+
+LocalizedNumberFormatter::LocalizedNumberFormatter(
+    const LocalizedNumberFormatter& other) = default;
+
+LocalizedNumberFormatter::LocalizedNumberFormatter(
+    LocalizedNumberFormatter&& other) noexcept = default;
+
+LocalizedNumberFormatter& LocalizedNumberFormatter::operator=(
+    const LocalizedNumberFormatter& other) = default;
+
+LocalizedNumberFormatter& LocalizedNumberFormatter::operator=(
+    LocalizedNumberFormatter&& other) noexcept = default;
+
+LocalizedNumberFormatter::~LocalizedNumberFormatter() = default;
+
+void LocalizedNumberFormatter::clearHandle() {
+  state_ = std::make_shared<impl::NumberFormatterState>(options_);
+}
+
+UNumberFormatter* LocalizedNumberFormatter::getFormatter(
+    UErrorCode& status) const {
+  if (state_ == nullptr) {
+    state_ = std::make_shared<impl::NumberFormatterState>(options_);
+  }
+  std::call_once(state_->once, [this] {
+    UErrorCode build_status = U_ZERO_ERROR;
+    UnicodeString skeleton = impl::BuildSkeleton(options_, build_status);
+    if (U_SUCCESS(build_status)) {
+      state_->formatter = unumf_openForSkeletonAndLocale(
+          reinterpret_cast<const UChar*>(skeleton.getBuffer()),
+          skeleton.length(), options_.locale.c_str(), &build_status);
+    }
+    state_->status = build_status;
+  });
+  if (U_SUCCESS(status) && U_FAILURE(state_->status)) {
+    status = state_->status;
+  }
+  return state_->formatter;
+}
+
+FormattedNumber LocalizedNumberFormatter::formatInt(int64_t value,
+                                                    UErrorCode& status) const {
+  UFormattedNumber* result = unumf_openResult(&status);
+  UNumberFormatter* formatter = getFormatter(status);
+  if (result != nullptr && formatter != nullptr) {
+    unumf_formatInt(formatter, value, result, &status);
+  }
+  return FormattedNumber(result, impl::ShouldUseFullwidthYen(options_));
+}
+
+FormattedNumber LocalizedNumberFormatter::formatDouble(
+    double value, UErrorCode& status) const {
+  UFormattedNumber* result = unumf_openResult(&status);
+  UNumberFormatter* formatter = getFormatter(status);
+  if (result != nullptr && formatter != nullptr) {
+    unumf_formatDouble(formatter, value, result, &status);
+  }
+  return FormattedNumber(result, impl::ShouldUseFullwidthYen(options_));
+}
+
+FormattedNumber LocalizedNumberFormatter::formatDecimal(
+    StringPiece value, UErrorCode& status) const {
+  UFormattedNumber* result = unumf_openResult(&status);
+  UNumberFormatter* formatter = getFormatter(status);
+  if (result != nullptr && formatter != nullptr) {
+    unumf_formatDecimal(formatter, value.data(), value.length(), result,
+                        &status);
+  }
+  return FormattedNumber(result, impl::ShouldUseFullwidthYen(options_));
+}
+
+LocalizedNumberFormatter UnlocalizedNumberFormatter::locale(
+    const Locale& locale) const {
+  impl::NumberFormatterOptions options = options_;
+  options.locale = locale.getName();
+  return LocalizedNumberFormatter(options);
+}
+
+UnlocalizedNumberFormatter NumberFormatter::forSkeleton(
+    const UnicodeString& skeleton, UParseError& parse_error,
+    UErrorCode& status) {
+  impl::NumberFormatterOptions options;
+  skeleton.toUTF8String(options.raw_skeleton);
+  parse_error.offset = -1;
+  if (U_FAILURE(status)) {
+    return UnlocalizedNumberFormatter();
+  }
+  return UnlocalizedNumberFormatter(options);
+}
+
+FormattedNumberRange::FormattedNumberRange()
+    : result_(nullptr), use_fullwidth_yen_(false) {}
+
+FormattedNumberRange::FormattedNumberRange(UFormattedNumberRange* result,
+                                           bool use_fullwidth_yen)
+    : result_(result), use_fullwidth_yen_(use_fullwidth_yen) {}
+
+FormattedNumberRange::FormattedNumberRange(
+    FormattedNumberRange&& other) noexcept
+    : result_(std::exchange(other.result_, nullptr)),
+      use_fullwidth_yen_(other.use_fullwidth_yen_) {}
+
+FormattedNumberRange& FormattedNumberRange::operator=(
+    FormattedNumberRange&& other) noexcept {
+  if (this != &other) {
+    unumrf_closeResult(result_);
+    result_ = std::exchange(other.result_, nullptr);
+    use_fullwidth_yen_ = other.use_fullwidth_yen_;
+  }
+  return *this;
+}
+
+FormattedNumberRange::~FormattedNumberRange() { unumrf_closeResult(result_); }
+
+UnicodeString FormattedNumberRange::toString(UErrorCode& status) const {
+  UnicodeString result = CFormattedValue::toString(status);
+  return use_fullwidth_yen_ ? impl::UseFullwidthYen(std::move(result)) : result;
+}
+
+const UFormattedValue* FormattedNumberRange::asUFormattedValue(
+    UErrorCode& status) const {
+  if (result_ == nullptr) {
+    status = U_INVALID_STATE_ERROR;
+    return nullptr;
+  }
+  return unumrf_resultAsValue(result_, &status);
+}
+
+LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter() = default;
+
+LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(
+    std::u16string skeleton, std::string locale)
+    : skeleton_(std::move(skeleton)), locale_(std::move(locale)) {}
+
+LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(
+    const LocalizedNumberRangeFormatter& other) = default;
+
+LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(
+    LocalizedNumberRangeFormatter&& other) noexcept = default;
+
+LocalizedNumberRangeFormatter& LocalizedNumberRangeFormatter::operator=(
+    const LocalizedNumberRangeFormatter& other) = default;
+
+LocalizedNumberRangeFormatter& LocalizedNumberRangeFormatter::operator=(
+    LocalizedNumberRangeFormatter&& other) noexcept = default;
+
+LocalizedNumberRangeFormatter::~LocalizedNumberRangeFormatter() = default;
+
+FormattedNumberRange LocalizedNumberRangeFormatter::formatFormattableRange(
+    const Formattable& first, const Formattable& second,
+    UErrorCode& status) const {
+  UNumberRangeFormatter* formatter =
+      unumrf_openForSkeletonWithCollapseAndIdentityFallback(
+          reinterpret_cast<const UChar*>(skeleton_.data()), skeleton_.size(),
+          UNUM_RANGE_COLLAPSE_AUTO, UNUM_IDENTITY_FALLBACK_APPROXIMATELY,
+          locale_.c_str(), nullptr, &status);
+  UFormattedNumberRange* result = unumrf_openResult(&status);
+  if (formatter != nullptr && result != nullptr) {
+    if (!first.isDecimal() && !second.isDecimal()) {
+      unumrf_formatDoubleRange(formatter, first.getDouble(), second.getDouble(),
+                               result, &status);
+    } else {
+      const std::string first_value = first.isDecimal()
+                                          ? first.getDecimal()
+                                          : std::to_string(first.getDouble());
+      const std::string second_value = second.isDecimal()
+                                           ? second.getDecimal()
+                                           : std::to_string(second.getDouble());
+      unumrf_formatDecimalRange(formatter, first_value.data(),
+                                first_value.size(), second_value.data(),
+                                second_value.size(), result, &status);
+    }
+  }
+  unumrf_close(formatter);
+  const bool use_fullwidth_yen =
+      impl::IsJapaneseLocale(locale_) &&
+      skeleton_.find(u"currency/JPY") != std::u16string::npos;
+  return FormattedNumberRange(result, use_fullwidth_yen);
+}
+
+UnlocalizedNumberRangeFormatter
+UnlocalizedNumberRangeFormatter::numberFormatterBoth(
+    UnlocalizedNumberFormatter&& formatter) const {
+  UnlocalizedNumberRangeFormatter result(*this);
+  UErrorCode status = U_ZERO_ERROR;
+  UnicodeString skeleton = formatter.toSkeleton(status);
+  result.skeleton_.assign(skeleton.getBuffer(),
+                          skeleton.getBuffer() + skeleton.length());
+  return result;
+}
+
+LocalizedNumberRangeFormatter UnlocalizedNumberRangeFormatter::locale(
+    const Locale& locale) const {
+  return LocalizedNumberRangeFormatter(skeleton_, locale.getName());
+}
+
+}  // namespace number
+U_NAMESPACE_END

--- a/system_icu/numbering_system.cc
+++ b/system_icu/numbering_system.cc
@@ -1,0 +1,56 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <cstring>
+
+#include "unicode/numsys.h"
+
+U_NAMESPACE_BEGIN
+namespace {
+
+bool HasExplicitNumberingSystem(const Locale& locale) {
+  UErrorCode status = U_ZERO_ERROR;
+  char value[ULOC_KEYWORD_AND_VALUES_CAPACITY] = {};
+  const int32_t length =
+      locale.getKeywordValue("numbers", value, sizeof(value), status);
+  return U_SUCCESS(status) && length > 0;
+}
+
+}  // namespace
+
+NumberingSystem::NumberingSystem(UNumberingSystem* numbering_system)
+    : numbering_system_(numbering_system) {}
+
+NumberingSystem::~NumberingSystem() { unumsys_close(numbering_system_); }
+
+NumberingSystem* NumberingSystem::createInstance(const Locale& locale,
+                                                 UErrorCode& status) {
+  UNumberingSystem* numbering_system =
+      std::strcmp(locale.getLanguage(), "bn") == 0 &&
+              !HasExplicitNumberingSystem(locale)
+          ? unumsys_openByName("beng", &status)
+          : unumsys_open(locale.getName(), &status);
+  return numbering_system == nullptr ? nullptr
+                                     : new NumberingSystem(numbering_system);
+}
+
+NumberingSystem* NumberingSystem::createInstanceByName(const char* name,
+                                                       UErrorCode& status) {
+  UNumberingSystem* numbering_system = unumsys_openByName(name, &status);
+  return numbering_system == nullptr ? nullptr
+                                     : new NumberingSystem(numbering_system);
+}
+
+StringEnumeration* NumberingSystem::getAvailableNames(UErrorCode& status) {
+  UEnumeration* names = unumsys_openAvailableNames(&status);
+  return names == nullptr ? nullptr : new StringEnumeration(names);
+}
+
+const char* NumberingSystem::getName() const {
+  return unumsys_getName(numbering_system_);
+}
+
+UBool NumberingSystem::isAlgorithmic() const {
+  return unumsys_isAlgorithmic(numbering_system_);
+}
+
+U_NAMESPACE_END

--- a/system_icu/plural_rules.cc
+++ b/system_icu/plural_rules.cc
@@ -1,0 +1,99 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <array>
+#include <memory>
+#include <vector>
+
+#include "unicode/plurrule.h"
+#include "unicode/uloc.h"
+
+U_NAMESPACE_BEGIN
+namespace {
+
+template <typename Select>
+UnicodeString SelectKeyword(Select select, UErrorCode& status) {
+  if (U_FAILURE(status)) {
+    return {};
+  }
+
+  std::array<UChar, 32> stack_buffer;
+  int32_t length = select(stack_buffer.data(), stack_buffer.size(), &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR) {
+    return U_SUCCESS(status)
+               ? UnicodeString(
+                     reinterpret_cast<const char16_t*>(stack_buffer.data()),
+                     length)
+               : UnicodeString();
+  }
+
+  status = U_ZERO_ERROR;
+  std::vector<UChar> buffer(length + 1);
+  length = select(buffer.data(), buffer.size(), &status);
+  return U_SUCCESS(status)
+             ? UnicodeString(reinterpret_cast<const char16_t*>(buffer.data()),
+                             length)
+             : UnicodeString();
+}
+
+}  // namespace
+
+PluralRules::PluralRules(UPluralRules* rules) : rules_(rules) {}
+
+PluralRules::~PluralRules() { uplrules_close(rules_); }
+
+PluralRules* PluralRules::forLocale(const Locale& locale, UPluralType type,
+                                    UErrorCode& status) {
+  UPluralRules* rules = uplrules_openForType(locale.getName(), type, &status);
+  return U_SUCCESS(status) && rules != nullptr ? new PluralRules(rules)
+                                               : nullptr;
+}
+
+UnicodeString PluralRules::select(const number::FormattedNumber& number,
+                                  UErrorCode& status) const {
+  return SelectKeyword(
+      [&](UChar* result, int32_t capacity, UErrorCode* error) {
+        return uplrules_selectFormatted(rules_, number.toUFormattedNumber(),
+                                        result, capacity, error);
+      },
+      status);
+}
+
+UnicodeString PluralRules::select(const number::FormattedNumberRange& range,
+                                  UErrorCode& status) const {
+  return SelectKeyword(
+      [&](UChar* result, int32_t capacity, UErrorCode* error) {
+        return uplrules_selectForRange(rules_, range.toUFormattedNumberRange(),
+                                       result, capacity, error);
+      },
+      status);
+}
+
+StringEnumeration* PluralRules::getKeywords(UErrorCode& status) const {
+  UEnumeration* enumeration = uplrules_getKeywords(rules_, &status);
+  return U_SUCCESS(status) && enumeration != nullptr
+             ? new StringEnumeration(enumeration)
+             : nullptr;
+}
+
+StringEnumeration* PluralRules::getAvailableLocales(UErrorCode& status) {
+  // The C++ API exposes the formatting locale registry. The public C API's
+  // locale registry is the same superset and is stable for the process
+  // lifetime, which makes it safe to wrap in a UEnumeration without copying.
+  static const std::vector<const char*> locales = [] {
+    std::vector<const char*> result;
+    const int32_t count = uloc_countAvailable();
+    result.reserve(count);
+    for (int32_t i = 0; i < count; ++i) {
+      result.push_back(uloc_getAvailable(i));
+    }
+    return result;
+  }();
+
+  UEnumeration* enumeration = uenum_openCharStringsEnumeration(
+      locales.data(), static_cast<int32_t>(locales.size()), &status);
+  return U_SUCCESS(status) && enumeration != nullptr
+             ? new StringEnumeration(enumeration)
+             : nullptr;
+}
+
+U_NAMESPACE_END

--- a/system_icu/relative_date_time_formatter.cc
+++ b/system_icu/relative_date_time_formatter.cc
@@ -1,0 +1,83 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <utility>
+
+#include "unicode/reldatefmt.h"
+
+U_NAMESPACE_BEGIN
+
+FormattedRelativeDateTime::FormattedRelativeDateTime() : result_(nullptr) {}
+
+FormattedRelativeDateTime::FormattedRelativeDateTime(
+    UFormattedRelativeDateTime* result)
+    : result_(result) {}
+
+FormattedRelativeDateTime::FormattedRelativeDateTime(
+    FormattedRelativeDateTime&& other) noexcept
+    : result_(std::exchange(other.result_, nullptr)) {}
+
+FormattedRelativeDateTime& FormattedRelativeDateTime::operator=(
+    FormattedRelativeDateTime&& other) noexcept {
+  if (this != &other) {
+    ureldatefmt_closeResult(result_);
+    result_ = std::exchange(other.result_, nullptr);
+  }
+  return *this;
+}
+
+FormattedRelativeDateTime::~FormattedRelativeDateTime() {
+  ureldatefmt_closeResult(result_);
+}
+
+const UFormattedValue* FormattedRelativeDateTime::asUFormattedValue(
+    UErrorCode& status) const {
+  if (result_ == nullptr) {
+    status = U_INVALID_STATE_ERROR;
+    return nullptr;
+  }
+  return ureldatefmt_resultAsValue(result_, &status);
+}
+
+RelativeDateTimeFormatter::RelativeDateTimeFormatter(
+    const Locale& locale, NumberFormat* number_format_to_adopt,
+    UDateRelativeDateTimeFormatterStyle style,
+    UDisplayContext capitalization_context, UErrorCode& status)
+    : formatter_(nullptr), style_(style) {
+  UNumberFormat* number_format =
+      number_format_to_adopt == nullptr
+          ? nullptr
+          : number_format_to_adopt->orphanUNumberFormat();
+  delete number_format_to_adopt;
+  formatter_ = ureldatefmt_open(locale.getName(), number_format, style,
+                                capitalization_context, &status);
+}
+
+RelativeDateTimeFormatter::~RelativeDateTimeFormatter() {
+  ureldatefmt_close(formatter_);
+}
+
+FormattedRelativeDateTime RelativeDateTimeFormatter::formatNumericToValue(
+    double offset, URelativeDateTimeUnit unit, UErrorCode& status) const {
+  UFormattedRelativeDateTime* result = ureldatefmt_openResult(&status);
+  if (result != nullptr) {
+    ureldatefmt_formatNumericToResult(formatter_, offset, unit, result,
+                                      &status);
+  }
+  return FormattedRelativeDateTime(result);
+}
+
+FormattedRelativeDateTime RelativeDateTimeFormatter::formatToValue(
+    double offset, URelativeDateTimeUnit unit, UErrorCode& status) const {
+  UFormattedRelativeDateTime* result = ureldatefmt_openResult(&status);
+  if (result != nullptr) {
+    ureldatefmt_formatToResult(formatter_, offset, unit, result, &status);
+  }
+  return FormattedRelativeDateTime(result);
+}
+
+UDateRelativeDateTimeFormatterStyle RelativeDateTimeFormatter::getFormatStyle()
+    const {
+  return style_;
+}
+
+U_NAMESPACE_END

--- a/system_icu/resource_bundle.cc
+++ b/system_icu/resource_bundle.cc
@@ -1,0 +1,17 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <cstring>
+
+#include "unicode/ures.h"
+
+#undef ures_open
+
+extern "C" UResourceBundle* v8_icu_compat_ures_open(const char* package_name,
+                                                    const char* locale,
+                                                    UErrorCode* status) {
+  if (package_name != nullptr &&
+      std::strstr(package_name, "-coll") != nullptr) {
+    package_name = nullptr;
+  }
+  return ures_open(package_name, locale, status);
+}

--- a/system_icu/string_support.cc
+++ b/system_icu/string_support.cc
@@ -1,0 +1,61 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include "unicode/ustring.h"
+#include "unicode/utf16.h"
+#include "ustr_imp.h"
+
+namespace {
+
+bool IsSurrogatePairAt(const char16_t* string, int32_t length, int32_t index) {
+  const char16_t value = string[index];
+  return (U16_IS_LEAD(value) && index + 1 < length &&
+          U16_IS_TRAIL(string[index + 1])) ||
+         (U16_IS_TRAIL(value) && index > 0 && U16_IS_LEAD(string[index - 1]));
+}
+
+}  // namespace
+
+U_CFUNC int32_t U_EXPORT2 uprv_strCompare(
+    const char16_t* left, int32_t left_length, const char16_t* right,
+    int32_t right_length, UBool strncmp_style, UBool code_point_order) {
+  if (left == right && left_length == right_length) {
+    return 0;
+  }
+  if (left_length < 0) {
+    left_length = u_strlen(left);
+  }
+  if (right_length < 0) {
+    right_length = u_strlen(right);
+  }
+
+  const int32_t common_length =
+      left_length < right_length ? left_length : right_length;
+  int32_t index = 0;
+  char16_t left_value = 0;
+  char16_t right_value = 0;
+  while (index < common_length) {
+    left_value = left[index];
+    right_value = right[index];
+    if (left_value != right_value) {
+      break;
+    }
+    if (strncmp_style && left_value == 0) {
+      return 0;
+    }
+    ++index;
+  }
+
+  if (index == common_length) {
+    return left_length < right_length ? -1 : left_length > right_length ? 1 : 0;
+  }
+
+  if (code_point_order && left_value >= 0xd800 && right_value >= 0xd800) {
+    if (!IsSurrogatePairAt(left, left_length, index)) {
+      left_value -= 0x2800;
+    }
+    if (!IsSurrogatePairAt(right, right_length, index)) {
+      right_value -= 0x2800;
+    }
+  }
+  return static_cast<int32_t>(left_value) - static_cast<int32_t>(right_value);
+}

--- a/system_icu/system_icu.cc
+++ b/system_icu/system_icu.cc
@@ -1,0 +1,695 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "unicode/bytestream.h"
+#include "unicode/locid.h"
+#include "unicode/strenum.h"
+#include "unicode/uenum.h"
+#include "unicode/uloc.h"
+#include "unicode/unistr.h"
+#include "unicode/ustring.h"
+
+U_NAMESPACE_BEGIN
+
+namespace {
+
+char* CopyString(const char* value) {
+  const size_t length = std::strlen(value);
+  auto* result = static_cast<char*>(std::malloc(length + 1));
+  if (result != nullptr) {
+    std::memcpy(result, value, length + 1);
+  }
+  return result;
+}
+
+std::string ToLanguageTag(const char* locale_id, UErrorCode& status) {
+  const int32_t required =
+      uloc_toLanguageTag(locale_id, nullptr, 0, true, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return {};
+  }
+  status = U_ZERO_ERROR;
+  std::string result(required + 1, '\0');
+  const int32_t length = uloc_toLanguageTag(locale_id, result.data(),
+                                            result.size(), true, &status);
+  return U_SUCCESS(status) ? std::string(result.data(), length) : std::string();
+}
+
+std::string ParsedKeywordValue(const char* locale_id, const char* keyword,
+                               UErrorCode& status) {
+  const char* entry = std::strchr(locale_id, '@');
+  if (entry == nullptr) {
+    return {};
+  }
+  ++entry;
+  const size_t keyword_length = std::strlen(keyword);
+  while (*entry != '\0') {
+    const char* equals = std::strchr(entry, '=');
+    if (equals == nullptr) {
+      break;
+    }
+    const char* end = std::strchr(equals + 1, ';');
+    if (end == nullptr) {
+      end = locale_id + std::strlen(locale_id);
+    }
+    if (static_cast<size_t>(equals - entry) == keyword_length &&
+        std::memcmp(entry, keyword, keyword_length) == 0) {
+      status = U_ZERO_ERROR;
+      return std::string(equals + 1, end);
+    }
+    entry = *end == '\0' ? end : end + 1;
+  }
+  return {};
+}
+
+std::string KeywordValue(const char* locale_id, const char* keyword,
+                         UErrorCode& status) {
+  const int32_t required =
+      uloc_getKeywordValue(locale_id, keyword, nullptr, 0, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return ParsedKeywordValue(locale_id, keyword, status);
+  }
+  if (required == 0) {
+    return {};
+  }
+  status = U_ZERO_ERROR;
+  std::string result(required + 1, '\0');
+  const int32_t length = uloc_getKeywordValue(locale_id, keyword, result.data(),
+                                              result.size(), &status);
+  if (U_SUCCESS(status)) {
+    return std::string(result.data(), length);
+  }
+
+  // Older ICU versions can enumerate all keywords in a long locale ID but
+  // fail to retrieve values near its capacity limit. The locale has already
+  // been normalized, so recover the value from its key=value list directly.
+  return ParsedKeywordValue(locale_id, keyword, status);
+}
+
+std::string ApplyModernLocaleAliases(std::string locale_id) {
+  const size_t keywords = locale_id.find('@');
+  const std::string base = locale_id.substr(0, keywords);
+  const std::string suffix = keywords == std::string::npos
+                                 ? std::string()
+                                 : locale_id.substr(keywords);
+
+  // These aliases were added after the ICU version shipped by older supported
+  // macOS releases. Keep the small CLDR delta here rather than shipping locale
+  // data alongside the executable.
+  if (base == "cel__GAULISH") {
+    return "xtg" + suffix;
+  }
+  if (base == "sr_CS") {
+    return "sr_Cyrl_RS" + suffix;
+  }
+  if (base == "hy_SU") {
+    return "hy_AM" + suffix;
+  }
+  if (base == "lv_SU") {
+    return "lv_LV" + suffix;
+  }
+
+  struct LanguageAlias {
+    const char* from;
+    const char* to;
+    const char* default_script;
+    const char* default_region;
+  };
+  constexpr LanguageAlias kLanguageAliases[] = {
+      {"arb", "ar", "", ""},    {"cmn", "zh", "", ""}, {"cnr", "sr", "", "ME"},
+      {"kmr", "ku", "", ""},    {"scc", "sr", "", ""}, {"scr", "hr", "", ""},
+      {"sh", "sr", "Latn", ""}, {"swh", "sw", "", ""}, {"tl", "fil", "", ""},
+      {"uzn", "uz", "", ""},    {"zsm", "ms", "", ""},
+  };
+  for (const auto& alias : kLanguageAliases) {
+    const size_t from_length = std::strlen(alias.from);
+    if (base == alias.from || (base.size() > from_length &&
+                               base.compare(0, from_length, alias.from) == 0 &&
+                               base[from_length] == '_')) {
+      UErrorCode status = U_ZERO_ERROR;
+      char script[ULOC_SCRIPT_CAPACITY] = {};
+      char region[ULOC_COUNTRY_CAPACITY] = {};
+      char variant[ULOC_FULLNAME_CAPACITY] = {};
+      uloc_getScript(base.c_str(), script, sizeof(script), &status);
+      status = U_ZERO_ERROR;
+      uloc_getCountry(base.c_str(), region, sizeof(region), &status);
+      status = U_ZERO_ERROR;
+      uloc_getVariant(base.c_str(), variant, sizeof(variant), &status);
+
+      std::string result(alias.to);
+      const char* resolved_script =
+          script[0] == 0 ? alias.default_script : script;
+      const char* resolved_region =
+          region[0] == 0 ? alias.default_region : region;
+      if (resolved_script[0] != 0) {
+        result += "_";
+        result += resolved_script;
+      }
+      if (resolved_region[0] != 0) {
+        result += "_";
+        result += resolved_region;
+      } else if (variant[0] != 0) {
+        result += "_";
+      }
+      if (variant[0] != 0) {
+        result += "_";
+        result += variant;
+      }
+      return result + suffix;
+    }
+  }
+  return locale_id;
+}
+
+void LongLocaleToLanguageTag(const Locale& locale, ByteSink& sink,
+                             UErrorCode& status) {
+  std::string base_tag = ToLanguageTag(locale.getBaseName(), status);
+  if (U_FAILURE(status)) {
+    return;
+  }
+
+  std::vector<std::pair<std::string, std::string>> unicode_keywords;
+  constexpr char kPosixSuffix[] = "-u-va-posix";
+  if (base_tag.size() >= sizeof(kPosixSuffix) - 1 &&
+      base_tag.compare(base_tag.size() - (sizeof(kPosixSuffix) - 1),
+                       sizeof(kPosixSuffix) - 1, kPosixSuffix) == 0) {
+    base_tag.resize(base_tag.size() - (sizeof(kPosixSuffix) - 1));
+    unicode_keywords.emplace_back("va", "posix");
+  }
+
+  UEnumeration* keywords = uloc_openKeywords(locale.getName(), &status);
+  if (U_FAILURE(status)) {
+    return;
+  }
+  if (keywords != nullptr) {
+    int32_t legacy_key_length = 0;
+    const char* legacy_key;
+    while ((legacy_key = uenum_next(keywords, &legacy_key_length, &status)) !=
+           nullptr) {
+      const char* unicode_key = uloc_toUnicodeLocaleKey(legacy_key);
+      if (unicode_key == nullptr || std::strlen(unicode_key) != 2) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        break;
+      }
+      std::string legacy_value =
+          KeywordValue(locale.getName(), legacy_key, status);
+      if (U_FAILURE(status)) {
+        break;
+      }
+      const char* unicode_value =
+          uloc_toUnicodeLocaleType(legacy_key, legacy_value.c_str());
+      if (unicode_value == nullptr) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        break;
+      }
+      unicode_keywords.emplace_back(unicode_key, unicode_value);
+    }
+    uenum_close(keywords);
+    if (U_FAILURE(status)) {
+      return;
+    }
+  }
+
+  std::sort(unicode_keywords.begin(), unicode_keywords.end());
+  std::string result = std::move(base_tag);
+  if (!unicode_keywords.empty()) {
+    result += "-u";
+    for (const auto& [key, value] : unicode_keywords) {
+      result += '-';
+      result += key;
+      if (value != "true") {
+        result += '-';
+        result += value;
+      }
+    }
+  }
+  sink.Append(result.data(), result.size());
+}
+
+}  // namespace
+
+Locale& Locale::init(const char* locale_id, UBool canonicalize) {
+  if (locale_id == nullptr) {
+    locale_id = "";
+  }
+
+  UErrorCode status = U_ZERO_ERROR;
+  char normalized[ULOC_FULLNAME_CAPACITY] = {};
+  const int32_t normalized_length =
+      canonicalize
+          ? uloc_canonicalize(locale_id, normalized, sizeof(normalized),
+                              &status)
+          : uloc_getName(locale_id, normalized, sizeof(normalized), &status);
+
+  std::string dynamic_normalized;
+  const char* name = normalized;
+  if (status == U_BUFFER_OVERFLOW_ERROR ||
+      normalized_length >= static_cast<int32_t>(sizeof(normalized))) {
+    status = U_ZERO_ERROR;
+    dynamic_normalized.resize(normalized_length + 1);
+    if (canonicalize) {
+      uloc_canonicalize(locale_id, dynamic_normalized.data(),
+                        dynamic_normalized.size(), &status);
+    } else {
+      uloc_getName(locale_id, dynamic_normalized.data(),
+                   dynamic_normalized.size(), &status);
+    }
+    if (U_SUCCESS(status)) {
+      dynamic_normalized[normalized_length] = '\0';
+    }
+    name = dynamic_normalized.c_str();
+  } else if (U_SUCCESS(status) && normalized_length >= 0) {
+    normalized[normalized_length] = '\0';
+  }
+
+  std::string aliased;
+  if (U_FAILURE(status)) {
+    name = "";
+    fIsBogus = true;
+  } else {
+    fIsBogus = false;
+    if (canonicalize) {
+      aliased = ApplyModernLocaleAliases(name);
+      name = aliased.c_str();
+    }
+  }
+
+  if (fullName != nullptr && fullName != fullNameBuffer) {
+    std::free(fullName);
+  }
+  if (baseName != nullptr && baseName != fullName &&
+      baseName != fullNameBuffer) {
+    std::free(baseName);
+  }
+
+  const size_t name_length = std::strlen(name);
+  if (name_length < sizeof(fullNameBuffer)) {
+    std::memcpy(fullNameBuffer, name, name_length + 1);
+    fullName = fullNameBuffer;
+  } else {
+    fullName = CopyString(name);
+    if (fullName == nullptr) {
+      fullNameBuffer[0] = 0;
+      fullName = fullNameBuffer;
+      fIsBogus = true;
+    }
+  }
+
+  status = U_ZERO_ERROR;
+  const int32_t base_length = uloc_getBaseName(fullName, nullptr, 0, &status);
+  std::string base;
+  if (status == U_BUFFER_OVERFLOW_ERROR) {
+    status = U_ZERO_ERROR;
+    base.resize(base_length + 1);
+    uloc_getBaseName(fullName, base.data(), base.size(), &status);
+  }
+  if (U_FAILURE(status)) {
+    base = "";
+    fIsBogus = true;
+  }
+  baseName = CopyString(base.c_str());
+  if (baseName == nullptr) {
+    baseName = fullName;
+    fIsBogus = true;
+  }
+
+  status = U_ZERO_ERROR;
+  uloc_getLanguage(fullName, language, sizeof(language), &status);
+  status = U_ZERO_ERROR;
+  uloc_getScript(fullName, script, sizeof(script), &status);
+  status = U_ZERO_ERROR;
+  uloc_getCountry(fullName, country, sizeof(country), &status);
+
+  char variant[ULOC_FULLNAME_CAPACITY];
+  status = U_ZERO_ERROR;
+  uloc_getVariant(fullName, variant, sizeof(variant), &status);
+  if (U_SUCCESS(status) && variant[0] != 0) {
+    const char* location = std::strstr(baseName, variant);
+    variantBegin =
+        location == nullptr ? std::strlen(baseName) : location - baseName;
+  } else {
+    variantBegin = std::strlen(baseName);
+  }
+  return *this;
+}
+
+Locale::Locale()
+    : variantBegin(0),
+      fullName(fullNameBuffer),
+      baseName(nullptr),
+      fIsBogus(false) {
+  fullNameBuffer[0] = 0;
+  init(uloc_getDefault(), false);
+}
+
+Locale::Locale(const char* language_value, const char* country_value,
+               const char* variant_value, const char* keywords_and_values)
+    : variantBegin(0),
+      fullName(fullNameBuffer),
+      baseName(nullptr),
+      fIsBogus(false) {
+  fullNameBuffer[0] = 0;
+  std::string id = language_value == nullptr ? "" : language_value;
+  if (country_value != nullptr && country_value[0] != 0) {
+    id += '_';
+    id += country_value;
+  }
+  if (variant_value != nullptr && variant_value[0] != 0) {
+    id += '_';
+    id += variant_value;
+  }
+  if (keywords_and_values != nullptr && keywords_and_values[0] != 0) {
+    id += '@';
+    id += keywords_and_values;
+  }
+  init(id.c_str(), false);
+}
+
+Locale::Locale(const Locale& other)
+    : variantBegin(0),
+      fullName(fullNameBuffer),
+      baseName(nullptr),
+      fIsBogus(false) {
+  fullNameBuffer[0] = 0;
+  init(other.getName(), false);
+}
+
+Locale::Locale(Locale&& other) noexcept
+    : variantBegin(0),
+      fullName(fullNameBuffer),
+      baseName(nullptr),
+      fIsBogus(false) {
+  fullNameBuffer[0] = 0;
+  init(other.getName(), false);
+}
+
+Locale::~Locale() {
+  if (baseName != nullptr && baseName != fullName &&
+      baseName != fullNameBuffer) {
+    std::free(baseName);
+  }
+  if (fullName != nullptr && fullName != fullNameBuffer) {
+    std::free(fullName);
+  }
+}
+
+Locale& Locale::operator=(const Locale& other) {
+  if (this != &other) {
+    init(other.getName(), false);
+  }
+  return *this;
+}
+
+Locale& Locale::operator=(Locale&& other) noexcept {
+  if (this != &other) {
+    init(other.getName(), false);
+  }
+  return *this;
+}
+
+Locale* Locale::clone() const { return new Locale(*this); }
+
+Locale Locale::createFromName(const char* name) {
+  return Locale(name, "", "", "");
+}
+
+Locale Locale::createCanonical(const char* name) {
+  Locale locale(name, "", "", "");
+  UErrorCode status = U_ZERO_ERROR;
+  locale.canonicalize(status);
+  return locale;
+}
+
+void Locale::canonicalize(UErrorCode& status) {
+  if (U_SUCCESS(status)) {
+    init(getName(), true);
+    if (isBogus()) {
+      status = U_ILLEGAL_ARGUMENT_ERROR;
+    }
+  }
+}
+
+void Locale::addLikelySubtags(UErrorCode& status) {
+  if (U_FAILURE(status)) {
+    return;
+  }
+  int32_t required = uloc_addLikelySubtags(getName(), nullptr, 0, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return;
+  }
+  status = U_ZERO_ERROR;
+  std::string locale_id(required + 1, '\0');
+  uloc_addLikelySubtags(getName(), locale_id.data(), locale_id.size(), &status);
+  if (U_SUCCESS(status)) {
+    init(locale_id.c_str(), false);
+  }
+}
+
+void Locale::minimizeSubtags(UErrorCode& status) {
+  if (U_FAILURE(status)) {
+    return;
+  }
+  int32_t required = uloc_minimizeSubtags(getName(), nullptr, 0, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return;
+  }
+  status = U_ZERO_ERROR;
+  std::string locale_id(required + 1, '\0');
+  uloc_minimizeSubtags(getName(), locale_id.data(), locale_id.size(), &status);
+  if (U_SUCCESS(status)) {
+    init(locale_id.c_str(), false);
+  }
+}
+
+UBool Locale::isRightToLeft() const {
+  // These minority languages were added to CLDR's right-to-left metadata
+  // after the ICU version on older supported macOS releases.
+  return (std::strcmp(getLanguage(), "bcc") == 0 ||
+          std::strcmp(getLanguage(), "pnb") == 0) ||
+         uloc_isRightToLeft(getName());
+}
+
+int32_t Locale::getKeywordValue(const char* keyword, char* buffer,
+                                int32_t capacity, UErrorCode& status) const {
+  return uloc_getKeywordValue(getName(), keyword, buffer, capacity, &status);
+}
+
+StringEnumeration* Locale::createKeywords(UErrorCode& status) const {
+  UEnumeration* keywords = uloc_openKeywords(getName(), &status);
+  return keywords == nullptr ? nullptr : new StringEnumeration(keywords);
+}
+
+const char* Locale::getBaseName() const { return baseName; }
+
+bool Locale::operator==(const Locale& other) const {
+  return std::strcmp(getName(), other.getName()) == 0;
+}
+
+Locale Locale::forLanguageTag(StringPiece tag, UErrorCode& status) {
+  if (U_FAILURE(status)) {
+    return Locale("", "", "", "");
+  }
+  std::string input(tag.data(), tag.length());
+  const int32_t required =
+      uloc_forLanguageTag(input.c_str(), nullptr, 0, nullptr, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return Locale("", "", "", "");
+  }
+  status = U_ZERO_ERROR;
+  std::string locale_id(required + 1, '\0');
+  int32_t parsed_length = 0;
+  uloc_forLanguageTag(input.c_str(), locale_id.data(), locale_id.size(),
+                      &parsed_length, &status);
+  if (U_FAILURE(status) || parsed_length != tag.length()) {
+    if (U_SUCCESS(status)) {
+      status = U_ILLEGAL_ARGUMENT_ERROR;
+    }
+    return Locale("", "", "", "");
+  }
+  return Locale(locale_id.c_str(), "", "", "");
+}
+
+void Locale::toLanguageTag(ByteSink& sink, UErrorCode& status) const {
+  if (U_FAILURE(status)) {
+    return;
+  }
+  const int32_t required =
+      uloc_toLanguageTag(getName(), nullptr, 0, true, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    if (status == U_ILLEGAL_ARGUMENT_ERROR && !isBogus()) {
+      status = U_ZERO_ERROR;
+      LongLocaleToLanguageTag(*this, sink, status);
+    }
+    return;
+  }
+  status = U_ZERO_ERROR;
+  std::string tag(required + 1, '\0');
+  const int32_t length =
+      uloc_toLanguageTag(getName(), tag.data(), tag.size(), true, &status);
+  if (U_SUCCESS(status)) {
+    sink.Append(tag.data(), length);
+  } else if (status == U_ILLEGAL_ARGUMENT_ERROR && !isBogus()) {
+    status = U_ZERO_ERROR;
+    LongLocaleToLanguageTag(*this, sink, status);
+  }
+}
+
+void Locale::setUnicodeKeywordValue(StringPiece keyword, StringPiece value,
+                                    UErrorCode& status) {
+  if (U_FAILURE(status)) {
+    return;
+  }
+  const std::string unicode_key(keyword.data(), keyword.length());
+  const std::string unicode_value(value.data(), value.length());
+  const char* legacy_key = uloc_toLegacyKey(unicode_key.c_str());
+  const char* legacy_value =
+      unicode_value.empty()
+          ? ""
+          : uloc_toLegacyType(unicode_key.c_str(), unicode_value.c_str());
+  if (legacy_key == nullptr || legacy_value == nullptr) {
+    status = U_ILLEGAL_ARGUMENT_ERROR;
+    return;
+  }
+
+  int32_t capacity = std::max<int32_t>(
+      ULOC_FULLNAME_CAPACITY,
+      std::strlen(getName()) + unicode_key.size() + unicode_value.size() + 32);
+  for (;;) {
+    std::string result(capacity, '\0');
+    std::strcpy(result.data(), getName());
+    const int32_t length = uloc_setKeywordValue(
+        legacy_key, legacy_value, result.data(), result.size(), &status);
+    if (status == U_BUFFER_OVERFLOW_ERROR) {
+      status = U_ZERO_ERROR;
+      capacity = length + 1;
+      continue;
+    }
+    if (U_SUCCESS(status)) {
+      init(result.c_str(), false);
+    }
+    return;
+  }
+}
+
+void Locale::getUnicodeKeywordValue(StringPiece keyword, ByteSink& sink,
+                                    UErrorCode& status) const {
+  if (U_FAILURE(status)) {
+    return;
+  }
+  const std::string unicode_key(keyword.data(), keyword.length());
+  const char* legacy_key = uloc_toLegacyKey(unicode_key.c_str());
+  if (legacy_key == nullptr) {
+    status = U_ILLEGAL_ARGUMENT_ERROR;
+    return;
+  }
+  const int32_t required =
+      uloc_getKeywordValue(getName(), legacy_key, nullptr, 0, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return;
+  }
+  if (required == 0) {
+    status = U_ILLEGAL_ARGUMENT_ERROR;
+    return;
+  }
+  status = U_ZERO_ERROR;
+  std::string value(required + 1, '\0');
+  const int32_t length = uloc_getKeywordValue(
+      getName(), legacy_key, value.data(), value.size(), &status);
+  if (U_SUCCESS(status)) {
+    value.resize(length);
+    const char* unicode_value =
+        uloc_toUnicodeLocaleType(unicode_key.c_str(), value.c_str());
+    if (unicode_value == nullptr) {
+      status = U_ILLEGAL_ARGUMENT_ERROR;
+      return;
+    }
+    sink.Append(unicode_value, std::strlen(unicode_value));
+  }
+}
+
+const Locale& Locale::getDefault() {
+  static Locale locale(uloc_getDefault(), "", "", "");
+  return locale;
+}
+
+const Locale& Locale::getRoot() {
+  static Locale locale("");
+  return locale;
+}
+
+void Locale::setDefault(const Locale& new_locale, UErrorCode& status) {
+  uloc_setDefault(new_locale.getName(), &status);
+}
+
+UClassID Locale::getStaticClassID() {
+  static char class_id = 0;
+  return &class_id;
+}
+
+UClassID Locale::getDynamicClassID() const { return getStaticClassID(); }
+
+Locale::Iterator::~Iterator() = default;
+
+UnicodeString& UnicodeString::toUpper() {
+  UErrorCode status = U_ZERO_ERROR;
+  const int32_t required =
+      u_strToUpper(nullptr, 0, reinterpret_cast<const UChar*>(getBuffer()),
+                   length(), nullptr, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return *this;
+  }
+  status = U_ZERO_ERROR;
+  std::u16string result(required, u'\0');
+  u_strToUpper(reinterpret_cast<UChar*>(result.data()), result.size(),
+               reinterpret_cast<const UChar*>(getBuffer()), length(), nullptr,
+               &status);
+  if (U_SUCCESS(status)) {
+    *this = UnicodeString(result);
+  }
+  return *this;
+}
+
+int8_t UnicodeString::doCaseCompare(int32_t start, int32_t requested_length,
+                                    const char16_t* source,
+                                    int32_t source_start, int32_t source_length,
+                                    uint32_t options) const {
+  if (isBogus()) {
+    return -1;
+  }
+
+  start = std::clamp(start, 0, length());
+  const int32_t actual_length =
+      std::clamp(requested_length, 0, length() - start);
+  if (source == nullptr) {
+    static const char16_t empty[] = u"";
+    source = empty;
+    source_start = 0;
+    source_length = 0;
+  } else {
+    source += std::max(source_start, 0);
+  }
+  UErrorCode status = U_ZERO_ERROR;
+  const int32_t result = u_strCaseCompare(
+      reinterpret_cast<const UChar*>(getBuffer() + start), actual_length,
+      reinterpret_cast<const UChar*>(source), source_length, options, &status);
+  if (U_FAILURE(status)) {
+    return -1;
+  }
+  return result < 0 ? -1 : result > 0 ? 1 : 0;
+}
+
+U_NAMESPACE_END
+
+extern "C" {
+
+void* uprv_malloc(size_t size) { return std::malloc(size); }
+
+void uprv_free(void* memory) { std::free(memory); }
+
+}  // extern "C"

--- a/system_icu/time_zone.cc
+++ b/system_icu/time_zone.cc
@@ -1,0 +1,239 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <vector>
+
+#include "unicode/basictz.h"
+#include "unicode/uloc.h"
+
+U_NAMESPACE_BEGIN
+
+namespace {
+
+UnicodeString ReadDefaultTimeZone(UErrorCode& status) {
+  int32_t length = ucal_getDefaultTimeZone(nullptr, 0, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(status)) {
+    return {};
+  }
+  status = U_ZERO_ERROR;
+  std::vector<UChar> buffer(length + 1);
+  length = ucal_getDefaultTimeZone(buffer.data(), buffer.size(), &status);
+  return U_SUCCESS(status)
+             ? UnicodeString(reinterpret_cast<const char16_t*>(buffer.data()),
+                             length)
+             : UnicodeString();
+}
+
+UCalendarDisplayNameType DisplayNameType(UBool daylight,
+                                         TimeZone::EDisplayType style) {
+  if (style == TimeZone::SHORT) {
+    return daylight ? UCAL_SHORT_DST : UCAL_SHORT_STANDARD;
+  }
+  return daylight ? UCAL_DST : UCAL_STANDARD;
+}
+
+}  // namespace
+
+TimeZone::TimeZone(const UnicodeString& id) : id_(id) {}
+
+TimeZone::TimeZone(const TimeZone& other) = default;
+
+TimeZone& TimeZone::operator=(const TimeZone& other) = default;
+
+TimeZone::~TimeZone() = default;
+
+TimeZone* TimeZone::clone() const { return new BasicTimeZone(id_); }
+
+bool TimeZone::operator==(const TimeZone& other) const {
+  return id_ == other.id_;
+}
+
+TimeZone* TimeZone::createTimeZone(const UnicodeString& id) {
+  return new BasicTimeZone(id);
+}
+
+TimeZone* TimeZone::createDefault() {
+  UErrorCode status = U_ZERO_ERROR;
+  UnicodeString id = ReadDefaultTimeZone(status);
+  if (U_FAILURE(status)) {
+    id = UnicodeString("Etc/UTC", -1, US_INV);
+  }
+  return new BasicTimeZone(id);
+}
+
+TimeZone* TimeZone::detectHostTimeZone() { return createDefault(); }
+
+void TimeZone::adoptDefault(TimeZone* zone) {
+  if (zone == nullptr) {
+    return;
+  }
+  UErrorCode status = U_ZERO_ERROR;
+  ucal_setDefaultTimeZone(
+      reinterpret_cast<const UChar*>(zone->id_.getTerminatedBuffer()), &status);
+  delete zone;
+}
+
+const TimeZone* TimeZone::getGMT() {
+  static const BasicTimeZone gmt(UnicodeString("Etc/GMT", -1, US_INV));
+  return &gmt;
+}
+
+StringEnumeration* TimeZone::createEnumeration() {
+  UErrorCode status = U_ZERO_ERROR;
+  UEnumeration* enumeration = ucal_openTimeZones(&status);
+  return enumeration == nullptr ? nullptr : new StringEnumeration(enumeration);
+}
+
+StringEnumeration* TimeZone::createTimeZoneIDEnumeration(
+    USystemTimeZoneType zone_type, const char* region,
+    const int32_t* raw_offset, UErrorCode& status) {
+  UEnumeration* enumeration =
+      ucal_openTimeZoneIDEnumeration(zone_type, region, raw_offset, &status);
+  return enumeration == nullptr ? nullptr : new StringEnumeration(enumeration);
+}
+
+UnicodeString& TimeZone::getCanonicalID(const UnicodeString& id,
+                                        UnicodeString& canonical,
+                                        UErrorCode& status) {
+  UBool is_system_id = false;
+  std::vector<UChar> buffer(128);
+  int32_t length = ucal_getCanonicalTimeZoneID(
+      reinterpret_cast<const UChar*>(id.getBuffer()), id.length(),
+      buffer.data(), buffer.size(), &is_system_id, &status);
+  if (status == U_BUFFER_OVERFLOW_ERROR) {
+    status = U_ZERO_ERROR;
+    buffer.resize(length + 1);
+    length = ucal_getCanonicalTimeZoneID(
+        reinterpret_cast<const UChar*>(id.getBuffer()), id.length(),
+        buffer.data(), buffer.size(), &is_system_id, &status);
+  }
+  if (U_SUCCESS(status)) {
+    canonical.remove();
+    canonical.append(reinterpret_cast<const char16_t*>(buffer.data()), length);
+  }
+  return canonical;
+}
+
+UnicodeString& TimeZone::getID(UnicodeString& id) const {
+  id = id_;
+  return id;
+}
+
+UCalendar* TimeZone::openCalendar(UErrorCode& status) const {
+  return ucal_open(reinterpret_cast<const UChar*>(id_.getBuffer()),
+                   id_.length(), uloc_getDefault(), UCAL_DEFAULT, &status);
+}
+
+void TimeZone::getDisplayName(UBool daylight, EDisplayType style,
+                              UnicodeString& result) const {
+  UErrorCode status = U_ZERO_ERROR;
+  UCalendar* calendar = openCalendar(status);
+  if (calendar == nullptr) {
+    return;
+  }
+  int32_t length =
+      ucal_getTimeZoneDisplayName(calendar, DisplayNameType(daylight, style),
+                                  uloc_getDefault(), nullptr, 0, &status);
+  if (status == U_BUFFER_OVERFLOW_ERROR) {
+    status = U_ZERO_ERROR;
+    std::vector<UChar> buffer(length + 1);
+    length = ucal_getTimeZoneDisplayName(
+        calendar, DisplayNameType(daylight, style), uloc_getDefault(),
+        buffer.data(), buffer.size(), &status);
+    if (U_SUCCESS(status)) {
+      result.remove();
+      result.append(reinterpret_cast<const char16_t*>(buffer.data()), length);
+    }
+  }
+  ucal_close(calendar);
+}
+
+void TimeZone::getOffset(UDate date, UBool local, int32_t& raw_offset,
+                         int32_t& dst_offset, UErrorCode& status) const {
+  UCalendar* calendar = openCalendar(status);
+  if (calendar == nullptr) {
+    return;
+  }
+  ucal_setMillis(calendar, date, &status);
+  if (local && U_SUCCESS(status)) {
+    ucal_getTimeZoneOffsetFromLocal(calendar, UCAL_TZ_LOCAL_FORMER,
+                                    UCAL_TZ_LOCAL_FORMER, &raw_offset,
+                                    &dst_offset, &status);
+  } else if (U_SUCCESS(status)) {
+    raw_offset = ucal_get(calendar, UCAL_ZONE_OFFSET, &status);
+    dst_offset = ucal_get(calendar, UCAL_DST_OFFSET, &status);
+  }
+  ucal_close(calendar);
+}
+
+BasicTimeZone::BasicTimeZone(const UnicodeString& id) : TimeZone(id) {}
+
+BasicTimeZone::BasicTimeZone(const BasicTimeZone& other) = default;
+
+BasicTimeZone::~BasicTimeZone() = default;
+
+BasicTimeZone* BasicTimeZone::clone() const { return new BasicTimeZone(*this); }
+
+void BasicTimeZone::getOffsetFromLocal(
+    UDate date, UTimeZoneLocalOption non_existing_time_opt,
+    UTimeZoneLocalOption duplicated_time_opt, int32_t& raw_offset,
+    int32_t& dst_offset, UErrorCode& status) const {
+  UCalendar* calendar = openCalendar(status);
+  if (calendar == nullptr) {
+    return;
+  }
+  ucal_setMillis(calendar, date, &status);
+  if (U_SUCCESS(status)) {
+    ucal_getTimeZoneOffsetFromLocal(calendar, non_existing_time_opt,
+                                    duplicated_time_opt, &raw_offset,
+                                    &dst_offset, &status);
+  }
+  ucal_close(calendar);
+}
+
+UBool BasicTimeZone::getNextTransition(UDate base, UBool inclusive,
+                                       TimeZoneTransition& result) const {
+  UErrorCode status = U_ZERO_ERROR;
+  UCalendar* calendar = openCalendar(status);
+  if (calendar == nullptr) {
+    return false;
+  }
+  ucal_setMillis(calendar, base, &status);
+  UDate transition = 0;
+  UBool found =
+      U_SUCCESS(status) && ucal_getTimeZoneTransitionDate(
+                               calendar,
+                               inclusive ? UCAL_TZ_TRANSITION_NEXT_INCLUSIVE
+                                         : UCAL_TZ_TRANSITION_NEXT,
+                               &transition, &status);
+  ucal_close(calendar);
+  if (found && U_SUCCESS(status)) {
+    result.setTime(transition);
+    return true;
+  }
+  return false;
+}
+
+UBool BasicTimeZone::getPreviousTransition(UDate base, UBool inclusive,
+                                           TimeZoneTransition& result) const {
+  UErrorCode status = U_ZERO_ERROR;
+  UCalendar* calendar = openCalendar(status);
+  if (calendar == nullptr) {
+    return false;
+  }
+  ucal_setMillis(calendar, base, &status);
+  UDate transition = 0;
+  UBool found =
+      U_SUCCESS(status) && ucal_getTimeZoneTransitionDate(
+                               calendar,
+                               inclusive ? UCAL_TZ_TRANSITION_PREVIOUS_INCLUSIVE
+                                         : UCAL_TZ_TRANSITION_PREVIOUS,
+                               &transition, &status);
+  ucal_close(calendar);
+  if (found && U_SUCCESS(status)) {
+    result.setTime(transition);
+    return true;
+  }
+  return false;
+}
+
+U_NAMESPACE_END

--- a/system_icu/unicode_set.cc
+++ b/system_icu/unicode_set.cc
@@ -1,0 +1,173 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+#include <string>
+#include <utility>
+
+#include "unicode/uniset.h"
+#include "unicode/unistr.h"
+#include "unicode/usetiter.h"
+
+U_NAMESPACE_BEGIN
+
+namespace {
+
+UChar32 GetRangeEndpoint(const USet* set, int32_t index, bool get_end) {
+  UErrorCode status = U_ZERO_ERROR;
+  UChar32 start = 0;
+  UChar32 end = 0;
+  uset_getItem(set, index, &start, &end, nullptr, 0, &status);
+  return U_SUCCESS(status) ? (get_end ? end : start) : -1;
+}
+
+int32_t GetRangeCount(const USet* set) {
+  const int32_t item_count = uset_getItemCount(set);
+  for (int32_t index = 0; index < item_count; ++index) {
+    UErrorCode status = U_ZERO_ERROR;
+    UChar32 start = 0;
+    UChar32 end = 0;
+    const int32_t length =
+        uset_getItem(set, index, &start, &end, nullptr, 0, &status);
+    if (length != 0 || status == U_BUFFER_OVERFLOW_ERROR) {
+      return index;
+    }
+  }
+  return item_count;
+}
+
+}  // namespace
+
+UnicodeSet::UnicodeSet() : set_(uset_openEmpty()) {}
+
+UnicodeSet::UnicodeSet(UChar32 start, UChar32 end)
+    : set_(uset_open(start, end)) {}
+
+UnicodeSet::UnicodeSet(const UnicodeString& pattern, UErrorCode& status)
+    : set_(nullptr) {
+  if (U_SUCCESS(status)) {
+    set_ = uset_openPattern(reinterpret_cast<const UChar*>(pattern.getBuffer()),
+                            pattern.length(), &status);
+  }
+  if (set_ == nullptr) {
+    set_ = uset_openEmpty();
+  }
+}
+
+UnicodeSet::UnicodeSet(const UnicodeSet& other)
+    : set_(uset_clone(other.set_)) {}
+
+UnicodeSet::~UnicodeSet() { uset_close(set_); }
+
+UnicodeSet& UnicodeSet::operator=(const UnicodeSet& other) {
+  if (this != &other) {
+    USet* replacement = uset_clone(other.set_);
+    uset_close(set_);
+    set_ = replacement;
+  }
+  return *this;
+}
+
+UnicodeSet& UnicodeSet::set(UChar32 start, UChar32 end) {
+  uset_set(set_, start, end);
+  return *this;
+}
+
+UnicodeSet& UnicodeSet::add(UChar32 code_point) {
+  uset_add(set_, code_point);
+  return *this;
+}
+
+UnicodeSet& UnicodeSet::add(UChar32 start, UChar32 end) {
+  uset_addRange(set_, start, end);
+  return *this;
+}
+
+UnicodeSet& UnicodeSet::removeAll(const UnicodeSet& other) {
+  uset_removeAll(set_, other.set_);
+  return *this;
+}
+
+UnicodeSet& UnicodeSet::closeOver(int32_t attributes) {
+  uset_closeOver(set_, attributes);
+  return *this;
+}
+
+UnicodeSet& UnicodeSet::applyIntPropertyValue(UProperty property, int32_t value,
+                                              UErrorCode& status) {
+  uset_applyIntPropertyValue(set_, property, value, &status);
+  return *this;
+}
+
+UnicodeSet& UnicodeSet::complement() {
+  uset_complement(set_);
+  return *this;
+}
+
+UnicodeSet& UnicodeSet::removeAllStrings() {
+  uset_removeAllStrings(set_);
+  return *this;
+}
+
+UnicodeSet& UnicodeSet::freeze() {
+  uset_freeze(set_);
+  return *this;
+}
+
+bool UnicodeSet::contains(UChar32 code_point) const {
+  return uset_contains(set_, code_point);
+}
+
+bool UnicodeSet::isEmpty() const { return uset_isEmpty(set_); }
+
+bool UnicodeSet::hasStrings() const {
+  return uset_getItemCount(set_) > GetRangeCount(set_);
+}
+
+int32_t UnicodeSet::size() const { return uset_size(set_); }
+
+int32_t UnicodeSet::getRangeCount() const { return GetRangeCount(set_); }
+
+UChar32 UnicodeSet::getRangeStart(int32_t index) const {
+  return GetRangeEndpoint(set_, index, false);
+}
+
+UChar32 UnicodeSet::getRangeEnd(int32_t index) const {
+  return GetRangeEndpoint(set_, index, true);
+}
+
+UnicodeSetIterator::UnicodeSetIterator(const UnicodeSet& set)
+    : set_(&set), string_index_(0), strings_only_(false), current_() {}
+
+UnicodeSetIterator::~UnicodeSetIterator() = default;
+
+UBool UnicodeSetIterator::next() {
+  if (!strings_only_) {
+    // V8 only uses code point ranges through UnicodeSet itself and switches
+    // this iterator to strings before advancing it.
+    strings_only_ = true;
+  }
+  const int32_t item_index = GetRangeCount(set_->set_) + string_index_++;
+  if (item_index >= uset_getItemCount(set_->set_)) {
+    return false;
+  }
+  UErrorCode status = U_ZERO_ERROR;
+  UChar32 start = 0;
+  UChar32 end = 0;
+  int32_t length =
+      uset_getItem(set_->set_, item_index, &start, &end, nullptr, 0, &status);
+  if (status != U_BUFFER_OVERFLOW_ERROR || length <= 0) {
+    return false;
+  }
+  status = U_ZERO_ERROR;
+  std::u16string string(length, u'\0');
+  uset_getItem(set_->set_, item_index, &start, &end,
+               reinterpret_cast<UChar*>(string.data()), string.size(), &status);
+  if (U_FAILURE(status)) {
+    return false;
+  }
+  current_ = UnicodeString(string.data(), string.size());
+  return true;
+}
+
+const UnicodeString& UnicodeSetIterator::getString() { return current_; }
+
+U_NAMESPACE_END


### PR DESCRIPTION
## Summary

- add an opt-in `system_icu` Cargo feature for macOS
- provide a V8-scoped C++ compatibility façade that delegates to the ICU C API exported by `libicucore`
- keep all compatibility C++ symbols in `v8_icu_compat`, avoiding Apple's private ICU C++ ABI and V8 source patches
- publish `_simdutf_system_icu` debug and release archives for both macOS architectures
- leave bundled ICU as the default; the feature is a no-op on non-macOS targets, including prebuilt archive selection

This lets cross-platform consumers such as Deno enable `system_icu` globally without adding Linux or Windows build variants.

## Size

Controlled release builds used Deno's `default-features = false, features = ["simdutf"]` configuration. The only difference between the two archives was the `system_icu` feature.

| Measurement | Bundled ICU | System ICU | Reduction |
| --- | ---: | ---: | ---: |
| `librusty_v8.a` | 142,713,144 B | 120,607,488 B | 22,105,656 B (21.082 MiB, 15.49%) |
| Sum of `__TEXT,__const` | 12,355,831 B | 1,140,462 B | 11,215,369 B (10.696 MiB) |
| Sum of `__TEXT,__text` | 35,082,004 B | 32,395,276 B | 2,686,728 B (2.562 MiB) |

The bundled `icudtl_dat.o` accounts for 10,822,192 bytes of the const reduction. Final executable savings will differ because dead-code elimination happens when the consumer links the archive.

## Design

V8 still compiles against the ICU C++ surface it expects. Overlay headers expose the subset V8 uses, and the façade implements that surface using stable, unsuffixed ICU C entry points from `libicucore`.

Small data-free value types such as `UnicodeString`, `StringPiece`, `ByteSink`, and `UObject` retain their vendored implementation and layout. Explicit compatibility paths cover system CLDR differences exercised by V8's Intl tests, including aliases, locale metadata, currency digits, numbering defaults, and date patterns.

The prebuilt suffix changes to `_simdutf_system_icu` only on macOS. Consumers on Linux and Windows continue selecting the existing `_simdutf` archive even when Cargo feature unification enables `system_icu`.

## Validation

- `V8_FROM_SOURCE=1 cargo build --release` with bundled ICU
- `V8_FROM_SOURCE=1 cargo build --release --no-default-features --features simdutf`
- `V8_FROM_SOURCE=1 cargo build --release --no-default-features --features simdutf,system_icu`
- `V8_FROM_SOURCE=1 cargo build --release --features simdutf,system_icu` for the exact CI publishing configuration
- rusty_v8 Nextest suite: 298/298 passed
- V8 Intl suite: 310/310 passed
- `mksnapshot`, `run_mksnapshot_default`, and `d8` link and run against `/usr/lib/libicucore.A.dylib`
- no undefined reference to Apple's private ICU C++ namespace
- every required ICU C symbol is present in the macOS 12 `libicucore.tbd`
- a separate Deno-configured consumer successfully links the CI-produced archive and runs Intl without manually loading ICU data
- Rust formatting, C++ formatting, workflow YAML parsing, and crate package coverage pass

## Tradeoffs

Intl output and canonicalization can now depend on the user's macOS ICU/CLDR version. The compatibility table keeps the current V8 Intl suite deterministic on the tested host, but untested locale output can still vary between macOS releases. The façade is also a maintenance surface that must track future changes to the ICU C++ APIs used by V8.
