### PR TITLE
feat: expose inspector object unwrapping

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3575,6 +3575,27 @@ v8_inspector__V8InspectorSession__wrapObject(
       .release();
 }
 
+bool v8_inspector__V8InspectorSession__unwrapObject(
+    v8_inspector::V8InspectorSession* self, v8_inspector::StringBuffer** error,
+    v8_inspector::StringView object_id, const v8::Value** value,
+    const v8::Context** context, v8_inspector::StringBuffer** object_group) {
+  std::unique_ptr<v8_inspector::StringBuffer> error_buffer;
+  v8::Local<v8::Value> local_value;
+  v8::Local<v8::Context> local_context;
+  std::unique_ptr<v8_inspector::StringBuffer> object_group_buffer;
+  bool success = self->unwrapObject(&error_buffer, object_id, &local_value,
+                                    &local_context, &object_group_buffer);
+  if (!success) {
+    *error = error_buffer.release();
+    return false;
+  }
+
+  *value = local_to_ptr(local_value);
+  *context = local_to_ptr(local_context);
+  *object_group = object_group_buffer.release();
+  return true;
+}
+
 void v8_inspector__RemoteObject__DELETE(
     v8_inspector::protocol::Runtime::API::RemoteObject* self) {
   delete self;

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -95,6 +95,14 @@ unsafe extern "C" {
     object_group: StringView,
     generate_preview: bool,
   ) -> *mut RawRemoteObject;
+  fn v8_inspector__V8InspectorSession__unwrapObject(
+    session: *mut RawV8InspectorSession,
+    error: *mut *mut StringBuffer,
+    object_id: StringView,
+    value: *mut *const Value,
+    context: *mut *const Context,
+    object_group: *mut *mut StringBuffer,
+  ) -> bool;
   fn v8_inspector__RemoteObject__DELETE(this: *mut RawRemoteObject);
   fn v8_inspector__RemoteObject__toBytes(
     this: *const RawRemoteObject,
@@ -846,6 +854,55 @@ impl V8InspectorSession {
       ))
       .map(|raw| RemoteObject { raw })
     }
+  }
+
+  /// Resolves an Inspector-generated object ID to its V8 value and context.
+  ///
+  /// On success, the returned object group contains the group name supplied
+  /// when the object was wrapped. An empty group name is returned as a
+  /// non-null buffer containing an empty string. On failure, the error buffer
+  /// is non-null and contains the Inspector's error message. This includes an
+  /// invalid ID or an ID made stale by releasing its object group.
+  ///
+  /// `_scope` is intentionally unused by Rust; borrowing it keeps the caller's
+  /// V8 `HandleScope` alive and ties the returned local handles to that scope.
+  #[allow(clippy::type_complexity)]
+  pub fn unwrap_object<'s>(
+    &self,
+    _scope: &mut PinScope<'s, '_>,
+    object_id: StringView,
+  ) -> Result<
+    (
+      Local<'s, Value>,
+      Local<'s, Context>,
+      UniquePtr<StringBuffer>,
+    ),
+    UniquePtr<StringBuffer>,
+  > {
+    let mut error = std::ptr::null_mut();
+    let mut value = std::ptr::null();
+    let mut context = std::ptr::null();
+    let mut object_group = std::ptr::null_mut();
+    let success = unsafe {
+      v8_inspector__V8InspectorSession__unwrapObject(
+        self.raw.as_ptr(),
+        &mut error,
+        object_id,
+        &mut value,
+        &mut context,
+        &mut object_group,
+      )
+    };
+
+    if !success {
+      return Err(unsafe { UniquePtr::from_raw(error) });
+    }
+
+    Ok((
+      unsafe { Local::from_raw(value).unwrap() },
+      unsafe { Local::from_raw(context).unwrap() },
+      unsafe { UniquePtr::from_raw(object_group) },
+    ))
   }
 
   pub fn schedule_pause_on_next_statement(

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -7369,6 +7369,70 @@ fn inspector_wrap_object() {
 }
 
 #[test]
+fn inspector_unwrap_object() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+
+  use v8::inspector::*;
+
+  let inspector_client = V8InspectorClient::new(Box::new(ClientCounter::new()));
+  let inspector = V8Inspector::create(isolate, inspector_client);
+
+  v8::scope!(let scope, isolate);
+  let context = v8::Context::new(scope, Default::default());
+  let scope = &mut v8::ContextScope::new(scope, context);
+
+  let name = StringView::from(&b""[..]);
+  inspector.context_created(context, 1, name, name);
+
+  let session = inspector.connect(
+    1,
+    Channel::new(Box::new(ChannelCounter::new())),
+    StringView::from(&b"{}"[..]),
+    V8InspectorClientTrustLevel::Untrusted,
+  );
+
+  let value = eval(scope, "({ answer: 42 })").unwrap();
+  let remote_object = session
+    .wrap_object(
+      scope,
+      context,
+      value,
+      StringView::from(&b"rusty-v8-test"[..]),
+      false,
+    )
+    .unwrap();
+  let json = String::from_utf8(
+    v8::crdtp::cbor_to_json(&remote_object.to_bytes()).unwrap(),
+  )
+  .unwrap();
+  let object_id = json
+    .split_once(r#""objectId":""#)
+    .unwrap()
+    .1
+    .split_once('"')
+    .unwrap()
+    .0;
+
+  let (unwrapped_value, unwrapped_context, object_group) = session
+    .unwrap_object(scope, StringView::from(object_id.as_bytes()))
+    .unwrap();
+  assert!(unwrapped_value.strict_equals(value));
+  assert_eq!(unwrapped_context, context);
+  assert_eq!(object_group.unwrap().string().to_string(), "rusty-v8-test");
+
+  let error = session
+    .unwrap_object(scope, StringView::from(&b"invalid"[..]))
+    .unwrap_err();
+  assert_eq!(
+    error.unwrap().string().to_string(),
+    "Invalid remote object id"
+  );
+
+  inspector.context_destroyed(context);
+}
+
+#[test]
 fn inspector_value_subtype() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
Closes #2033.

## Summary

Expose V8 Inspector `V8InspectorSession::unwrapObject` to Rust embedders, completing the remote-object lifecycle API discussed in #2033.

- add `V8InspectorSession::unwrap_object` with a scope-bound `Result<(Local<Value>, Local<Context>, UniquePtr<StringBuffer>), UniquePtr<StringBuffer>>` API
- keep the C++ bool and out-parameters inside the FFI bridge, constructing Rust `Local` handles only after V8 reports success
- transfer error and object-group `StringBuffer` ownership directly through `UniquePtr` without copying into Rust strings
- model the successful object-group output without an outer `Option`, because V8 always supplies a non-null buffer, including an empty buffer for an empty group name
- document invalid and stale object IDs together with the caller `HandleScope` requirement
- test wrap/unwrap identity, context and object-group round trips, plus the invalid-object-ID error path

This intentionally contains only `unwrapObject`; `releaseObjectGroup` landed in #2040 and `wrapObject` landed in #2041.

## Testing

- `cargo fmt --check`
- `clang-format-19 --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=third_party/rust-toolchain/lib cargo clippy --all-targets --locked -- -D clippy::all`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=third_party/rust-toolchain/lib cargo nextest run --all-targets --locked --no-fail-fast`