### PR TITLE
build: support explicit Linux bindgen sysroots

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ are not installed in host search paths, set the explicit bindgen inputs:
 ```bash
 export LIBCLANG_PATH=/path/to/libclang/lib
 export RUSTY_V8_BINDGEN_RESOURCE_DIR=/path/to/lib/clang/21
-export RUSTY_V8_GLIBC_SYSROOT=/path/to/aarch64-linux-gnu
+export RUSTY_V8_GLIBC_PREFIX=/path/to/aarch64-linux-gnu
 V8_FROM_SOURCE=1 cargo build -vv --target aarch64-unknown-linux-gnu
 ```
 
 `RUSTY_V8_BINDGEN_RESOURCE_DIR` takes the directory printed by
-`clang -print-resource-dir`. `RUSTY_V8_GLIBC_SYSROOT` takes a GNU target prefix
+`clang -print-resource-dir`. `RUSTY_V8_GLIBC_PREFIX` takes a GNU target prefix
 whose `include` child contains the target libc headers. Musl cross-builds use
 `RUSTY_V8_MUSL_SYSROOT` instead; it is passed to Clang with `--sysroot`.
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ sudo apt install libclang-21-dev
 export LIBCLANG_PATH=/usr/lib/llvm-21/lib
 ```
 
+Linux cross-builds normally discover Clang's builtin headers and the target
+libc headers from the host toolchain. For hermetic toolchains where those files
+are not installed in host search paths, set the explicit bindgen inputs:
+
+```bash
+export LIBCLANG_PATH=/path/to/libclang/lib
+export RUSTY_V8_BINDGEN_RESOURCE_DIR=/path/to/lib/clang/21
+export RUSTY_V8_GLIBC_SYSROOT=/path/to/aarch64-linux-gnu
+V8_FROM_SOURCE=1 cargo build -vv --target aarch64-unknown-linux-gnu
+```
+
+`RUSTY_V8_BINDGEN_RESOURCE_DIR` takes the directory printed by
+`clang -print-resource-dir`. `RUSTY_V8_GLIBC_SYSROOT` takes a GNU target prefix
+whose `include` child contains the target libc headers. Musl cross-builds use
+`RUSTY_V8_MUSL_SYSROOT` instead; it is passed to Clang with `--sysroot`.
+
 For Windows builds: the 64-bit toolchain needs to be used. 32-bit targets are
 not supported. The default source build downloads Chromium's pinned libclang
 automatically. If `$CLANG_BASE_PATH` is set to a custom LLVM installation,

--- a/build.rs
+++ b/build.rs
@@ -68,7 +68,7 @@ fn main() {
     "OUT_DIR",
     "RUSTY_V8_ARCHIVE",
     "RUSTY_V8_BINDGEN_RESOURCE_DIR",
-    "RUSTY_V8_GLIBC_SYSROOT",
+    "RUSTY_V8_GLIBC_PREFIX",
     "RUSTY_V8_MIRROR",
     "RUSTY_V8_MIRROR_TAG",
     "RUSTY_V8_MIRROR_FALLBACK",
@@ -252,20 +252,17 @@ fn build_binding() {
         clang_args.push(format!("-isystem{}/include", resource_dir.trim()));
       }
     }
-    // Parse the V8 headers against the musl sysroot. bindgen already targets
-    // the musl triple (from $TARGET), so without this it looks for the target
-    // arch's glibc multiarch headers, which aren't installed when cross-
-    // compiling (e.g. aarch64 glibc headers on an x86_64 runner).
+    // Add target libc headers for Linux cross-builds. bindgen already targets
+    // Cargo's triple (from $TARGET), but target headers may not be installed in
+    // the host's search paths.
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
-    let target_triple = env::var("TARGET").unwrap();
     let musl_sysroot = env::var("RUSTY_V8_MUSL_SYSROOT").ok();
-    let glibc_sysroot = env::var("RUSTY_V8_GLIBC_SYSROOT").ok();
+    let glibc_prefix = env::var("RUSTY_V8_GLIBC_PREFIX").ok();
     clang_args.extend(explicit_linux_bindgen_args(
       &target_env,
-      &target_triple,
       resource_dir.as_deref(),
       musl_sysroot.as_deref(),
-      glibc_sysroot.as_deref(),
+      glibc_prefix.as_deref(),
     ));
   } else if target_os == "windows" {
     // libclang otherwise discovers the runner's system Clang resource
@@ -348,12 +345,22 @@ fn build_binding() {
     .expect("Couldn't write bindings!");
 }
 
+/// Builds the explicit Linux header-search arguments for bindgen.
+///
+/// An explicit Clang resource directory uses `-resource-dir` so Clang resolves
+/// the complete builtin resource layout. The auto-discovery path only adds the
+/// discovered `include` directory because it is supplementing libclang's
+/// existing resource setup.
+///
+/// Musl receives `--sysroot` because its input is a complete sysroot. A GNU
+/// cross prefix instead stores target headers directly under `<prefix>/include`;
+/// treating it as a sysroot would make Clang search `<prefix>/usr/include`.
+/// bindgen supplies the Clang target from Cargo's `TARGET` environment variable.
 fn explicit_linux_bindgen_args(
   target_env: &str,
-  target_triple: &str,
   resource_dir: Option<&str>,
   musl_sysroot: Option<&str>,
-  glibc_sysroot: Option<&str>,
+  glibc_prefix: Option<&str>,
 ) -> Vec<String> {
   let mut args = Vec::new();
   if let Some(resource_dir) = resource_dir {
@@ -367,9 +374,8 @@ fn explicit_linux_bindgen_args(
       }
     }
     "gnu" => {
-      if let Some(sysroot) = glibc_sysroot {
-        args.push(format!("--target={target_triple}"));
-        args.push(format!("-isystem{sysroot}/include"));
+      if let Some(prefix) = glibc_prefix {
+        args.push(format!("-isystem{prefix}/include"));
       }
     }
     _ => {}
@@ -1862,40 +1868,52 @@ edge [fontsize=10]
     assert_eq!(
       explicit_linux_bindgen_args(
         "gnu",
-        "aarch64-unknown-linux-gnu",
         Some("/opt/llvm/lib/clang/21"),
         None,
         Some("/opt/aarch64-linux-gnu"),
       ),
       vec![
         "-resource-dir=/opt/llvm/lib/clang/21",
-        "--target=aarch64-unknown-linux-gnu",
         "-isystem/opt/aarch64-linux-gnu/include",
       ]
     );
   }
 
   #[test]
-  fn test_explicit_linux_bindgen_args_keep_sysroots_target_scoped() {
+  fn test_explicit_linux_bindgen_args_keep_libc_inputs_target_scoped() {
     assert_eq!(
       explicit_linux_bindgen_args(
         "musl",
-        "aarch64-unknown-linux-musl",
-        None,
+        Some("/opt/llvm/lib/clang/21"),
         Some("/opt/musl-sysroot"),
-        Some("/opt/glibc-sysroot"),
+        Some("/opt/glibc-prefix"),
       ),
-      vec!["--sysroot=/opt/musl-sysroot"]
+      vec![
+        "-resource-dir=/opt/llvm/lib/clang/21",
+        "--sysroot=/opt/musl-sysroot",
+      ]
     );
     assert!(
       explicit_linux_bindgen_args(
         "uclibc",
-        "aarch64-unknown-linux-uclibc",
         None,
         Some("/opt/musl-sysroot"),
-        Some("/opt/glibc-sysroot"),
+        Some("/opt/glibc-prefix"),
       )
       .is_empty()
+    );
+  }
+
+  #[test]
+  fn test_explicit_linux_bindgen_args_for_resource_dir_only() {
+    assert_eq!(
+      explicit_linux_bindgen_args(
+        "gnu",
+        Some("/opt/llvm/lib/clang/21"),
+        None,
+        None,
+      ),
+      vec!["-resource-dir=/opt/llvm/lib/clang/21"]
     );
   }
 }

--- a/build.rs
+++ b/build.rs
@@ -67,9 +67,12 @@ fn main() {
     "NINJA",
     "OUT_DIR",
     "RUSTY_V8_ARCHIVE",
+    "RUSTY_V8_BINDGEN_RESOURCE_DIR",
+    "RUSTY_V8_GLIBC_SYSROOT",
     "RUSTY_V8_MIRROR",
     "RUSTY_V8_MIRROR_TAG",
     "RUSTY_V8_MIRROR_FALLBACK",
+    "RUSTY_V8_MUSL_SYSROOT",
     "RUSTY_V8_SRC_BINDING_PATH",
     "SCCACHE",
     "V8_FORCE_DEBUG",
@@ -233,7 +236,10 @@ fn build_binding() {
     clang_args.push(sdk_path.trim().to_string());
   } else if target_os == "linux" {
     // Add clang resource directory for builtin headers (stddef.h, etc)
-    if let Ok(libclang_path) = env::var("LIBCLANG_PATH") {
+    let resource_dir = env::var("RUSTY_V8_BINDGEN_RESOURCE_DIR").ok();
+    if resource_dir.is_none()
+      && let Ok(libclang_path) = env::var("LIBCLANG_PATH")
+    {
       let clang_dir = PathBuf::from(&libclang_path)
         .parent()
         .unwrap()
@@ -251,11 +257,16 @@ fn build_binding() {
     // arch's glibc multiarch headers, which aren't installed when cross-
     // compiling (e.g. aarch64 glibc headers on an x86_64 runner).
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
-    if target_env == "musl"
-      && let Ok(sysroot) = env::var("RUSTY_V8_MUSL_SYSROOT")
-    {
-      clang_args.push(format!("--sysroot={sysroot}"));
-    }
+    let target_triple = env::var("TARGET").unwrap();
+    let musl_sysroot = env::var("RUSTY_V8_MUSL_SYSROOT").ok();
+    let glibc_sysroot = env::var("RUSTY_V8_GLIBC_SYSROOT").ok();
+    clang_args.extend(explicit_linux_bindgen_args(
+      &target_env,
+      &target_triple,
+      resource_dir.as_deref(),
+      musl_sysroot.as_deref(),
+      glibc_sysroot.as_deref(),
+    ));
   } else if target_os == "windows" {
     // libclang otherwise discovers the runner's system Clang resource
     // directory, which may not match the pinned Chromium libclang.
@@ -335,6 +346,35 @@ fn build_binding() {
   bindings
     .write_to_file(out_path)
     .expect("Couldn't write bindings!");
+}
+
+fn explicit_linux_bindgen_args(
+  target_env: &str,
+  target_triple: &str,
+  resource_dir: Option<&str>,
+  musl_sysroot: Option<&str>,
+  glibc_sysroot: Option<&str>,
+) -> Vec<String> {
+  let mut args = Vec::new();
+  if let Some(resource_dir) = resource_dir {
+    args.push(format!("-resource-dir={resource_dir}"));
+  }
+
+  match target_env {
+    "musl" => {
+      if let Some(sysroot) = musl_sysroot {
+        args.push(format!("--sysroot={sysroot}"));
+      }
+    }
+    "gnu" => {
+      if let Some(sysroot) = glibc_sysroot {
+        args.push(format!("--target={target_triple}"));
+        args.push(format!("-isystem{sysroot}/include"));
+      }
+    }
+    _ => {}
+  }
+  args
 }
 
 fn build_v8(is_asan: bool) {
@@ -1814,6 +1854,48 @@ edge [fontsize=10]
     assert_eq!(
       candidate_urls(None, true, &TEST_VARS),
       candidate_urls(None, false, &TEST_VARS)
+    );
+  }
+
+  #[test]
+  fn test_explicit_linux_bindgen_args_for_glibc_cross_compile() {
+    assert_eq!(
+      explicit_linux_bindgen_args(
+        "gnu",
+        "aarch64-unknown-linux-gnu",
+        Some("/opt/llvm/lib/clang/21"),
+        None,
+        Some("/opt/aarch64-linux-gnu"),
+      ),
+      vec![
+        "-resource-dir=/opt/llvm/lib/clang/21",
+        "--target=aarch64-unknown-linux-gnu",
+        "-isystem/opt/aarch64-linux-gnu/include",
+      ]
+    );
+  }
+
+  #[test]
+  fn test_explicit_linux_bindgen_args_keep_sysroots_target_scoped() {
+    assert_eq!(
+      explicit_linux_bindgen_args(
+        "musl",
+        "aarch64-unknown-linux-musl",
+        None,
+        Some("/opt/musl-sysroot"),
+        Some("/opt/glibc-sysroot"),
+      ),
+      vec!["--sysroot=/opt/musl-sysroot"]
+    );
+    assert!(
+      explicit_linux_bindgen_args(
+        "uclibc",
+        "aarch64-unknown-linux-uclibc",
+        None,
+        Some("/opt/musl-sysroot"),
+        Some("/opt/glibc-sysroot"),
+      )
+      .is_empty()
     );
   }
 }


### PR DESCRIPTION
## Summary

- Allow Linux source builds to provide bindgen's Clang resource directory and target libc headers explicitly.
- Preserve existing automatic discovery and musl behavior when the new overrides are unset.

## Motivation

`rusty_v8` expects a system `libclang`, but its Linux bindgen setup currently assumes that `LIBCLANG_PATH` has a sibling `bin/clang` and that target libc headers are installed in host search paths. Split or hermetic cross-toolchains do not necessarily use either layout.

The generic bindgen extra-argument variables can work around this, but the build already has target-aware Linux setup and a dedicated musl sysroot input. Keeping these inputs in `build.rs` makes the GNU and musl paths explicit, target-scoped, documented, and tracked by Cargo.

## What Changed

- Add `RUSTY_V8_BINDGEN_RESOURCE_DIR` for installations where matching Clang resources cannot be discovered beside `LIBCLANG_PATH`.
- Add `RUSTY_V8_GLIBC_PREFIX` for GNU cross-toolchains whose target headers are outside host search paths.
- Keep `RUSTY_V8_GLIBC_PREFIX` and `RUSTY_V8_MUSL_SYSROOT` scoped to their respective target environments; bindgen continues to derive the Clang target from Cargo's `TARGET`.
- Register all three explicit bindgen inputs with Cargo's environment-change tracking. This also fixes the existing omission of `RUSTY_V8_MUSL_SYSROOT`, so changing it now retriggers the build script.
- Document why explicit resources use `-resource-dir`, musl uses `--sysroot`, and GNU prefixes use `-isystem<prefix>/include`.
- Add focused tests for GNU prefix handling, GNU resource-only handling, musl resource-plus-sysroot handling, and target-environment scoping.
- Document the variables and their expected directory layouts.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --locked --test build -- -D clippy::all`
- `cargo test --locked --test build -- --nocapture` — 12 passed
- The pre-rebase full local suite passed, including 292 API tests, UI tests, and doctests; the exact rebased head is covered by the upstream CI matrix now running on this PR.
- Locked bindgen 0.72 source verification confirms that, absent an explicit target argument, it reads Cargo's `TARGET` and injects the matching Clang `--target` for cross-builds.
- The original contribution passed upstream's complete CI matrix: [31548574780](https://github.com/denoland/rusty_v8/actions/runs/31548574780).
- Review-staging CI passed GNU x86_64 release with and without pointer compression, x86_64 and ARM64 musl releases, iOS device/simulator, and an available Apple ARM64 release. Four paid Intel macOS jobs could not start because paid Actions are not configured on the fork: [31700715004](https://github.com/Shrimpworks/rusty_v8/actions/runs/31700715004).
- An end-to-end x64-to-ARM64 builder run using the equivalent explicit inputs passed a network-disabled source build, bindgen generation, and QEMU test: [30925045754](https://github.com/Shrimpworks/rusty_v8/actions/runs/30925045754).

## Related Work

- #1595 documents the system-`libclang` requirement that this extends to split and hermetic toolchains. This PR does not reopen or close that issue.
- #2018 established the existing explicit musl sysroot path that this change preserves and keeps separate from GNU prefixes.

## Scope Notes

- The branch is based on exact upstream commit `00fce34ac8a6eb7cb2da7d8aa51fe1f0bca897c7` and changes only `README.md` and `build.rs`.
- All new behavior is opt-in; unset inputs retain current behavior.
- No CI workflow, V8 build configuration, or artifact publication changes are included.
- The end-to-end hermetic build used the equivalent inputs on v150.2.0; current v152 validation covers the focused build-script behavior and upstream's platform matrix.
