### PR TITLE
feat: expose classic script IDs

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2870,9 +2870,17 @@ const v8::UnboundScript* v8__Script__GetUnboundScript(
   return local_to_ptr(ptr_to_local(&script)->GetUnboundScript());
 }
 
+int v8__Script__ScriptId(const v8::Script& script) {
+  return ptr_to_local(&script)->ScriptId();
+}
+
 const v8::Script* v8__UnboundScript__BindToCurrentContext(
     const v8::UnboundScript& unbound_script) {
   return local_to_ptr(ptr_to_local(&unbound_script)->BindToCurrentContext());
+}
+
+int v8__UnboundScript__ScriptId(const v8::UnboundScript& unbound_script) {
+  return ptr_to_local(&unbound_script)->ScriptId();
 }
 
 v8::ScriptCompiler::CachedData* v8__UnboundScript__CreateCodeCache(

--- a/src/script.rs
+++ b/src/script.rs
@@ -28,6 +28,7 @@ unsafe extern "C" {
   fn v8__Script__GetUnboundScript(
     script: *const Script,
   ) -> *const UnboundScript;
+  fn v8__Script__ScriptId(script: *const Script) -> i32;
   fn v8__Script__Run(
     script: *const Script,
     context: *const Context,
@@ -85,6 +86,12 @@ impl Script {
         .cast_local(|_| v8__Script__GetUnboundScript(self))
         .unwrap()
     }
+  }
+
+  /// Returns the ID assigned to the underlying script by V8.
+  #[inline(always)]
+  pub fn script_id(&self) -> i32 {
+    unsafe { v8__Script__ScriptId(self) }
   }
 
   /// Runs the script returning the resulting value. It will be run in the

--- a/src/unbound_script.rs
+++ b/src/unbound_script.rs
@@ -10,6 +10,7 @@ unsafe extern "C" {
   fn v8__UnboundScript__BindToCurrentContext(
     script: *const UnboundScript,
   ) -> *const Script;
+  fn v8__UnboundScript__ScriptId(script: *const UnboundScript) -> i32;
   fn v8__UnboundScript__CreateCodeCache(
     script: *const UnboundScript,
   ) -> *mut CachedData<'static>;
@@ -34,6 +35,12 @@ impl UnboundScript {
       scope.cast_local(|_| v8__UnboundScript__BindToCurrentContext(self))
     }
     .unwrap()
+  }
+
+  /// Returns the ID assigned to this context-unbound script by V8.
+  #[inline(always)]
+  pub fn script_id(&self) -> i32 {
+    unsafe { v8__UnboundScript__ScriptId(self) }
   }
 
   /// Creates and returns code cache for the specified unbound_script.

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -9965,6 +9965,22 @@ fn wasm_module_compilation_abort() {
 }
 
 #[test]
+fn script_id() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  v8::scope!(let scope, isolate);
+
+  let context = v8::Context::new(scope, Default::default());
+  let scope = &mut v8::ContextScope::new(scope, context);
+  let source = v8::String::new(scope, "1 + 2").unwrap();
+  let script = v8::Script::compile(scope, source, None).unwrap();
+
+  let script_id = script.script_id();
+  assert!(script_id > 0);
+  assert_eq!(script.get_unbound_script(scope).script_id(), script_id);
+}
+
+#[test]
 fn unbound_script_conversion() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
## Summary

- expose the V8-assigned identity through `Script::script_id()`
- expose the same identity through `UnboundScript::script_id()`
- verify bound and unbound script handles report the same positive ID

## Testing

- `cargo fmt --check`
- `clang-format-21 --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=third_party/rust-toolchain/lib cargo clippy --all-targets --locked -- -D clippy::all`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=third_party/rust-toolchain/lib cargo nextest run --all-targets --locked` (345 passed)

Closes #2055