### PR TITLE
fix: correct 32-bit layout of ScriptCompiler::Source

### DIFF
--- a/src/script_compiler.rs
+++ b/src/script_compiler.rs
@@ -76,7 +76,7 @@ pub struct Source {
   _consume_cache_task: usize,
   _compile_hint_callback: usize,
   _compile_hint_callback_data: usize,
-  _compilation_details: [usize; 3],
+  _compilation_details: [u64; 3],
 }
 
 /// Compilation data that the embedder can cache and pass back to speed up future


### PR DESCRIPTION
Hello,

While building rusty_v8 for 32-bit ARMv7 (armv7-unknown-linux-gnueabi), I might have stumbled into a stack buffer overflow in `ScriptCompiler::Source`. My best guess is that the Rust struct doesn't match the C++ layout on 32-bit platforms. Happy to be corrected.

The `ScriptCompiler::Source` Rust struct ends in `_compilation_details: [usize; 3]`, however the C++ `v8::ScriptCompiler::CompilationDetails` expects `sizeof(int64_t) * 3`, as binding.cc itself asserts ("CompilationDetails size mismatch").
https://github.com/denoland/rusty_v8/blob/8149304f6924411df09a1917cd6de0fc90fa7fec/src/script_compiler.rs#L65-L80
https://github.com/denoland/rusty_v8/blob/8149304f6924411df09a1917cd6de0fc90fa7fec/src/binding.cc#L66-L68

Thus, when `Source::new` / `new_with_cached_data` allocates a `MaybeUninit::<Self>` and passes it to `v8__ScriptCompiler__Source__CONSTRUCT`, the C++ function writes past the end of the Rust allocation.
https://github.com/denoland/rusty_v8/blob/8149304f6924411df09a1917cd6de0fc90fa7fec/src/script_compiler.rs#L145-L161

My fix is to change the `_compilation_details` field to be `[u64; 3]` regardless of which platform it's built for. I understand 32-bit isn't a supported/CI target so feel free to WONTFIX this.

Thanks for taking a look!