### PR TITLE
feat: expose inspector object wrapping

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -50,6 +50,7 @@ config("rusty_v8_config") {
     ".",
     "$target_gen_dir",
     "$target_gen_dir/v8",
+    "$target_gen_dir/v8/include",
     "$target_gen_dir/src/inspector",
     "$target_gen_dir/src/deno_inspector",
   ]

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 #include "cppgc/allocation.h"
 #include "cppgc/persistent.h"
@@ -18,6 +19,7 @@
 #include "v8-callbacks.h"
 #include "v8-cppgc.h"
 #include "v8-fast-api-calls.h"
+#include "v8-inspector-protocol.h"
 #include "v8-inspector.h"
 #include "v8-internal.h"
 #include "v8-platform.h"
@@ -3514,6 +3516,22 @@ void v8_inspector__V8InspectorSession__releaseObjectGroup(
     v8_inspector::V8InspectorSession* self,
     v8_inspector::StringView object_group) {
   self->releaseObjectGroup(object_group);
+}
+
+v8_inspector::protocol::Runtime::API::RemoteObject*
+v8_inspector__V8InspectorSession__wrapObject(
+    v8_inspector::V8InspectorSession* self, const v8::Context* context,
+    const v8::Value* value, v8_inspector::StringView object_group,
+    bool generate_preview) {
+  return self
+      ->wrapObject(ptr_to_local(context), ptr_to_local(value), object_group,
+                   generate_preview)
+      .release();
+}
+
+void v8_inspector__RemoteObject__DELETE(
+    v8_inspector::protocol::Runtime::API::RemoteObject* self) {
+  delete self;
 }
 
 void v8_inspector__V8InspectorSession__schedulePauseOnNextStatement(

--- a/src/crdtp.rs
+++ b/src/crdtp.rs
@@ -208,7 +208,19 @@ struct DispatchResponseWrapper(Opaque);
 pub struct UberDispatcher(Opaque);
 
 #[repr(C)]
-struct CppVecU8(Opaque);
+pub(crate) struct CppVecU8(Opaque);
+
+impl CppVecU8 {
+  pub(crate) unsafe fn take_from_raw(ptr: *mut Self) -> Vec<u8> {
+    unsafe {
+      let len = crdtp__vec_u8__size(ptr);
+      let mut result = vec![0u8; len];
+      crdtp__vec_u8__copy(ptr, result.as_mut_ptr());
+      crdtp__vec_u8__DELETE(ptr);
+      result
+    }
+  }
+}
 
 #[repr(C)]
 struct RawSerializable(Opaque);
@@ -225,11 +237,7 @@ impl Serializable {
     unsafe {
       let vec = crdtp__vec_u8__new();
       crdtp__Serializable__AppendSerialized(self.ptr, vec);
-      let len = crdtp__vec_u8__size(vec);
-      let mut result = vec![0u8; len];
-      crdtp__vec_u8__copy(vec, result.as_mut_ptr());
-      crdtp__vec_u8__DELETE(vec);
-      result
+      CppVecU8::take_from_raw(vec)
     }
   }
 
@@ -625,11 +633,7 @@ pub fn json_to_cbor(json: &[u8]) -> Option<Vec<u8>> {
     let vec = crdtp__vec_u8__new();
     let ok = crdtp__json__ConvertJSONToCBOR(json.as_ptr(), json.len(), vec);
     if ok {
-      let len = crdtp__vec_u8__size(vec);
-      let mut result = vec![0u8; len];
-      crdtp__vec_u8__copy(vec, result.as_mut_ptr());
-      crdtp__vec_u8__DELETE(vec);
-      Some(result)
+      Some(CppVecU8::take_from_raw(vec))
     } else {
       crdtp__vec_u8__DELETE(vec);
       None
@@ -643,11 +647,7 @@ pub fn cbor_to_json(cbor: &[u8]) -> Option<Vec<u8>> {
     let vec = crdtp__vec_u8__new();
     let ok = crdtp__json__ConvertCBORToJSON(cbor.as_ptr(), cbor.len(), vec);
     if ok {
-      let len = crdtp__vec_u8__size(vec);
-      let mut result = vec![0u8; len];
-      crdtp__vec_u8__copy(vec, result.as_mut_ptr());
-      crdtp__vec_u8__DELETE(vec);
-      Some(result)
+      Some(CppVecU8::take_from_raw(vec))
     } else {
       crdtp__vec_u8__DELETE(vec);
       None

--- a/src/crdtp_binding.cc
+++ b/src/crdtp_binding.cc
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "support.h"
+#include "v8-inspector-protocol.h"
 #include "v8/third_party/inspector_protocol/crdtp/cbor.h"
 #include "v8/third_party/inspector_protocol/crdtp/dispatch.h"
 #include "v8/third_party/inspector_protocol/crdtp/frontend_channel.h"
@@ -251,6 +252,13 @@ bool crdtp__json__ConvertCBORToJSON(const uint8_t* cbor_data, size_t cbor_len,
 
 std::vector<uint8_t>* crdtp__vec_u8__new() {
   return new std::vector<uint8_t>();
+}
+
+std::vector<uint8_t>* v8_inspector__RemoteObject__toBytes(
+    const v8_inspector::protocol::Runtime::API::RemoteObject* self) {
+  auto* bytes = crdtp__vec_u8__new();
+  self->AppendSerialized(bytes);
+  return bytes;
 }
 
 void crdtp__vec_u8__DELETE(std::vector<uint8_t>* self) { delete self; }

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -20,6 +20,7 @@ use crate::Local;
 use crate::PinScope;
 use crate::StackTrace;
 use crate::Value;
+use crate::crdtp::CppVecU8;
 use crate::isolate::RealIsolate;
 use crate::support::CxxVTable;
 use crate::support::Opaque;
@@ -87,6 +88,17 @@ unsafe extern "C" {
     session: *mut RawV8InspectorSession,
     object_group: StringView,
   );
+  fn v8_inspector__V8InspectorSession__wrapObject(
+    session: *mut RawV8InspectorSession,
+    context: *const Context,
+    value: *const Value,
+    object_group: StringView,
+    generate_preview: bool,
+  ) -> *mut RawRemoteObject;
+  fn v8_inspector__RemoteObject__DELETE(this: *mut RawRemoteObject);
+  fn v8_inspector__RemoteObject__toBytes(
+    this: *const RawRemoteObject,
+  ) -> *mut CppVecU8;
   fn v8_inspector__V8InspectorSession__schedulePauseOnNextStatement(
     session: *mut RawV8InspectorSession,
     break_reason: StringView,
@@ -801,6 +813,41 @@ impl V8InspectorSession {
     }
   }
 
+  /// Wraps a V8 value in an Inspector `Runtime.RemoteObject`.
+  ///
+  /// With `generate_preview == false`, V8 uses `kIdOnly`: object results still
+  /// include metadata such as `className` and `description`, but no property
+  /// preview. With `true`, V8 uses `kPreview`, which additionally includes a
+  /// property preview.
+  ///
+  /// `context` is used only to obtain an execution-context ID and look up the
+  /// corresponding `InspectedContext` in this session's context group. The
+  /// selected `InjectedScript` wraps `value` in that inspected context's stored
+  /// V8 context. Returns `None` if no matching inspected context is registered,
+  /// for example before `V8Inspector::context_created`.
+  ///
+  /// `_scope` is intentionally unused by Rust; borrowing it keeps the caller's
+  /// V8 `HandleScope` alive while `ValueMirror::create` allocates local handles.
+  pub fn wrap_object<'s>(
+    &self,
+    _scope: &mut PinScope<'s, '_>,
+    context: Local<'s, Context>,
+    value: Local<'s, Value>,
+    object_group: StringView,
+    generate_preview: bool,
+  ) -> Option<RemoteObject> {
+    unsafe {
+      UniqueRef::try_from_raw(v8_inspector__V8InspectorSession__wrapObject(
+        self.raw.as_ptr(),
+        &*context,
+        &*value,
+        object_group,
+        generate_preview,
+      ))
+      .map(|raw| RemoteObject { raw })
+    }
+  }
+
   pub fn schedule_pause_on_next_statement(
     &self,
     reason: StringView,
@@ -838,6 +885,38 @@ impl V8InspectorSession {
 impl Drop for V8InspectorSession {
   fn drop(&mut self) {
     unsafe { v8_inspector__V8InspectorSession__DELETE(self.raw.as_ptr()) };
+  }
+}
+
+/// An opaque, owned Inspector `Runtime.RemoteObject`.
+pub struct RemoteObject {
+  raw: UniqueRef<RawRemoteObject>,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+struct RawRemoteObject(Opaque);
+
+impl RemoteObject {
+  /// Serializes this remote object to its CRDTP/CBOR representation.
+  pub fn to_bytes(&self) -> Vec<u8> {
+    unsafe {
+      CppVecU8::take_from_raw(v8_inspector__RemoteObject__toBytes(
+        self.raw.as_ptr(),
+      ))
+    }
+  }
+}
+
+impl Debug for RemoteObject {
+  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    f.debug_struct("RemoteObject").finish()
+  }
+}
+
+impl Drop for RawRemoteObject {
+  fn drop(&mut self) {
+    unsafe { v8_inspector__RemoteObject__DELETE(self) }
   }
 }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -7263,6 +7263,98 @@ fn inspector_release_object_group() {
 }
 
 #[test]
+fn inspector_wrap_object() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+
+  use v8::inspector::*;
+
+  let inspector_client = V8InspectorClient::new(Box::new(ClientCounter::new()));
+  let inspector = V8Inspector::create(isolate, inspector_client);
+
+  v8::scope!(let scope, isolate);
+  let context = v8::Context::new(scope, Default::default());
+  let scope = &mut v8::ContextScope::new(scope, context);
+
+  let channel = ChannelCounter::new();
+  let session = inspector.connect(
+    1,
+    Channel::new(Box::new(channel.clone())),
+    StringView::from(&b"{}"[..]),
+    V8InspectorClientTrustLevel::Untrusted,
+  );
+
+  let value = eval(scope, "({ answer: 42 })").unwrap();
+  assert!(
+    session
+      .wrap_object(
+        scope,
+        context,
+        value,
+        StringView::from(&b"rusty-v8-test"[..]),
+        false,
+      )
+      .is_none()
+  );
+
+  let name = StringView::from(&b""[..]);
+  inspector.context_created(context, 1, name, name);
+
+  let remote_object = session
+    .wrap_object(
+      scope,
+      context,
+      value,
+      StringView::from(&b"rusty-v8-test"[..]),
+      false,
+    )
+    .unwrap();
+  let json = String::from_utf8(
+    v8::crdtp::cbor_to_json(&remote_object.to_bytes()).unwrap(),
+  )
+  .unwrap();
+  assert!(json.contains(r#""type":"object""#));
+  assert!(!json.contains(r#""preview":"#));
+  let object_id = json
+    .split_once(r#""objectId":""#)
+    .unwrap()
+    .1
+    .split_once('"')
+    .unwrap()
+    .0;
+
+  let get_properties = format!(
+    r#"{{"id":1,"method":"Runtime.getProperties","params":{{"objectId":"{object_id}","ownProperties":true}}}}"#,
+  );
+  session
+    .dispatch_protocol_message(StringView::from(get_properties.as_bytes()));
+
+  let preview_object = session
+    .wrap_object(
+      scope,
+      context,
+      value,
+      StringView::from(&b"rusty-v8-test"[..]),
+      true,
+    )
+    .unwrap();
+  let preview_json = String::from_utf8(
+    v8::crdtp::cbor_to_json(&preview_object.to_bytes()).unwrap(),
+  )
+  .unwrap();
+  assert!(preview_json.contains(r#""preview":{"#));
+  assert!(preview_json.contains(r#""name":"answer""#));
+
+  {
+    let state = channel.state.borrow();
+    assert_eq!(state.responses.len(), 1);
+    assert!(state.responses[0].contains(r#""name":"answer""#));
+    assert!(state.responses[0].contains(r#""value":42"#));
+  }
+  inspector.context_destroyed(context);
+}
+
+#[test]
 fn inspector_value_subtype() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
Part of #2033.

## Summary

Expose V8 Inspector's `V8InspectorSession::wrapObject` API without exposing generated protocol classes through the public Rust API.

- add `V8InspectorSession::wrap_object`, returning an owned `RemoteObject` and modeling null results as `Option`
- serialize remote objects to CRDTP/CBOR through the shared byte-vector bridge
- keep the generated protocol type opaque at the Rust FFI boundary and add only the GN include path required by the C++ binding target
- document the `kIdOnly`/`kPreview` behavior, context lookup semantics, and the `HandleScope` requirement
- test the unregistered-context `None` path, preview generation, and interoperability of wrapped object IDs with `Runtime.getProperties`

This intentionally contains only `wrapObject`; `releaseObjectGroup` is handled separately in #2040, and `unwrapObject` remains follow-up work as requested in #2033.

## Testing

- `cargo fmt --check`
- `clang-format-19 --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=third_party/rust-toolchain/lib cargo clippy --all-targets --locked -- -D clippy::all`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=third_party/rust-toolchain/lib cargo nextest run --all-targets --locked --no-fail-fast` (290 passed)
