### PR TITLE
feat: expose inspector value subtype callbacks

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3562,6 +3562,13 @@ void v8_inspector__V8InspectorClient__BASE__consoleAPIMessage(
     const v8_inspector::StringView& message,
     const v8_inspector::StringView& url, unsigned lineNumber,
     unsigned columnNumber, v8_inspector::V8StackTrace* stackTrace);
+v8_inspector::StringBuffer* v8_inspector__V8InspectorClient__BASE__valueSubtype(
+    v8_inspector::V8InspectorClient* self, v8::Context* context,
+    v8::Value* value);
+v8_inspector::StringBuffer*
+v8_inspector__V8InspectorClient__BASE__descriptionForValueSubtype(
+    v8_inspector::V8InspectorClient* self, v8::Context* context,
+    v8::Value* value);
 v8::Context* v8_inspector__V8InspectorClient__BASE__ensureDefaultContextInGroup(
     v8_inspector::V8InspectorClient* self, int context_group_id);
 v8_inspector::StringBuffer*
@@ -3598,6 +3605,24 @@ struct v8_inspector__V8InspectorClient__BASE
     v8_inspector__V8InspectorClient__BASE__consoleAPIMessage(
         this, contextGroupId, level, message, url, lineNumber, columnNumber,
         stackTrace);
+  }
+  std::unique_ptr<v8_inspector::StringBuffer> valueSubtype(
+      v8::Local<v8::Value> value) override {
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    if (isolate == nullptr) return nullptr;
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    if (context.IsEmpty()) return nullptr;
+    v8_inspector::StringBuffer* b =
+        v8_inspector__V8InspectorClient__BASE__valueSubtype(
+            this, local_to_ptr(context), local_to_ptr(value));
+    return std::unique_ptr<v8_inspector::StringBuffer>(b);
+  }
+  std::unique_ptr<v8_inspector::StringBuffer> descriptionForValueSubtype(
+      v8::Local<v8::Context> context, v8::Local<v8::Value> value) override {
+    v8_inspector::StringBuffer* b =
+        v8_inspector__V8InspectorClient__BASE__descriptionForValueSubtype(
+            this, local_to_ptr(context), local_to_ptr(value));
+    return std::unique_ptr<v8_inspector::StringBuffer>(b);
   }
   v8::Local<v8::Context> ensureDefaultContextInGroup(
       int context_group_id) override {

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -13,9 +13,11 @@
 //! https://github.com/nodejs/node/tree/v13.7.0/src/inspector
 //! https://github.com/denoland/deno/blob/v0.38.0/cli/inspector.rs
 
+use crate::CallbackScope;
 use crate::Context;
 use crate::Isolate;
 use crate::Local;
+use crate::PinScope;
 use crate::StackTrace;
 use crate::Value;
 use crate::isolate::RealIsolate;
@@ -27,6 +29,7 @@ use crate::support::int;
 use std::cell::UnsafeCell;
 use std::ffi::c_void;
 use std::fmt::{self, Debug, Formatter};
+use std::pin::pin;
 
 unsafe extern "C" {
   fn v8_inspector__V8Inspector__Channel__BASE__CONSTRUCT(
@@ -269,6 +272,42 @@ unsafe extern "C" fn v8_inspector__V8InspectorClient__BASE__consoleAPIMessage(
         column_number,
         stack_trace,
       );
+  }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn v8_inspector__V8InspectorClient__BASE__valueSubtype(
+  this: *mut RawV8InspectorClient,
+  context: Local<Context>,
+  value: Local<Value>,
+) -> *mut StringBuffer {
+  let scope = pin!(unsafe { CallbackScope::new(context) });
+  let mut scope = scope.init();
+  unsafe {
+    V8InspectorClientHeap::from_raw(this)
+      .imp
+      .value_subtype(&mut scope, value)
+      .and_then(|mut v| v.take())
+      .map(|r| r.into_raw())
+      .unwrap_or(std::ptr::null_mut())
+  }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn v8_inspector__V8InspectorClient__BASE__descriptionForValueSubtype(
+  this: *mut RawV8InspectorClient,
+  context: Local<Context>,
+  value: Local<Value>,
+) -> *mut StringBuffer {
+  let scope = pin!(unsafe { CallbackScope::new(context) });
+  let mut scope = scope.init();
+  unsafe {
+    V8InspectorClientHeap::from_raw(this)
+      .imp
+      .description_for_value_subtype(&mut scope, value)
+      .and_then(|mut v| v.take())
+      .map(|r| r.into_raw())
+      .unwrap_or(std::ptr::null_mut())
   }
 }
 
@@ -531,6 +570,42 @@ pub trait V8InspectorClientImpl {
     column_number: u32,
     stack_trace: &mut V8StackTrace,
   ) {
+  }
+
+  /// Returns a custom Chrome DevTools Protocol `Runtime.RemoteObject` subtype
+  /// for `value`. Use one of the protocol's defined subtype enum values.
+  /// Returning `Some` causes V8 to call
+  /// [`Self::description_for_value_subtype`].
+  ///
+  /// The callback scope uses the isolate's current context as a best-effort
+  /// context; it is not necessarily the context in which `value` originated.
+  /// If the isolate has no current context, V8 skips this callback entirely.
+  /// This callback runs while the inspector is constructing a value mirror.
+  /// Operations such as property access can execute JavaScript through getters
+  /// or proxies, so wrap them in a [`crate::TryCatch`] to avoid leaving a
+  /// pending exception in the inspector's mirror-building path.
+  fn value_subtype<'s>(
+    &self,
+    scope: &mut PinScope<'s, '_>,
+    value: Local<'s, Value>,
+  ) -> Option<UniquePtr<StringBuffer>> {
+    None
+  }
+
+  /// Returns the description for a value whose custom subtype was returned by
+  /// [`Self::value_subtype`]. Returning `None` makes V8 fall back to the default
+  /// object mirror, which also discards the custom subtype unless it is
+  /// `"error"` or `"array"`.
+  ///
+  /// Like [`Self::value_subtype`], this callback runs while the inspector is
+  /// constructing a value mirror. Wrap operations that can execute JavaScript
+  /// in a [`crate::TryCatch`] so an exception does not remain pending.
+  fn description_for_value_subtype<'s>(
+    &self,
+    scope: &mut PinScope<'s, '_>,
+    value: Local<'s, Value>,
+  ) -> Option<UniquePtr<StringBuffer>> {
+    None
   }
 
   fn ensure_default_context_in_group(

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -7241,6 +7241,107 @@ fn inspector_release_object_group() {
 }
 
 #[test]
+fn inspector_value_subtype() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+
+  use v8::inspector::*;
+
+  struct Client;
+
+  impl V8InspectorClientImpl for Client {
+    fn value_subtype<'s>(
+      &self,
+      scope: &mut v8::PinScope<'s, '_>,
+      value: v8::Local<'s, v8::Value>,
+    ) -> Option<v8::UniquePtr<StringBuffer>> {
+      v8::tc_scope!(let scope, scope);
+      let object = value.to_object(scope)?;
+      let key = v8::String::new(scope, "__rusty_v8_value_subtype")?;
+      if object.get(scope, key.into())?.is_true() {
+        Some(StringBuffer::create(StringView::from(&b"node"[..])))
+      } else {
+        None
+      }
+    }
+
+    fn description_for_value_subtype<'s>(
+      &self,
+      scope: &mut v8::PinScope<'s, '_>,
+      value: v8::Local<'s, v8::Value>,
+    ) -> Option<v8::UniquePtr<StringBuffer>> {
+      v8::tc_scope!(let scope, scope);
+      let object = value.to_object(scope)?;
+      let key = v8::String::new(scope, "__rusty_v8_value_description")?;
+      if object.get(scope, key.into())?.is_true() {
+        Some(StringBuffer::create(StringView::from(
+          &b"marked object"[..],
+        )))
+      } else {
+        None
+      }
+    }
+  }
+
+  let inspector_client = V8InspectorClient::new(Box::new(Client));
+  let inspector = V8Inspector::create(isolate, inspector_client);
+
+  v8::scope!(let scope, isolate);
+
+  let context = v8::Context::new(scope, Default::default());
+  let scope = &mut v8::ContextScope::new(scope, context);
+  eval(
+    scope,
+    r#"
+      globalThis.marked = {
+        __rusty_v8_value_subtype: true,
+        __rusty_v8_value_description: true,
+      };
+      globalThis.defaultDescription = {
+        __rusty_v8_value_subtype: true,
+      };
+    "#,
+  )
+  .unwrap();
+
+  let name_view = StringView::from(&b""[..]);
+  let aux_data_view = StringView::from(&b"{\"isDefault\": true}"[..]);
+  inspector.context_created(context, 1, name_view, aux_data_view);
+
+  let channel = ChannelCounter::new();
+  let session = inspector.connect(
+    1,
+    Channel::new(Box::new(channel.clone())),
+    StringView::from(&b"{}"[..]),
+    V8InspectorClientTrustLevel::Untrusted,
+  );
+
+  session.dispatch_protocol_message(StringView::from(
+    &br#"{"id":1,"method":"Runtime.evaluate","params":{"expression":"marked","contextId":1}}"#[..],
+  ));
+  session.dispatch_protocol_message(StringView::from(
+    &br#"{"id":2,"method":"Runtime.evaluate","params":{"expression":"defaultDescription","contextId":1}}"#[..],
+  ));
+  session.dispatch_protocol_message(StringView::from(
+    &br#"{"id":3,"method":"Runtime.evaluate","params":{"expression":"({})","contextId":1}}"#[..],
+  ));
+
+  {
+    let state = channel.state.borrow();
+    assert_eq!(state.responses.len(), 3);
+    assert!(state.responses[0].contains(r#""subtype":"node""#));
+    assert!(state.responses[0].contains(r#""description":"marked object""#));
+    // V8 drops the custom subtype when the client supplies no description.
+    assert!(state.responses[1].contains(r#""description":"Object""#));
+    assert!(!state.responses[1].contains(r#""subtype""#));
+    assert!(state.responses[2].contains(r#""description":"Object""#));
+    assert!(!state.responses[2].contains(r#""subtype""#));
+  }
+
+  inspector.context_destroyed(context);
+}
+
+#[test]
 fn inspector_exception_thrown() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
Closes #2032.

## Summary

Expose V8 Inspector's `valueSubtype` and `descriptionForValueSubtype`
callbacks to Rust embedders.

- add source-compatible default methods to `V8InspectorClientImpl`
- establish the required V8 and Rust callback scopes before invoking client code
- pass scoped `Local<Value>` handles to the Rust callbacks
- return optional descriptions through `UniquePtr<StringBuffer>`, following the existing ownership pattern
- add a focused Inspector test covering custom subtype and description metadata while verifying that ordinary objects retain V8's default representation

## Testing

- `cargo fmt --check`
- `clang-format-19 --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo clippy --all-targets --locked -- -D clippy::all`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo nextest run --all-targets --locked`