### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
         run: git config --global core.symlinks true
 
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 10
           submodules: recursive
@@ -287,10 +287,10 @@ jobs:
             tar -xz -C tools/win
 
       - name: Install rust
-        uses: dsherret/rust-toolchain-file@v1
+        uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@f21464c976f072485f2ab0743b3337b66911d97f # main
 
       - name: Install nextest
         run: cargo binstall cargo-nextest --secure --locked --no-confirm
@@ -298,7 +298,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.11.x
           architecture: x64
@@ -392,7 +392,7 @@ jobs:
         run: git submodule status --recursive > git_submodule_status.txt
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           # Note: rusty_v8 targets always get get rebuilt, and their outputs
           # ('librusty_v8.rlib', the whole 'gn_out' directory, etc.) can be
@@ -502,7 +502,7 @@ jobs:
           ls -l target/src_binding${{ env.FEATURES_SUFFIX }}_${{ matrix.config.variant }}_${{ matrix.config.target }}.rs
 
       - name: Binary publish
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         if: >-
           github.repository == 'denoland/rusty_v8' &&
           startsWith(github.ref, 'refs/tags/') &&
@@ -515,7 +515,7 @@ jobs:
             target/src_binding${{ env.FEATURES_SUFFIX }}_${{ matrix.config.variant }}_${{ matrix.config.target }}.rs
 
       - name: Upload CI artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: src_binding${{ env.FEATURES_SUFFIX }}_${{ matrix.config.variant }}_${{ matrix.config.target }}.rs
           path: target/src_binding${{ env.FEATURES_SUFFIX }}_${{ matrix.config.variant }}_${{ matrix.config.target }}.rs
@@ -533,22 +533,22 @@ jobs:
         run: git config --global core.symlinks true
 
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 10
           submodules: recursive
 
       - name: Install rust
-        uses: dsherret/rust-toolchain-file@v1
+        uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@f21464c976f072485f2ab0743b3337b66911d97f # main
 
       - name: Install nextest
         run: cargo binstall cargo-nextest --secure --locked
 
       - name: Install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.11.x
           architecture: x64
@@ -562,7 +562,7 @@ jobs:
         run: git submodule status --recursive > git_submodule_status.txt
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |-
             target/sccache
@@ -590,7 +590,7 @@ jobs:
           echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Rust (nightly)
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb # nightly
 
       - name: Test (ASAN)
         env:
@@ -621,7 +621,7 @@ jobs:
         run: git config --global core.symlinks true
 
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 10
           submodules: recursive
@@ -633,19 +633,19 @@ jobs:
           curl -fL https://chromium.googlesource.com/chromium/src/tools/win/+archive/faefd1b6fa9eeb033ad6fe60368ccb9bf908cbd0.tar.gz |
             tar -xz -C tools/win
 
-      - uses: dsherret/rust-toolchain-file@v1
+      - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
 
       - name: Install Windows ARM64 target
         run: rustup target add aarch64-pc-windows-msvc
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@05a48dd55a51ce65834213873715ad7a3bf63718 # nextest
 
       - name: Write git_submodule_status.txt
         run: git submodule status --recursive > git_submodule_status.txt
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |-
             target/sccache
@@ -690,7 +690,7 @@ jobs:
           ls -l target/src_binding_release_aarch64-pc-windows-msvc.rs
 
       - name: Binary publish
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         if: github.repository == 'denoland/rusty_v8' && startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -700,13 +700,13 @@ jobs:
             target/src_binding_release_aarch64-pc-windows-msvc.rs
 
       - name: Upload CI artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: src_binding_release_aarch64-pc-windows-msvc.rs
           path: target/src_binding_release_aarch64-pc-windows-msvc.rs
 
       - name: Upload prebuilt library for testing
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: windows-arm64-prebuilt-release
           path: |
@@ -730,7 +730,7 @@ jobs:
         run: git config --global core.symlinks true
 
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 10
           submodules: recursive
@@ -742,19 +742,19 @@ jobs:
           curl -fL https://chromium.googlesource.com/chromium/src/tools/win/+archive/faefd1b6fa9eeb033ad6fe60368ccb9bf908cbd0.tar.gz |
             tar -xz -C tools/win
 
-      - uses: dsherret/rust-toolchain-file@v1
+      - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
 
       - name: Install Windows ARM64 target
         run: rustup target add aarch64-pc-windows-msvc
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@05a48dd55a51ce65834213873715ad7a3bf63718 # nextest
 
       - name: Write git_submodule_status.txt
         run: git submodule status --recursive > git_submodule_status.txt
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |-
             target/sccache
@@ -799,7 +799,7 @@ jobs:
           ls -l target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
 
       - name: Binary publish
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         if: github.repository == 'denoland/rusty_v8' && startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -809,7 +809,7 @@ jobs:
             target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
 
       - name: Upload CI artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
           path: target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
@@ -824,18 +824,18 @@ jobs:
         run: git config --global core.symlinks true
 
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 10
           submodules: recursive
 
-      - uses: dsherret/rust-toolchain-file@v1
+      - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@05a48dd55a51ce65834213873715ad7a3bf63718 # nextest
 
       - name: Download prebuilt library
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: windows-arm64-prebuilt-release
 
@@ -854,7 +854,7 @@ jobs:
         run: git config --global core.symlinks true
 
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 10
           submodules: recursive
@@ -867,16 +867,16 @@ jobs:
             tar -xz -C tools/win
 
       - name: Install rust
-        uses: dsherret/rust-toolchain-file@v1
+        uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
 
       - name: Install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.11.x
           architecture: x64
 
       - name: Download CI artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: gen
           pattern: src_binding_*.rs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           token: ${{ secrets.DENOBOT_PAT }}
 
       - uses: denoland/setup-deno@v1
-      - uses: dsherret/rust-toolchain-file@v1
+      - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
 
       - name: Tag and release
         env:

--- a/.github/workflows/update-v8.yml
+++ b/.github/workflows/update-v8.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'denoland/rusty_v8'
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Fetch origin/main
         run: git fetch origin main
       - uses: denoland/setup-deno@main


### PR DESCRIPTION
Second half of the follow-up to #1981, separate from #2046 so the noisy diff stays out of the behavioural change. Either can land without the other.

Every action outside the denoland org resolves from a mutable ref at run time. Four of them track something that moves on purpose:

    cargo-bins/cargo-binstall@main
    taiki-e/install-action@nextest
    dtolnay/rust-toolchain@nightly
    actions/checkout@v3, @v4, actions/cache@v4, actions/setup-python@v5, actions/upload-artifact@v4, actions/download-artifact@v4

The major-version tags belong in that list rather than above it. CVE-2025-30066 did not involve a malicious release: the attacker rewrote existing tags on tj-actions/changed-files so that every workflow tracking `@v45` picked up the payload on its next run without anything in any repository changing. A pin to a commit is the only ref an upstream compromise cannot rewrite.

This pins all 37 non-denoland `uses:` entries to the commit each ref currently resolves to, with the version in a trailing comment. No versions change, so the actions that run after this are byte-identical to the ones running today.

Two details worth flagging for review:

- `denoland/setup-deno` is left on `v1` and `main`. It is yours, and pinning it would mean a bump in this repository every time you release it. Say the word if you would rather have it pinned as well.
- `taiki-e/install-action@nextest` and `dtolnay/rust-toolchain@nightly` look like they encode their tool and toolchain in the ref string, which would break under a SHA pin. They do not. Each ref carries its own `action.yml` with `tool: default: nextest` and `toolchain: default: nightly` respectively, so pinning to the commit that ref points at preserves the default and needs no added `with:` block. I read both files at those refs to confirm before pinning rather than assuming it.

Keeping these current is `dependabot` with `package-ecosystem: github-actions`, which understands SHA pins and rewrites both the SHA and the comment. Happy to add that config in a third PR if you want it.
