### PR TITLE
docs: V8 must be initialized before threads that enter an isolate

### DIFF
--- a/src/V8.rs
+++ b/src/V8.rs
@@ -201,6 +201,39 @@ pub fn initialize_platform(platform: SharedRef<Platform>) {
 
 /// Initializes V8. This function needs to be called before the first Isolate
 /// is created. It always returns true.
+///
+/// # Call this before creating threads that will enter an isolate
+///
+/// On platforms with memory protection keys (x86-64 with `pku`/`ospke`,
+/// which covers most current server hardware), V8 allocates a protection
+/// key here and uses it to guard its internal pointer tables. Access to a
+/// protection key is governed by the `PKRU` register, which is **per
+/// thread** and is **inherited from the creating thread at thread creation
+/// time**.
+///
+/// A thread created *before* this call therefore never gains access to that
+/// key. Such a thread runs correctly until it enters an isolate, at which
+/// point its first read of a pointer table traps with `SIGSEGV` and
+/// `si_code == SEGV_PKUERR`. The faulting address lies in a mapping that
+/// `/proc/<pid>/maps` reports as present and readable, because protection
+/// keys are enforced by the MMU and appear in no mapping flag.
+///
+/// This matters most for embedders that build a thread pool up front and
+/// then enter a [`SharedIsolate`](crate::SharedIsolate) from its workers:
+///
+/// ```no_run
+/// // Correct: the pool inherits access to the key.
+/// v8::V8::initialize_platform(
+///   v8::new_default_platform(0, false).make_shared(),
+/// );
+/// v8::V8::initialize();
+/// let pool = std::thread::spawn(|| { /* may enter an isolate */ });
+/// # let _ = pool;
+/// ```
+///
+/// Creating the pool first compiles and runs, and fails only once a worker
+/// first executes JavaScript. V8 states the same requirement internally, in
+/// the name of `SandboxHardwareSupport::TryActivateBeforeThreadCreation`.
 pub fn initialize() {
   let mut global_state_guard = GLOBAL_STATE.lock().unwrap();
   *global_state_guard = match *global_state_guard {

--- a/src/locker.rs
+++ b/src/locker.rs
@@ -104,6 +104,21 @@ pub(crate) struct RawUnlocker([usize; 1]);
 /// the *same* number of locks in both — the loss was migration alone. If an
 /// embedder can keep consecutive locks of one isolate on one thread, or run
 /// fewer workers, it is worth doing.
+///
+/// # Initialize V8 before creating the threads that will lock
+///
+/// Every thread that calls [`SharedIsolate::lock`] must have been created
+/// *after* [`V8::initialize`](crate::V8::initialize). On hardware with
+/// memory protection keys, V8 guards its pointer tables with a key whose
+/// access lives in the per-thread `PKRU` register, and a thread inherits
+/// that access only at creation time. A worker created before V8 was
+/// initialized will lock successfully and then take `SIGSEGV` with
+/// `si_code == SEGV_PKUERR` the first time it runs JavaScript.
+///
+/// The failure is easy to misread: it presents as a fault on a mapped,
+/// readable page, and no debug build, heap verifier or handle check
+/// reports anything, because nothing is corrupt. See
+/// [`V8::initialize`](crate::V8::initialize) for the full description.
 #[derive(Debug)]
 pub struct SharedIsolate {
   inner: Arc<SharedIsolateInner>,


### PR DESCRIPTION
On hardware with memory protection keys — x86-64 with `pku`/`ospke`, which is most current server hardware — `V8::Initialize` allocates a protection key and guards V8's internal pointer tables with it. Access is governed by `PKRU`, which is **per-thread** and **inherited from the creating thread at thread creation time**.

A thread created *before* initialization therefore never gains access. It compiles, starts, and locks an isolate without complaint, then takes `SIGSEGV` the first time it runs JavaScript.

Nothing on the Rust side documents this. V8 states the same requirement internally, in the name of `SandboxHardwareSupport::TryActivateBeforeThreadCreation`, but that is `V8_EXPORT_PRIVATE` and invisible to embedders. The per-thread enable is also internal, so an embedder cannot grant access after the fact — ordering is the only remedy, which is why this is a docs change.

### Why this is worth documenting rather than leaving to discovery

The failure is unusually hard to read, and every signal points away from the cause:

- `si_code` is `SEGV_PKUERR`, but nothing surfaces that unless you go looking for it.
- The faulting address lies in a mapping that `/proc/<pid>/maps` reports as **present and readable**. A plain read appears impossible to fault there, because protection keys are enforced by the MMU and appear in no mapping flag.
- A debug V8, `--verify-heap`, `v8_enable_handle_zapping` and `v8_enable_v8_checks` all stay **silent**. Nothing is corrupt: the data is correct and the read is legal, only that thread may not perform it.
- It disappears entirely on hardware without `pku`/`ospke`, so it reads as a CPU-specific or codegen bug and sends you hunting there.

In the case that prompted this, the crash presented as "segfaults on AMD Zen 4, works on Intel" and survived elimination of the v8 version, the archive, every codegen tier, every CPU feature flag, thread count, heap limits and machine size. `--jitless` was the only surviving flag, since it never reads the protected table.

`SharedIsolate` makes this easy to hit by accident: entering an isolate from a pre-existing worker pool is precisely the pattern it enables, and an embedder that builds its pool before initializing V8 has already lost.

### Reproduction

Differs only in when a thread is created. The `AFTER` thread prints `OK`; the `BEFORE` thread dies with `si_code == SEGV_PKUERR` and `PKRU == 0x55555554` (key 1 access disabled) while every other thread holds `0x55555558`.

```rust
// Thread created BEFORE v8 initialises, then handed a SharedIsolate.
let (tx, rx) = std::sync::mpsc::channel();
let early = std::thread::spawn(move || call_fn(&rx.recv().unwrap()));

v8::V8::initialize_platform(v8::new_default_platform(0, false).make_shared());
v8::V8::initialize();
let shared = Arc::new(unsafe { v8::Isolate::new(Default::default()).try_into_shared().unwrap() });
// ... store a Global<Context> and Global<Function> in slots ...

// Thread created AFTER inherits the permissive PKRU and succeeds.
std::thread::spawn({ let s = shared.clone(); move || call_fn(&s) }).join().unwrap();

tx.send(shared).unwrap();
early.join().unwrap();   // SIGSEGV in Builtins_CallFunction_ReceiverIsAny
```

### Changes

- `V8::initialize` — the requirement, the failure signature, and a short correct-ordering example.
- `SharedIsolate` — a pointer to the above, since locking from a pool is its expected use.

Docs only, no behaviour change. `cargo fmt --check` clean; the new doctest compiles.