### PR TITLE
ci: always build simdutf, drop the feature split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions: write-all
 
 jobs:
   build:
-    name: ${{ matrix.config.variant }} ${{ matrix.config.target }} ${{ matrix.config.v8_enable_pointer_compression && 'ptrcomp' || '' }} ${{ matrix.config.simdutf && 'simdutf' || '' }}
+    name: ${{ matrix.config.variant }} ${{ matrix.config.target }} ${{ matrix.config.v8_enable_pointer_compression && 'ptrcomp' || '' }}
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 180
     strategy:
@@ -78,20 +78,17 @@ jobs:
           # iOS: built from source. The simulator keeps the JIT; the device
           # build is jitless (no JIT entitlement on device) -- see build.rs.
           # Cross-compiled, so the test suite is not run on the runner.
-          # Built with simdutf (the variant downstream consumers like Deno
-          # need); WebAssembly is disabled (Torque can't build it jitless).
+          # WebAssembly is disabled (Torque can't build it jitless).
           - os: macos-15
             target: aarch64-apple-ios-sim
             variant: release
             v8_enable_pointer_compression: false
-            simdutf: true
             cargo: cargo
 
           - os: macos-15
             target: aarch64-apple-ios
             variant: release
             v8_enable_pointer_compression: false
-            simdutf: true
             cargo: cargo
 
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
@@ -129,12 +126,6 @@ jobs:
             v8_enable_pointer_compression: false
             cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: x86_64-unknown-linux-musl
-            variant: release
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
           # aarch64 musl: cross-compiled on the x64 glibc runner (host + snapshot
           # toolchains stay glibc; only the arm64 target objects are musl).
@@ -144,12 +135,6 @@ jobs:
             v8_enable_pointer_compression: false
             cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: aarch64-unknown-linux-musl
-            variant: release
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
           - os: ${{ github.repository == 'denoland/rusty_v8' && 'windows-2022-xxl' || 'windows-2022' }}
             target: x86_64-pc-windows-msvc
@@ -181,91 +166,24 @@ jobs:
             v8_enable_pointer_compression: false
             cargo: cargo
 
-          # simdutf builds
-          - os: macos-15-large
-            target: x86_64-apple-darwin
-            variant: debug
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
-          - os: macos-15-large
-            target: x86_64-apple-darwin
-            variant: release
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
-          - os: macos-15
-            target: aarch64-apple-darwin
-            variant: debug
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
-          - os: macos-15
-            target: aarch64-apple-darwin
-            variant: release
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: x86_64-unknown-linux-gnu
-            variant: debug
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: x86_64-unknown-linux-gnu
-            variant: release
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: aarch64-unknown-linux-gnu
-            variant: debug
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: aarch64-unknown-linux-gnu
-            variant: release
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: riscv64gc-unknown-linux-gnu
-            variant: debug
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
-            target: riscv64gc-unknown-linux-gnu
-            variant: release
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
-          - os: ${{ github.repository == 'denoland/rusty_v8' && 'windows-2022-xxl' || 'windows-2022' }}
-            target: x86_64-pc-windows-msvc
-            variant: release # Note: we do not support windows debug builds.
-            v8_enable_pointer_compression: false
-            simdutf: true
-            cargo: cargo
 
     env:
       V8_FROM_SOURCE: true
       CARGO_VARIANT_FLAG: ${{ matrix.config.variant == 'release' && '--release' || '' }}
-      CARGO_FEATURE_FLAGS: ${{ format('{0} {1}', matrix.config.v8_enable_pointer_compression && '--features v8_enable_pointer_compression' || '', matrix.config.simdutf && '--features simdutf' || '') }}
+      CARGO_FEATURE_FLAGS: ${{ matrix.config.v8_enable_pointer_compression && '--features v8_enable_pointer_compression' || '' }}
       LIB_NAME: ${{ contains(matrix.config.target, 'windows') && 'rusty_v8' || 'librusty_v8' }}
       LIB_EXT: ${{ contains(matrix.config.target, 'windows') && 'lib' || 'a' }}
-      FEATURES_SUFFIX: ${{ format('{0}{1}', matrix.config.v8_enable_pointer_compression && '_ptrcomp' || '', matrix.config.simdutf && '_simdutf' || '') }}
+      FEATURES_SUFFIX: ${{ matrix.config.v8_enable_pointer_compression && '_ptrcomp' || '' }}
       RUSTFLAGS: -D warnings
 
     steps:
@@ -405,7 +323,7 @@ jobs:
             target/*/.*
             target/*/build
             target/*/deps
-          key: cargo1-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-${{ matrix.config.simdutf }}-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
+          key: cargo1-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
           restore-keys: cargo1-${{ matrix.config.target }}-${{ matrix.config.variant }}-${{ matrix.config.v8_enable_pointer_compression }}-
 
       - name: Install and start sccache
@@ -714,106 +632,6 @@ jobs:
             target/src_binding_release_aarch64-pc-windows-msvc.rs
           retention-days: 1
 
-  build-windows-arm64-simdutf:
-    name: release aarch64-pc-windows-msvc simdutf
-    runs-on: ${{ github.repository == 'denoland/rusty_v8' && 'windows-2022-xxl' || 'windows-2022' }}
-    timeout-minutes: 180
-    env:
-      CARGO_VARIANT_FLAG: --release
-      V8_FROM_SOURCE: true
-      CCACHE: ccache
-      LIB_NAME: rusty_v8
-      LIB_EXT: lib
-      FEATURES_SUFFIX: '_simdutf'
-    steps:
-      - name: Configure git
-        run: git config --global core.symlinks true
-
-      - name: Clone repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 10
-          submodules: recursive
-
-      - name: Download tools/win
-        shell: bash
-        run: |
-          mkdir -p tools/win
-          curl -fL https://chromium.googlesource.com/chromium/src/tools/win/+archive/faefd1b6fa9eeb033ad6fe60368ccb9bf908cbd0.tar.gz |
-            tar -xz -C tools/win
-
-      - uses: dsherret/rust-toolchain-file@v1
-
-      - name: Install Windows ARM64 target
-        run: rustup target add aarch64-pc-windows-msvc
-
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Write git_submodule_status.txt
-        run: git submodule status --recursive > git_submodule_status.txt
-
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |-
-            target/sccache
-            target/aarch64-pc-windows-msvc/release/gn_out
-          key: cargo1-aarch64-pc-windows-msvc-release-simdutf-${{ hashFiles('Cargo.lock', 'build.rs', 'git_submodule_status.txt') }}
-          restore-keys: cargo1-aarch64-pc-windows-msvc-release-simdutf-
-
-      - name: Install and start sccache
-        shell: pwsh
-        env:
-          SCCACHE_DIR: ${{ github.workspace }}/target/sccache
-          SCCACHE_CACHE_SIZE: 256M
-          SCCACHE_IDLE_TIMEOUT: 0
-        run: |
-          $version = "v0.8.2"
-          $platform = "x86_64-pc-windows-msvc"
-          $basename = "sccache-$version-$platform"
-          $url = "https://github.com/mozilla/sccache/releases/download/$version/$basename.tar.gz"
-          cd ~
-          curl -LO $url
-          tar -xzvf "$basename.tar.gz"
-          . $basename/sccache --start-server
-          echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Install Clang
-        run: python3 tools/clang/scripts/update.py
-
-      - name: Build (cross-compile, no tests)
-        env:
-          SCCACHE_IDLE_TIMEOUT: 0
-        run: cargo build --all-targets --locked --target aarch64-pc-windows-msvc --release --features simdutf
-
-      - name: Clippy
-        run: cargo clippy --all-targets --locked --target aarch64-pc-windows-msvc --release --features simdutf -- -D clippy::all
-
-      - name: Prepare binary publish
-        run: |
-          gzip -9c target/aarch64-pc-windows-msvc/release/gn_out/obj/rusty_v8.lib > target/rusty_v8_simdutf_release_aarch64-pc-windows-msvc.lib.gz
-          ls -l target/rusty_v8_simdutf_release_aarch64-pc-windows-msvc.lib.gz
-
-          cp target/aarch64-pc-windows-msvc/release/gn_out/src_binding.rs target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
-          ls -l target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
-
-      - name: Binary publish
-        uses: softprops/action-gh-release@v0.1.15
-        if: github.repository == 'denoland/rusty_v8' && startsWith(github.ref, 'refs/tags/')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          files: |
-            target/rusty_v8_simdutf_release_aarch64-pc-windows-msvc.lib.gz
-            target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
-
-      - name: Upload CI artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
-          path: target/src_binding_simdutf_release_aarch64-pc-windows-msvc.rs
-
   test-windows-arm64:
     name: test aarch64-pc-windows-msvc
     needs: build-windows-arm64
@@ -846,7 +664,7 @@ jobs:
         run: cargo nextest run -v --all-targets --locked --target aarch64-pc-windows-msvc --release --no-fail-fast
 
   publish:
-    needs: [build, build-windows-arm64, build-windows-arm64-simdutf]
+    needs: [build, build-windows-arm64]
     runs-on: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}
     if: github.repository == 'denoland/rusty_v8' && startsWith(github.ref, 'refs/tags/')
     steps:

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,10 +1,6 @@
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 import("//build/config/host_byteorder.gni")
 
-declare_args() {
-  rusty_v8_enable_simdutf = false
-}
-
 static_library("rusty_v8") {
   complete_static_lib = true
   sources = [
@@ -18,10 +14,8 @@ static_library("rusty_v8") {
     "//v8:v8_libplatform",
     "//v8/third_party/inspector_protocol:crdtp",
     "//src/deno_inspector:deno_inspector_protocol",
+    "//third_party/simdutf:simdutf",
   ]
-  if (rusty_v8_enable_simdutf) {
-    deps += [ "//third_party/simdutf:simdutf" ]
-  }
   configs -= [
     "//build/config/compiler:default_init_stack_vars",
     "//build/config/compiler:thin_archive",
@@ -57,10 +51,6 @@ config("rusty_v8_config") {
   defines = []
   if (is_debug) {
     defines += [ "DEBUG" ]
-  }
-
-  if (rusty_v8_enable_simdutf) {
-    defines += [ "RUSTY_V8_ENABLE_SIMDUTF" ]
   }
 
   if (is_clang) {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,9 @@ opt-level = 1
 [features]
 default = ["use_custom_libcxx"]
 use_custom_libcxx = []
+# Deprecated no-op: simdutf is always built in. Kept so that downstream
+# crates passing `--features simdutf` continue to build; remove at the next
+# major version.
 simdutf = []
 v8_enable_pointer_compression = []
 v8_enable_sandbox = ["v8_enable_pointer_compression"]

--- a/build.rs
+++ b/build.rs
@@ -402,11 +402,6 @@ fn build_v8(is_asan: bool) {
     env::var("CARGO_FEATURE_V8_ENABLE_V8_CHECKS").is_ok()
   ));
 
-  gn_args.push(format!(
-    "rusty_v8_enable_simdutf={}",
-    env::var("CARGO_FEATURE_SIMDUTF").is_ok()
-  ));
-
   // Fix GN's host_cpu detection when using x86_64 bins on Apple Silicon
   if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
     gn_args.push("host_cpu=\"arm64\"".to_string());
@@ -739,9 +734,6 @@ fn prebuilt_features_suffix() -> String {
   }
   if env::var("CARGO_FEATURE_V8_ENABLE_SANDBOX").is_ok() {
     features.push_str("_sandbox");
-  }
-  if env::var("CARGO_FEATURE_SIMDUTF").is_ok() {
-    features.push_str("_simdutf");
   }
   features
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -4694,10 +4694,9 @@ RustObj* cppgc__WeakPersistent__Get(cppgc::WeakPersistent<RustObj>* self) {
 }  // extern "C"
 
 // =============================================================================
-// simdutf bindings (gated behind RUSTY_V8_ENABLE_SIMDUTF)
+// simdutf bindings
 // =============================================================================
 
-#ifdef RUSTY_V8_ENABLE_SIMDUTF
 #include "third_party/simdutf/simdutf.h"
 
 struct simdutf__result {
@@ -4939,5 +4938,3 @@ size_t simdutf__binary_to_base64(const char* input, size_t length, char* output,
 }
 
 }  // extern "C"
-
-#endif  // RUSTY_V8_ENABLE_SIMDUTF

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,6 @@ pub mod crdtp;
 pub mod inspector;
 pub mod json;
 pub mod script_compiler;
-#[cfg(feature = "simdutf")]
 pub mod simdutf;
 // This module is intentionally named "V8" rather than "v8" to match the
 // C++ namespace "v8::V8".

--- a/src/simdutf.rs
+++ b/src/simdutf.rs
@@ -3,8 +3,6 @@
 //! These bindings expose the [simdutf](https://github.com/simdutf/simdutf)
 //! library that is already bundled with V8, avoiding C++ symbol clashes
 //! that occur when linking a separate simdutf crate.
-//!
-//! Enable with the `simdutf` cargo feature.
 
 // ---------------------------------------------------------------------------
 // FFI declarations

--- a/src/string.rs
+++ b/src/string.rs
@@ -84,7 +84,6 @@ pub unsafe fn latin1_to_utf8(
 /// Minimum non-ASCII UTF-8 byte length before `new_from_utf8` decodes with
 /// simdutf instead of V8's decoder. Below this the two potential simdutf FFI
 /// calls cost more than V8 handling the tiny string itself.
-#[cfg(feature = "simdutf")]
 const NONASCII_ENCODE_SIMD_THRESHOLD: usize = 16;
 
 unsafe extern "C" {
@@ -490,7 +489,6 @@ impl String {
     // otherwise accept some of those (the decoded string is shorter), which
     // would change behavior, so only take them when the byte length is in
     // range and let V8 reject the rest.
-    #[cfg(feature = "simdutf")]
     if buffer.len() <= Self::MAX_LENGTH {
       // Pure ASCII (the common case): the bytes are already valid one-byte
       // (Latin-1) data. `onebyte_is_ascii` uses a wide simdutf scan for long
@@ -522,7 +520,6 @@ impl String {
   /// Decodes non-ASCII, non-empty valid UTF-8 into one-byte (Latin-1) or
   /// two-byte (UTF-16) data with simdutf and hands it to V8. Falls back to
   /// V8's lossy `NewFromUtf8` when the input isn't valid UTF-8.
-  #[cfg(feature = "simdutf")]
   fn new_from_utf8_transcode<'s>(
     scope: &PinScope<'s, '_, ()>,
     buffer: &[u8],
@@ -1051,8 +1048,8 @@ impl String {
   /// Convenience function not present in the original V8 API.
   ///
   /// Uses [`ValueView`] internally for single-pass access to the string
-  /// data. When the `simdutf` feature is enabled, uses SIMD-accelerated
-  /// transcoding for Latin-1 and two-byte strings.
+  /// data, with SIMD-accelerated transcoding for Latin-1 and two-byte
+  /// strings.
   pub fn to_rust_string_lossy(&self, scope: &Isolate) -> std::string::String {
     // No preliminary `self.length()` FFI call: the `ValueView` reports the
     // length, and `data()` yields an empty slice for empty strings, which the
@@ -1146,7 +1143,6 @@ impl String {
         // code ran before the memcpy. Only taken when the worst-case 2x
         // expansion fits the borrow buffer (so the convert can't overflow) and
         // the string is long enough for the simdutf FFI call to pay off.
-        #[cfg(feature = "simdutf")]
         if bytes.len() >= ONEBYTE_SIMD_THRESHOLD
           && bytes.len().saturating_mul(2) <= N
         {
@@ -1336,9 +1332,8 @@ impl<'s> ValueView<'s> {
   /// - **One-byte Latin-1** (non-ASCII): transcodes to UTF-8, returns
   ///   `Cow::Owned`.
   /// - **Two-byte** (UTF-16/WTF-16): transcodes to UTF-8, returns
-  ///   `Cow::Owned`. When the `simdutf` feature is enabled, uses
-  ///   SIMD-accelerated conversion for valid UTF-16 strings above a
-  ///   threshold size.
+  ///   `Cow::Owned`, using SIMD-accelerated conversion for valid UTF-16
+  ///   strings above a threshold size.
   #[inline(always)]
   pub fn to_cow_lossy(&self) -> Cow<'_, str> {
     match self.data() {
@@ -1357,21 +1352,18 @@ impl<'s> ValueView<'s> {
 
 // ---------------------------------------------------------------------------
 // String conversion helpers.
-// When the `simdutf` feature is enabled, hot paths dispatch to
-// SIMD-accelerated routines in `crate::simdutf`.
+// Hot paths dispatch to SIMD-accelerated routines in `crate::simdutf`.
 // ---------------------------------------------------------------------------
 
 /// The minimum number of UTF-16 code units before we try the SIMD path.
 /// With the single-pass `convert_utf16le_to_utf8_with_errors` conversion the
 /// crossover against the scalar `decode_utf16` loop is low; measured wins start
 /// around 16 units.
-#[cfg(feature = "simdutf")]
 const WTF16_SIMD_THRESHOLD: usize = 16;
 
 /// Minimum one-byte string length before the simdutf `utf8_length_from_latin1`
 /// path beats std's inline `is_ascii` SWAR scan (the simdutf FFI call has fixed
 /// overhead that only pays off once the scan is long enough).
-#[cfg(feature = "simdutf")]
 const ONEBYTE_SIMD_THRESHOLD: usize = 128;
 
 /// Transcodes Latin-1 `bytes` into the caller-provided output region, returning
@@ -1385,7 +1377,6 @@ const ONEBYTE_SIMD_THRESHOLD: usize = 128;
 /// # Safety
 /// `out_ptr` must be valid for writes of `out_len` bytes, and `out_len` must be
 /// at least the UTF-8 length of `bytes` (which never exceeds `bytes.len() * 2`).
-#[cfg(feature = "simdutf")]
 #[inline(always)]
 unsafe fn transcode_latin1_to_utf8(
   bytes: &[u8],
@@ -1405,7 +1396,6 @@ unsafe fn transcode_latin1_to_utf8(
 /// by the one-byte read paths that only need the ASCII/Latin-1 decision.
 #[inline(always)]
 fn onebyte_is_ascii(bytes: &[u8]) -> bool {
-  #[cfg(feature = "simdutf")]
   if bytes.len() >= ONEBYTE_SIMD_THRESHOLD {
     // simdutf's `validate_ascii` scans the *whole* buffer even when the very
     // first byte is non-ASCII, whereas std's `is_ascii` short-circuits. Do a
@@ -1434,7 +1424,6 @@ fn onebyte_is_ascii(bytes: &[u8]) -> bool {
 /// `is_ascii` scan + separate length scan + transcode).
 #[inline(always)]
 fn onebyte_to_string(bytes: &[u8]) -> std::string::String {
-  #[cfg(feature = "simdutf")]
   {
     // For long strings, one `utf8_length_from_latin1` SIMD pass both detects
     // ASCII and sizes the Latin-1 transcode. For short strings the simdutf FFI
@@ -1497,28 +1486,14 @@ fn onebyte_to_string(bytes: &[u8]) -> std::string::String {
 #[inline(always)]
 fn latin1_to_string(bytes: &[u8]) -> std::string::String {
   debug_assert!(!bytes.is_ascii());
-  #[cfg(feature = "simdutf")]
-  {
-    let utf8_len = crate::simdutf::utf8_length_from_latin1(bytes);
-    let mut buf: Vec<u8> = Vec::with_capacity(utf8_len);
-    // SAFETY: `buf` has capacity `utf8_len`, exactly what the transcode writes.
-    unsafe {
-      let written = transcode_latin1_to_utf8(bytes, buf.as_mut_ptr(), utf8_len);
-      debug_assert_eq!(written, utf8_len);
-      buf.set_len(written);
-      std::string::String::from_utf8_unchecked(buf)
-    }
-  }
-  #[cfg(not(feature = "simdutf"))]
-  {
-    let max_utf8_len = bytes.len() * 2;
-    let mut buf: Vec<u8> = Vec::with_capacity(max_utf8_len);
-    unsafe {
-      let written =
-        latin1_to_utf8(bytes.len(), bytes.as_ptr(), buf.as_mut_ptr());
-      buf.set_len(written);
-      std::string::String::from_utf8_unchecked(buf)
-    }
+  let utf8_len = crate::simdutf::utf8_length_from_latin1(bytes);
+  let mut buf: Vec<u8> = Vec::with_capacity(utf8_len);
+  // SAFETY: `buf` has capacity `utf8_len`, exactly what the transcode writes.
+  unsafe {
+    let written = transcode_latin1_to_utf8(bytes, buf.as_mut_ptr(), utf8_len);
+    debug_assert_eq!(written, utf8_len);
+    buf.set_len(written);
+    std::string::String::from_utf8_unchecked(buf)
   }
 }
 
@@ -1526,7 +1501,6 @@ fn latin1_to_string(bytes: &[u8]) -> std::string::String {
 /// owned [`std::string::String`], replacing unpaired surrogates with U+FFFD.
 #[inline(always)]
 fn wtf16_to_string(units: &[u16]) -> std::string::String {
-  #[cfg(feature = "simdutf")]
   {
     // Single simdutf pass that validates *and* converts. Each UTF-16 code unit
     // yields at most 3 UTF-8 bytes (surrogate pairs are 2 units -> 4 bytes), so
@@ -1561,7 +1535,6 @@ fn wtf16_to_string(units: &[u16]) -> std::string::String {
 /// Appends WTF-16 code units as UTF-8 into an existing string buffer.
 #[inline(always)]
 fn wtf16_into_string(units: &[u16], buf: &mut std::string::String) {
-  #[cfg(feature = "simdutf")]
   {
     if units.len() >= WTF16_SIMD_THRESHOLD {
       let cap = units.len() * 3;
@@ -1597,24 +1570,12 @@ fn latin1_to_cow_str<'a, const N: usize>(
   bytes: &[u8],
   buffer: &'a mut [MaybeUninit<u8>; N],
 ) -> Cow<'a, str> {
-  #[cfg(feature = "simdutf")]
   let utf8_len = crate::simdutf::utf8_length_from_latin1(bytes);
-  #[cfg(not(feature = "simdutf"))]
-  let utf8_len = bytes.len() * 2; // conservative upper bound
 
   if utf8_len <= N {
     // SAFETY: `buffer` is valid for `N >= utf8_len` writes (guarded above).
-    #[cfg(feature = "simdutf")]
     let written = unsafe {
       transcode_latin1_to_utf8(bytes, buffer.as_mut_ptr() as *mut u8, utf8_len)
-    };
-    #[cfg(not(feature = "simdutf"))]
-    let written = unsafe {
-      latin1_to_utf8(
-        bytes.len(),
-        bytes.as_ptr(),
-        buffer.as_mut_ptr() as *mut u8,
-      )
     };
 
     unsafe {
@@ -1634,7 +1595,6 @@ fn wtf16_to_cow_str<'a, const N: usize>(
   units: &[u16],
   buffer: &'a mut [MaybeUninit<u8>; N],
 ) -> Cow<'a, str> {
-  #[cfg(feature = "simdutf")]
   {
     if units.len() >= WTF16_SIMD_THRESHOLD {
       // Each unit is at most 3 UTF-8 bytes, so if `len * 3` fits the stack

--- a/tests/test_simdutf.rs
+++ b/tests/test_simdutf.rs
@@ -1,7 +1,6 @@
-#![cfg(feature = "simdutf")]
-// Tests for the simdutf feature-gated bindings.
+// Tests for the simdutf bindings.
 //
-// These tests require `V8_FROM_SOURCE=1 cargo test --features simdutf`.
+// These tests require `V8_FROM_SOURCE=1 cargo test`.
 
 use v8::simdutf;
 


### PR DESCRIPTION
V8 already depends on //third_party/simdutf via v8_base_without_compiler,
so simdutf object code is linked into every rusty_v8 archive regardless of
the cargo feature. The rusty_v8_enable_simdutf gn arg only added a
redundant dep edge plus a define gating the wrapper functions in
binding.cc, which works out to a 7.8 KB difference between the two
published archives. For that we rebuilt V8 from scratch 13 extra times per
CI run -- 42% of its 15.4h machine time -- and shipped two near-identical
archive sets for every target.

This builds the wrappers unconditionally and removes the split, taking the
matrix from 34 to 21 entries. The three non-simdutf fallbacks in string.rs
are deleted rather than left unbuilt, since they covered a configuration
that could not actually occur and would only have rotted. The cargo
feature stays as an accepted no-op so downstream crates passing
--features simdutf keep building.

Note that this changes published archive names: consumers fetching
librusty_v8_simdutf_* need to move to librusty_v8_*, so it wants a
coordinated release. Worth watching the ptrcomp jobs on the first run --
that combination has never been built with simdutf before.