### PR TITLE
fix(test): initialize V8 through the guard in test_default_allocator

### DIFF
--- a/src/array_buffer.rs
+++ b/src/array_buffer.rs
@@ -235,10 +235,7 @@ fn test_rust_allocator() {
 
 #[test]
 fn test_default_allocator() {
-  crate::V8::initialize_platform(
-    crate::new_default_platform(0, false).make_shared(),
-  );
-  crate::V8::initialize();
+  crate::initialize_v8();
   new_default_allocator();
 }
 


### PR DESCRIPTION
`cargo test --lib` fails one test on every run, and *which* test fails depends on the order they run in — it moves between parallel and single-threaded runs.

```
thread 'scope::tests::deref_types' panicked at src/V8.rs:192:10:
Invalid global state
```

## Cause

`test_default_allocator` initializes V8 directly:

```rust
crate::V8::initialize_platform(crate::new_default_platform(0, false).make_shared());
crate::V8::initialize();
```

Every other test uses `initialize_v8()`, which guards those same two calls behind a `Once`. Initializing outside the guard leaves the `Once` unconsumed, so the two paths disagree about whether V8 is already up, and whichever runs second re-initializes — which `initialize_platform` rejects.

Both orders fail. If `test_default_allocator` runs first, a later `initialize_v8()` fires its untouched `Once`. If anything else runs first, `test_default_allocator` re-initializes.

## Verified

Built from source (`V8_FROM_SOURCE=1`) on x86_64 linux:

| | before | after |
|---|---|---|
| `cargo test --lib` | 12 passed, 1 failed | **13 passed, 0 failed** |
| `cargo test --lib -- --test-threads=1` | 12 passed, 1 failed | **13 passed, 0 failed** |
| `cargo test --test test_api` | 292 passed | 292 passed |

Present on `v152.0.0` and `v152.1.0` alike, so not a recent regression.