### PR TITLE
feat: expose inspector inspected objects

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3504,6 +3504,62 @@ void v8_inspector__V8InspectorSession__cancelPauseOnNextStatement(
 }
 }  // extern "C"
 
+extern "C" {
+const v8::Value* v8_inspector__V8InspectorSession__Inspectable__BASE__get(
+    void* rust_impl, const v8::Context* context);
+void v8_inspector__V8InspectorSession__Inspectable__BASE__DROP(void* rust_impl);
+}
+
+class v8_inspector__V8InspectorSession__Inspectable__BASE final
+    : public v8_inspector::V8InspectorSession::Inspectable {
+ public:
+  explicit v8_inspector__V8InspectorSession__Inspectable__BASE(void* rust_impl)
+      : rust_impl_(rust_impl) {}
+
+  ~v8_inspector__V8InspectorSession__Inspectable__BASE() override {
+    v8_inspector__V8InspectorSession__Inspectable__BASE__DROP(rust_impl_);
+  }
+
+  v8::Local<v8::Value> get(v8::Local<v8::Context> context) override {
+    // The Rust CallbackScope relies on `NewCallbackScope for Local<Context>`
+    // having `NEEDS_SCOPE == false` and must not open its own HandleScope.
+    // Handles created by the Rust implementation are allocated in this scope
+    // and must be escaped here. Opening a nested HandleScope in Rust would
+    // destroy that scope before Escape uses its handle, causing a
+    // use-after-free.
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    if (isolate == nullptr) return v8::Local<v8::Value>();
+    v8::EscapableHandleScope handle_scope(isolate);
+    v8::Context::Scope context_scope(context);
+    return handle_scope.Escape(
+        ptr_to_local(v8_inspector__V8InspectorSession__Inspectable__BASE__get(
+            rust_impl_, local_to_ptr(context))));
+  }
+
+ private:
+  void* rust_impl_;
+};
+
+extern "C" {
+v8_inspector::V8InspectorSession::Inspectable*
+v8_inspector__V8InspectorSession__Inspectable__NEW(void* rust_impl) {
+  return new v8_inspector__V8InspectorSession__Inspectable__BASE(rust_impl);
+}
+
+void v8_inspector__V8InspectorSession__Inspectable__DELETE(
+    v8_inspector::V8InspectorSession::Inspectable* inspectable) {
+  delete inspectable;
+}
+
+void v8_inspector__V8InspectorSession__addInspectedObject(
+    v8_inspector::V8InspectorSession* self,
+    v8_inspector::V8InspectorSession::Inspectable* inspectable) {
+  self->addInspectedObject(
+      std::unique_ptr<v8_inspector::V8InspectorSession::Inspectable>(
+          inspectable));
+}
+}
+
 struct v8_inspector__V8Inspector__Channel__BASE
     : public v8_inspector::V8Inspector::Channel {
   using v8_inspector::V8Inspector::Channel::Channel;

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -98,6 +98,16 @@ unsafe extern "C" {
   fn v8_inspector__V8InspectorSession__canDispatchMethod(
     method: StringView,
   ) -> bool;
+  fn v8_inspector__V8InspectorSession__Inspectable__NEW(
+    rust_impl: *mut c_void,
+  ) -> *mut RawInspectable;
+  fn v8_inspector__V8InspectorSession__Inspectable__DELETE(
+    inspectable: *mut RawInspectable,
+  );
+  fn v8_inspector__V8InspectorSession__addInspectedObject(
+    session: *mut RawV8InspectorSession,
+    inspectable: *mut RawInspectable,
+  );
 
   fn v8_inspector__StringBuffer__DELETE(this: *mut StringBuffer);
   fn v8_inspector__StringBuffer__string(this: &StringBuffer) -> StringView<'_>;
@@ -676,6 +686,89 @@ impl Debug for V8InspectorClient {
 
 #[repr(C)]
 #[derive(Debug)]
+struct RawInspectable(Opaque);
+
+impl Drop for RawInspectable {
+  fn drop(&mut self) {
+    unsafe {
+      v8_inspector__V8InspectorSession__Inspectable__DELETE(self);
+    }
+  }
+}
+
+// A trait object is a fat pointer, so box it once more before passing it through
+// the FFI as a thin `*mut c_void`.
+struct InspectableData {
+  imp: Box<dyn InspectableImpl>,
+}
+
+/// Supplies the value of an object added to the inspector's `$0` through `$4`
+/// history.
+pub trait InspectableImpl {
+  /// Called by the inspector from within a V8 callback when the console
+  /// dereferences one of `$0` through `$4`.
+  ///
+  /// There is no way to return an empty handle; if no value is available,
+  /// return `undefined`.
+  fn get<'s>(
+    &self,
+    scope: &mut PinScope<'s, '_>,
+    context: Local<'s, Context>,
+  ) -> Local<'s, Value>;
+}
+
+/// An object that can be added to an inspector session's `$0` through `$4`
+/// history.
+pub struct Inspectable {
+  raw: UniqueRef<RawInspectable>,
+}
+
+impl Inspectable {
+  pub fn new(imp: Box<dyn InspectableImpl>) -> Self {
+    let data = Box::into_raw(Box::new(InspectableData { imp })).cast();
+    let raw = unsafe {
+      UniqueRef::from_raw(v8_inspector__V8InspectorSession__Inspectable__NEW(
+        data,
+      ))
+    };
+    Self { raw }
+  }
+}
+
+impl Debug for Inspectable {
+  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    f.debug_struct("Inspectable").finish()
+  }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn v8_inspector__V8InspectorSession__Inspectable__BASE__get(
+  rust_impl: *mut c_void,
+  context: Local<Context>,
+) -> *const Value {
+  let data = unsafe { &*rust_impl.cast::<InspectableData>() };
+  // SAFETY: `CallbackScope::new(context)` must not open its own HandleScope.
+  // `NewCallbackScope for Local<Context>` has `NEEDS_SCOPE == false`, and
+  // `make_new_callback_scope` constructs it with `needs_scope == false`. The
+  // handle returned here is allocated in the EscapableHandleScope opened by
+  // the C++ shim and escaped there. If Rust opens its own HandleScope, that
+  // scope is destroyed before C++ escapes the handle, causing a use-after-free.
+  let scope = pin!(unsafe { CallbackScope::new(context) });
+  let mut scope = scope.init();
+  data.imp.get(&mut scope, context).as_non_null().as_ptr()
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn v8_inspector__V8InspectorSession__Inspectable__BASE__DROP(
+  rust_impl: *mut c_void,
+) {
+  unsafe {
+    drop(Box::from_raw(rust_impl.cast::<InspectableData>()));
+  }
+}
+
+#[repr(C)]
+#[derive(Debug)]
 pub struct RawV8InspectorSession(Opaque);
 
 pub struct V8InspectorSession {
@@ -728,6 +821,15 @@ impl V8InspectorSession {
     unsafe {
       v8_inspector__V8InspectorSession__cancelPauseOnNextStatement(
         self.raw.as_ptr(),
+      );
+    }
+  }
+
+  pub fn add_inspected_object(&self, inspectable: Inspectable) {
+    unsafe {
+      v8_inspector__V8InspectorSession__addInspectedObject(
+        self.raw.as_ptr(),
+        inspectable.raw.into_raw(),
       );
     }
   }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -7097,6 +7097,28 @@ impl v8::inspector::ChannelImpl for ChannelCounter {
   }
 }
 
+struct TestInspectable {
+  value: v8::Global<v8::Value>,
+  drop_count: Arc<AtomicUsize>,
+}
+
+impl v8::inspector::InspectableImpl for TestInspectable {
+  fn get<'s>(
+    &self,
+    scope: &mut v8::PinScope<'s, '_>,
+    context: v8::Local<'s, v8::Context>,
+  ) -> v8::Local<'s, v8::Value> {
+    assert_eq!(scope.get_current_context(), context);
+    v8::Local::new(scope, &self.value)
+  }
+}
+
+impl Drop for TestInspectable {
+  fn drop(&mut self) {
+    self.drop_count.fetch_add(1, Ordering::SeqCst);
+  }
+}
+
 #[test]
 fn inspector_can_dispatch_method() {
   use v8::inspector::*;
@@ -7339,6 +7361,120 @@ fn inspector_value_subtype() {
   }
 
   inspector.context_destroyed(context);
+}
+
+#[test]
+fn inspector_inspected_object_round_trip() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+
+  use v8::inspector::*;
+
+  let inspector_client = V8InspectorClient::new(Box::new(ClientCounter::new()));
+  let inspector = V8Inspector::create(isolate, inspector_client);
+
+  v8::scope!(let scope, isolate);
+  let context = v8::Context::new(scope, Default::default());
+  let scope = &mut v8::ContextScope::new(scope, context);
+  let value = eval(scope, "({ answer: 42 })").unwrap();
+  let value = v8::Global::new(scope, value);
+
+  let name = StringView::from(&b""[..]);
+  let aux_data = StringView::from(&b"{\"isDefault\": true}"[..]);
+  inspector.context_created(context, 1, name, aux_data);
+
+  let channel = ChannelCounter::new();
+  let session = inspector.connect(
+    1,
+    Channel::new(Box::new(channel.clone())),
+    StringView::from(&b"{}"[..]),
+    V8InspectorClientTrustLevel::FullyTrusted,
+  );
+  let drop_count = Arc::new(AtomicUsize::new(0));
+  session.add_inspected_object(Inspectable::new(Box::new(TestInspectable {
+    value,
+    drop_count: drop_count.clone(),
+  })));
+
+  session.dispatch_protocol_message(StringView::from(
+    &br#"{"id":1,"method":"Runtime.evaluate","params":{"expression":"$0.answer","contextId":1,"includeCommandLineAPI":true}}"#[..],
+  ));
+
+  {
+    let state = channel.state.borrow();
+    assert_eq!(state.responses.len(), 1);
+    assert!(state.responses[0].contains(r#""value":42"#));
+  }
+
+  assert_eq!(drop_count.load(Ordering::SeqCst), 0);
+  drop(session);
+  assert_eq!(drop_count.load(Ordering::SeqCst), 1);
+  drop(inspector);
+  assert_eq!(drop_count.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn inspector_inspectable_drops_rust_impl_when_not_added() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+
+  use v8::inspector::*;
+
+  v8::scope!(let scope, isolate);
+  let value: v8::Local<v8::Value> = v8::undefined(scope).into();
+  let value = v8::Global::new(scope, value);
+  let drop_count = Arc::new(AtomicUsize::new(0));
+  let inspectable = Inspectable::new(Box::new(TestInspectable {
+    value,
+    drop_count: drop_count.clone(),
+  }));
+
+  assert_eq!(drop_count.load(Ordering::SeqCst), 0);
+  drop(inspectable);
+  assert_eq!(drop_count.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn inspector_inspected_object_drops_rust_impl_when_evicted() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+
+  use v8::inspector::*;
+
+  let inspector_client = V8InspectorClient::new(Box::new(ClientCounter::new()));
+  let inspector = V8Inspector::create(isolate, inspector_client);
+
+  v8::scope!(let scope, isolate);
+  let context = v8::Context::new(scope, Default::default());
+  let scope = &mut v8::ContextScope::new(scope, context);
+
+  let name = StringView::from(&b""[..]);
+  inspector.context_created(context, 1, name, name);
+
+  let session = inspector.connect(
+    1,
+    Channel::new(Box::new(ChannelCounter::new())),
+    StringView::from(&b"{}"[..]),
+    V8InspectorClientTrustLevel::Untrusted,
+  );
+
+  // V8 retains five inspected objects for $0 through $4, so adding a sixth
+  // evicts the oldest one.
+  let mut drop_counts = Vec::new();
+  for number in 0..6 {
+    let value: v8::Local<v8::Value> = v8::Integer::new(scope, number).into();
+    let drop_count = Arc::new(AtomicUsize::new(0));
+    session.add_inspected_object(Inspectable::new(Box::new(TestInspectable {
+      value: v8::Global::new(scope, value),
+      drop_count: drop_count.clone(),
+    })));
+    drop_counts.push(drop_count);
+  }
+
+  assert_eq!(drop_counts[0].load(Ordering::SeqCst), 1);
+  for drop_count in &drop_counts[1..] {
+    assert_eq!(drop_count.load(Ordering::SeqCst), 0);
+  }
 }
 
 #[test]


### PR DESCRIPTION
Closes #2034.

## Summary

Expose V8 Inspector's `V8InspectorSession::Inspectable` and
`addInspectedObject` APIs to Rust embedders, allowing embedder-selected values
to appear in the Inspector Console as `$0` through `$4`.

- add `InspectableImpl` and an owning `Inspectable` wrapper
- allocate the C++ subclass separately from the boxed Rust implementation
- establish the required V8 handle/context scope and Rust callback scope around `get()`
- consume the Rust wrapper when transferring the C++ object into V8's `unique_ptr`
- drop the Rust implementation when V8 destroys or evicts the inspected object
- add focused tests for `$0` round-trip behavior and Rust-side cleanup on eviction

## Testing

- `cargo fmt --check`
- `clang-format-19 --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo clippy --all-targets --locked -- -D clippy::all`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo nextest run --all-targets --locked` (288 passed)
