### PR TITLE
ci: nightly releases and auto-merged V8 rolls

### DIFF
--- a/.github/workflows/autoroll-notify.yml
+++ b/.github/workflows/autoroll-notify.yml
@@ -1,0 +1,38 @@
+name: autoroll notify
+
+# A failing V8 roll is otherwise silent: auto-merge simply never fires and the
+# PR sits open until someone thinks to look at it. This comments on the roll so
+# the failure shows up in notifications instead.
+
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+
+permissions: write-all
+
+jobs:
+  comment:
+    name: comment on failed roll
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'denoland/rusty_v8' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_branch == 'autoroll' &&
+      github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Comment on the autoroll PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr=$(gh pr list --head autoroll --state open --json number --jq '.[0].number // empty')
+          if [ -z "$pr" ]; then
+            echo "No open autoroll PR; nothing to comment on."
+            exit 0
+          fi
+          gh pr comment "$pr" --body "CI failed for \`${SHA:0:9}\`, so this roll will not auto-merge: $RUN_URL
+
+          Tomorrow's run force-pushes a newer V8 onto this branch and retries."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,6 +510,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # Nightlies must not show up as the repository's latest release.
+          prerelease: ${{ contains(github.ref, '-nightly.') }}
           files: |
             target/${{ env.LIB_NAME }}${{ env.FEATURES_SUFFIX }}_${{ matrix.config.variant }}_${{ matrix.config.target }}.${{ env.LIB_EXT }}.gz
             target/src_binding${{ env.FEATURES_SUFFIX }}_${{ matrix.config.variant }}_${{ matrix.config.target }}.rs
@@ -695,6 +697,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          prerelease: ${{ contains(github.ref, '-nightly.') }}
           files: |
             target/rusty_v8_release_aarch64-pc-windows-msvc.lib.gz
             target/src_binding_release_aarch64-pc-windows-msvc.rs
@@ -804,6 +807,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          prerelease: ${{ contains(github.ref, '-nightly.') }}
           files: |
             target/rusty_v8_simdutf_release_aarch64-pc-windows-msvc.lib.gz
             target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,81 @@
+name: nightly
+
+on:
+  schedule:
+    # A couple of hours after the V8 autoroll in update-v8.yml, so a roll that
+    # lands in the morning makes it into the same day's nightly.
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+
+permissions: write-all
+
+jobs:
+  tag:
+    name: tag nightly
+    runs-on: ubuntu-latest
+    if: github.repository == 'denoland/rusty_v8'
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          # Full history and tags are needed to tell whether anything landed
+          # since the last nightly.
+          fetch-depth: 0
+          # Tags pushed with the default GITHUB_TOKEN do NOT trigger `on: push`
+          # workflows. Without a PAT the tag would be created and no release
+          # would ever be built for it.
+          token: ${{ secrets.DENOBOT_PAT }}
+
+      - uses: denoland/setup-deno@v1
+
+      - name: Configure git
+        run: |
+          git config user.email "denobot@users.noreply.github.com"
+          git config user.name "denobot"
+
+      # Writes the nightly version to Cargo.toml/Cargo.lock and tags it. The
+      # commit is deliberately left off main -- only the tag is pushed.
+      - name: Prepare nightly
+        id: prepare
+        run: deno run -A ./tools/prepare_nightly.ts
+
+      # This is what starts the actual release: ci.yml runs on `refs/tags/**`
+      # and already handles the build matrix, the prebuilt binary upload and
+      # `cargo publish`.
+      - name: Push tag
+        if: steps.prepare.outputs.skipped == 'false'
+        run: git push origin ${{ steps.prepare.outputs.tag }}
+
+      - name: Summary
+        if: steps.prepare.outputs.skipped == 'false'
+        run: |
+          echo "Tagged \`${{ steps.prepare.outputs.tag }}\`." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The release itself is built by the \`ci\` workflow for that tag." >> $GITHUB_STEP_SUMMARY
+
+  cleanup:
+    name: expire old nightlies
+    runs-on: ubuntu-latest
+    if: github.repository == 'denoland/rusty_v8'
+    steps:
+      # Each nightly attaches ~40 prebuilt archives, so keeping them forever is
+      # not an option. Deleting the release makes its prebuilt binaries 404;
+      # consumers pinned to an expired nightly fall back to building V8 from
+      # source. The crates.io version stays published either way -- crates.io
+      # versions can only be yanked, never deleted.
+      - name: Delete nightly releases older than 30 days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          cutoff=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          gh release list --limit 200 --json tagName,createdAt,isPrerelease \
+            --jq ".[]
+                  | select(.isPrerelease
+                           and (.tagName | contains(\"-nightly.\"))
+                           and (.createdAt < \"$cutoff\"))
+                  | .tagName" \
+            | while read -r tag; do
+                echo "Deleting $tag"
+                gh release delete "$tag" --yes --cleanup-tag
+              done

--- a/.github/workflows/update-v8.yml
+++ b/.github/workflows/update-v8.yml
@@ -26,6 +26,44 @@ jobs:
           git config --global user.password ${{ secrets.DENOBOT_PAT }}
           echo "GIT_USER=${{ secrets.DENOBOT_PAT }}" >> $GITHUB_ENV
           git remote set-url origin https://${{ secrets.DENOBOT_PAT }}@github.com/denoland/rusty_v8.git
-      - run: deno run -A ./tools/auto_update_v8.ts
+      - id: roll
+        run: deno run -A ./tools/auto_update_v8.ts
         env:
           GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
+
+      # main requires an approving review, and GitHub does not let an author
+      # approve their own PR -- so this has to come from an identity other than
+      # the denobot PAT that opened it. GITHUB_TOKEN reviews as
+      # github-actions[bot], which satisfies the requirement.
+      - name: Approve the roll
+        if: steps.roll.outputs.rolled == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ steps.roll.outputs.pr }}
+        run: |
+          # Re-runs edit the existing PR; don't stack redundant approvals on it.
+          approved=$(gh pr view "$PR" --json reviews \
+            --jq '[.reviews[] | select((.author.login | startswith("github-actions")) and .state == "APPROVED")] | length')
+          if [ "$approved" -gt 0 ]; then
+            echo "Already approved."
+          else
+            gh pr review "$PR" --approve --body "Automated V8 roll: approving so auto-merge can land it once CI is green."
+          fi
+
+      # Enabled with the PAT rather than GITHUB_TOKEN on purpose: the merge is
+      # attributed to whoever turned auto-merge on, and a merge attributed to
+      # github-actions[bot] would not trigger the `push: main` CI run that keeps
+      # the build cache warm.
+      - name: Enable auto-merge
+        if: steps.roll.outputs.rolled == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.DENOBOT_PAT }}
+          GH_REPO: ${{ github.repository }}
+        run: gh pr merge ${{ steps.roll.outputs.pr }} --auto --squash
+
+      - name: Summary
+        if: steps.roll.outputs.rolled == 'true'
+        run: |
+          echo "Rolled to V8 ${{ steps.roll.outputs.version }} in #${{ steps.roll.outputs.pr }}." >> $GITHUB_STEP_SUMMARY
+          echo "It will merge automatically once the required checks pass." >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ As a Rust crate, Rusty V8 follows semantic versioning (semver) and will not
 introduce breaking changes within a major version. However, major version bumps
 will occur regularly to stay in sync with Chrome's release cycle.
 
+## Nightly releases
+
+A nightly is published from `main` every day that has new commits, as a semver
+prerelease of the next minor version:
+
+```
+152.1.0-nightly.20260804
+```
+
+Cargo never resolves a prerelease unless you ask for one by name, so nightlies
+cannot be picked up by accident:
+
+```toml
+[dependencies]
+v8 = "=152.1.0-nightly.20260804"
+```
+
+Nightlies carry the same prebuilt binaries as a stable release, published as a
+GitHub prerelease under the matching `v152.1.0-nightly.20260804` tag. Those
+GitHub releases are deleted after 30 days; the crates.io version stays
+published, so an expired nightly still builds, but it has to compile V8 from
+source. Pin a stable version for anything long-lived.
+
 ## Binary Build
 
 V8 is very large and takes a long time to compile. Many users will prefer to use
@@ -275,6 +298,38 @@ for M1 build.
 ```
 $ V8_FROM_SOURCE=1 cargo build
 $ V8_FROM_SOURCE=1 cargo build --release
+```
+
+**V8 rolls**
+
+`update-v8.yml` runs daily. When the V8 tracking branch has moved it pushes to
+the `autoroll` branch, opens (or retitles) a PR, approves it and turns on
+auto-merge, so a green roll lands without anyone touching it. If CI fails the
+roll stays open and `autoroll-notify.yml` comments on it; the next day's run
+force-pushes a newer V8 onto the branch and retries.
+
+The approval comes from `GITHUB_TOKEN` (`github-actions[bot]`) rather than the
+denobot PAT, because `main` requires one approving review and GitHub refuses to
+let a PR's author approve it. Auto-merge is enabled with the PAT rather than
+`GITHUB_TOKEN`, so the resulting merge is attributed to a real user and still
+triggers the `push: main` CI run that keeps the build cache warm.
+
+**Nightlies**
+
+The `nightly` workflow runs daily and, when `main` has moved since the last
+nightly, tags `v{next-minor}-nightly.{date}` via `tools/prepare_nightly.ts`.
+The version bump lives only on the tagged commit -- it is never pushed to
+`main` -- and the tag is what drives the rest: `ci.yml` builds and publishes
+every tag, nightly or not.
+
+The tag has to be pushed with `DENOBOT_PAT`. Tags pushed with the default
+`GITHUB_TOKEN` do not trigger `on: push` workflows, so the tag would be created
+and no release would ever be built for it.
+
+To cut one by hand, run the workflow via `workflow_dispatch`, or locally:
+
+```
+$ deno run -A ./tools/prepare_nightly.ts --dry-run
 ```
 
 ## Experimental Features

--- a/tools/auto_update_v8.ts
+++ b/tools/auto_update_v8.ts
@@ -28,6 +28,20 @@ function extractVersion() {
   return `${major}.${minor}.${build}.${patch}`;
 }
 
+/**
+ * Publishes a step output so update-v8.yml can approve the roll and turn on
+ * auto-merge afterwards. Those two steps live in the workflow rather than here
+ * because each needs a different token: the approval has to come from an
+ * identity other than the one that opened the PR.
+ */
+function setOutput(key: string, value: string) {
+  console.log(`${key}=${value}`);
+  const path = Deno.env.get("GITHUB_OUTPUT");
+  if (path !== undefined) {
+    Deno.writeTextFileSync(path, `${key}=${value}\n`, { append: true });
+  }
+}
+
 function parseGitHubRepository(remoteUrl: string): string | undefined {
   const normalized = remoteUrl.trim().replace(/\.git$/, "");
   return normalized.match(/github\.com[/:]([^/]+\/[^/]+)$/)?.[1];
@@ -115,6 +129,7 @@ await run("git", ["checkout", `origin/${V8_TRACKING_BRANCH}`], "./v8");
 const newVersion = extractVersion();
 if (currentVersion == newVersion) {
   console.log(`No new version available. Staying on ${newVersion}`);
+  setOutput("rolled", "false");
   Deno.exit(0);
 }
 
@@ -172,12 +187,15 @@ const openPrs = (JSON.parse(
   headRepositoryOwner: { login: string };
 }[]).filter((pr) => pr.headRepositoryOwner.login === pushOwner);
 
+let prNumber: number;
+
 if (openPrs.length > 0) {
   console.log("Already open PR. Editing existing PR.");
+  prNumber = openPrs[0].number;
   await run("gh", [
     "pr",
     "edit",
-    openPrs[0].number.toString(),
+    prNumber.toString(),
     "--repo",
     UPSTREAM_REPOSITORY,
     "--title",
@@ -185,18 +203,31 @@ if (openPrs.length > 0) {
   ]);
 } else {
   console.log("No PR open. Creating a new PR.");
-  await run("gh", [
-    "pr",
-    "create",
-    "--repo",
-    UPSTREAM_REPOSITORY,
-    "--title",
-    `Rolling to V8 ${newVersion}`,
-    "--body",
-    "",
-    "--base",
-    UPSTREAM_BRANCH,
-    "--head",
-    prHead,
-  ]);
+  const created = decoder.decode(
+    await run("gh", [
+      "pr",
+      "create",
+      "--repo",
+      UPSTREAM_REPOSITORY,
+      "--title",
+      `Rolling to V8 ${newVersion}`,
+      "--body",
+      "",
+      "--base",
+      UPSTREAM_BRANCH,
+      "--head",
+      prHead,
+    ]),
+  );
+  // `gh pr create` prints the URL of the new PR.
+  const match = created.trim().match(/\/pull\/(\d+)\s*$/);
+  if (match === null) {
+    console.error(`Could not read the PR number from: ${created}`);
+    Deno.exit(1);
+  }
+  prNumber = Number(match[1]);
 }
+
+setOutput("rolled", "true");
+setOutput("pr", prNumber.toString());
+setOutput("version", newVersion);

--- a/tools/prepare_nightly.ts
+++ b/tools/prepare_nightly.ts
@@ -1,0 +1,194 @@
+// Prepares a nightly release.
+//
+// Nightlies reuse the regular release pipeline: everything in ci.yml that
+// builds the matrix, uploads prebuilt binaries and runs `cargo publish` is
+// already triggered by any pushed tag. So all this script has to do is produce
+// a correctly versioned tag.
+//
+// The version bump is committed on a detached commit that is *not* pushed to
+// main -- only the tag is pushed. That keeps main's Cargo.toml on the last
+// stable version while the tagged tree carries the nightly version, which is
+// what build.rs uses to locate prebuilt binaries (it downloads from
+// `releases/download/v{CARGO_PKG_VERSION}/`).
+//
+// Usage:
+//   deno run -A ./tools/prepare_nightly.ts [--dry-run]
+
+const CARGO_TOML = "./Cargo.toml";
+const CARGO_LOCK = "./Cargo.lock";
+
+const dryRun = Deno.args.includes("--dry-run");
+
+function git(...args: string[]): string {
+  const result = tryGit(...args);
+  if (result === null) {
+    throw new Error(`git ${args.join(" ")} failed`);
+  }
+  return result;
+}
+
+/** Like `git`, but returns null instead of throwing when the command fails. */
+function tryGit(...args: string[]): string | null {
+  const output = new Deno.Command("git", { args, stderr: "inherit" })
+    .outputSync();
+  if (!output.success) {
+    return null;
+  }
+  return new TextDecoder().decode(output.stdout).trim();
+}
+
+/** Returns the `version` of the `[package]` section, e.g. "152.0.0". */
+export function packageVersion(cargoToml: string): string {
+  const section = cargoToml.split(/^\[/m).find((s) => s.startsWith("package]"));
+  if (section === undefined) {
+    throw new Error("no [package] section in Cargo.toml");
+  }
+  const match = section.match(/^version = "([^"]+)"$/m);
+  if (match === null) {
+    throw new Error("no version in the [package] section of Cargo.toml");
+  }
+  return match[1];
+}
+
+/**
+ * Computes the version for today's nightly.
+ *
+ * A prerelease sorts *below* its base version, so a nightly cut after 152.0.0
+ * was published must be based on the next unreleased version -- otherwise
+ * `152.0.0-nightly.20260804` would rank as older than the 152.0.0 it was built
+ * from. We bump the minor, matching the default of the regular release
+ * workflow.
+ *
+ * `existingTags` disambiguates repeat runs on the same day: the second nightly
+ * of the day becomes `...-nightly.20260804.1`. Numeric prerelease identifiers
+ * compare numerically, so the ordering stays correct.
+ */
+export function nightlyVersion(
+  baseVersion: string,
+  date: Date,
+  existingTags: string[],
+): string {
+  const match = baseVersion.match(/^(\d+)\.(\d+)\.(\d+)(-nightly\.|$|-|\+)/);
+  if (match === null) {
+    throw new Error(`unexpected version in Cargo.toml: ${baseVersion}`);
+  }
+  const [, major, minor, patch, suffix] = match;
+  // Idempotent: a version that is already a nightly has had the minor bumped
+  // once, so bumping again would drift a minor per run.
+  const next = suffix === "-nightly."
+    ? `${major}.${minor}.${patch}`
+    : `${major}.${Number(minor) + 1}.0`;
+
+  const stamp = [
+    date.getUTCFullYear(),
+    String(date.getUTCMonth() + 1).padStart(2, "0"),
+    String(date.getUTCDate()).padStart(2, "0"),
+  ].join("");
+
+  const candidate = `${next}-nightly.${stamp}`;
+  if (!existingTags.includes(`v${candidate}`)) {
+    return candidate;
+  }
+  for (let n = 1;; n++) {
+    if (!existingTags.includes(`v${candidate}.${n}`)) {
+      return `${candidate}.${n}`;
+    }
+  }
+}
+
+function replacePackageVersion(cargoToml: string, version: string): string {
+  let seen = false;
+  return cargoToml.replace(/^version = "[^"]+"$/m, (line) => {
+    // Only the first line-anchored `version = ` belongs to [package]; keys in
+    // dependency tables are inline (`foo = { version = "..." }`).
+    if (seen) return line;
+    seen = true;
+    return `version = "${version}"`;
+  });
+}
+
+function replaceLockVersion(cargoLock: string, version: string): string {
+  // `cargo publish --locked` fails unless the lockfile agrees with Cargo.toml.
+  const re = /(\[\[package\]\]\nname = "v8"\nversion = ")[^"]+(")/;
+  if (!re.test(cargoLock)) {
+    throw new Error("could not find the v8 package entry in Cargo.lock");
+  }
+  return cargoLock.replace(re, `$1${version}$2`);
+}
+
+/** Tags of past nightlies, oldest first. */
+function nightlyTags(): string[] {
+  const tags = git("tag", "--list", "v*-nightly.*", "--sort=creatordate");
+  return tags.length === 0 ? [] : tags.split("\n");
+}
+
+function setOutput(key: string, value: string) {
+  console.log(`${key}=${value}`);
+  const path = Deno.env.get("GITHUB_OUTPUT");
+  if (path !== undefined) {
+    Deno.writeTextFileSync(path, `${key}=${value}\n`, { append: true });
+  }
+}
+
+function main() {
+  const head = git("rev-parse", "HEAD");
+  const tags = nightlyTags();
+  const previous = tags.at(-1);
+
+  // Every nightly tag points at a bump commit whose parent is the main commit
+  // it was cut from, so the parent tells us whether anything has landed since.
+  if (previous !== undefined) {
+    const previousBase = git("rev-parse", `${previous}^`);
+    if (previousBase === head) {
+      console.log(
+        `No commits since ${previous} (${head.slice(0, 9)}), skipping.`,
+      );
+      setOutput("skipped", "true");
+      return;
+    }
+  }
+
+  const cargoToml = Deno.readTextFileSync(CARGO_TOML);
+  const version = nightlyVersion(
+    packageVersion(cargoToml),
+    new Date(),
+    tags,
+  );
+  const tag = `v${version}`;
+  const cargoLock = replaceLockVersion(
+    Deno.readTextFileSync(CARGO_LOCK),
+    version,
+  );
+
+  if (dryRun) {
+    console.log(`Would tag ${tag} at ${head.slice(0, 9)}.`);
+    setOutput("skipped", "false");
+    setOutput("version", version);
+    setOutput("tag", tag);
+    return;
+  }
+
+  // Commit detached so the branch never moves: the bump belongs to the tag
+  // only, and main keeps the last stable version. Detaching also keeps repeat
+  // runs in one working tree behaving like the fresh checkouts CI does -- the
+  // branch is restored below, so the next run sees an unbumped tree again.
+  const original = tryGit("symbolic-ref", "--quiet", "--short", "HEAD") ?? head;
+  git("checkout", "--detach", "--quiet", "HEAD");
+
+  Deno.writeTextFileSync(CARGO_TOML, replacePackageVersion(cargoToml, version));
+  Deno.writeTextFileSync(CARGO_LOCK, cargoLock);
+
+  git("add", CARGO_TOML, CARGO_LOCK);
+  git("commit", "--quiet", "-m", `${version}`);
+  git("tag", "-a", tag, "-m", `Nightly release ${version} from ${head}`);
+  git("checkout", "--quiet", original);
+
+  console.log(`Tagged ${tag} at ${head.slice(0, 9)}.`);
+  setOutput("skipped", "false");
+  setOutput("version", version);
+  setOutput("tag", tag);
+}
+
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
Publishing a nightly requires the daily V8 roll to land on its own, which it
currently doesn't: the autoroll PR is opened and then waits for someone to
approve and merge it. This makes the roll self-landing and adds a nightly
release on top of it, so a V8 update reaches crates.io without anyone touching
either step.

Nightlies reuse the existing release pipeline. Everything in ci.yml that builds
the matrix, uploads prebuilt binaries and runs `cargo publish` already triggers
on any pushed tag, so the new workflow only has to produce a correctly
versioned one. The version bump lives solely on the tagged commit and is never
pushed to main. Nightlies are prereleases of the next minor
(`152.1.0-nightly.20260804`) rather than of the current one, because semver
ranks a prerelease below its base version and `152.0.0-nightly.X` would
therefore sort as older than the 152.0.0 it was built from. Cargo never
resolves a prerelease unless asked for by name, so this cannot be picked up by
accident. The GitHub prereleases expire after 30 days; the crates.io versions
remain, since those can only be yanked.

For the roll itself, main requires one approving review, and GitHub will not
let a PR's author approve it. The approval therefore comes from GITHUB_TOKEN,
which reviews as github-actions[bot] and is a different identity from the
denobot PAT that opens the PR; auto-merge is then enabled with the PAT so the
merge is attributed to a real user and still triggers the push-to-main CI run
that keeps the build cache warm. A red roll no longer fails silently -- it gets
a comment pointing at the failed run, and the next day's roll force-pushes a
newer V8 onto the branch and retries.