### PR TITLE
build: relax RUSTY_V8_MIRROR release-tag assumptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,6 +663,53 @@ jobs:
           RUSTY_V8_SRC_BINDING_PATH: ${{ github.workspace }}/src_binding_release_aarch64-pc-windows-msvc.rs
         run: cargo nextest run -v --all-targets --locked --target aarch64-pc-windows-msvc --release --no-fail-fast
 
+  # Exercises the prebuilt-download path from a bare git checkout, which ships
+  # only `gen/.gitkeep` (no bindings). With no RUSTY_V8_ARCHIVE /
+  # RUSTY_V8_SRC_BINDING_PATH / V8_FROM_SOURCE set, build.rs must auto-fetch both
+  # the static library and the bindings from the release matching the crate
+  # version. Skips itself when that version has no published release yet (e.g. a
+  # version-bump PR before the tag is cut).
+  prebuilt-git-checkout:
+    name: prebuilt from git checkout
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.x
+
+      - name: Resolve release for current version
+        id: rel
+        shell: bash
+        run: |
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          URL="https://github.com/denoland/rusty_v8/releases/download/v${VERSION}/librusty_v8_release_aarch64-apple-darwin.a.gz"
+          if curl -sfIL "$URL" -o /dev/null; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No published release for v${VERSION}; skipping prebuilt-from-git-checkout build."
+          fi
+
+      - name: Build prebuilt from a clean checkout
+        if: steps.rel.outputs.published == 'true'
+        shell: bash
+        run: |
+          # Confirm this really is the git-checkout case (no shipped binding).
+          test ! -e gen/src_binding_release_aarch64-apple-darwin.rs
+          cargo build --all-targets --locked --release --target aarch64-apple-darwin
+          # The binding must have been fetched into OUT_DIR, not the source tree.
+          test ! -e gen/src_binding_release_aarch64-apple-darwin.rs
+
   publish:
     needs: [build, build-windows-arm64]
     runs-on: ${{ github.repository == 'denoland/rusty_v8' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,7 +697,11 @@ jobs:
             echo "published=true" >> "$GITHUB_OUTPUT"
           else
             echo "published=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No published release for v${VERSION}; skipping prebuilt-from-git-checkout build."
+            # A warning rather than a notice: this job contributes no signal when
+            # it skips, and a silently-green skip is easy to stop noticing. The
+            # expected case is a version bump that has landed before its tag.
+            echo "::warning::No published release for v${VERSION}; the prebuilt-from-git-checkout job verified NOTHING this run."
+            echo "### :warning: prebuilt-from-git-checkout skipped: no release for v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Build prebuilt from a clean checkout
@@ -709,6 +713,56 @@ jobs:
           cargo build --all-targets --locked --release --target aarch64-apple-darwin
           # The binding must have been fetched into OUT_DIR, not the source tree.
           test ! -e gen/src_binding_release_aarch64-apple-darwin.rs
+          # ... and it must actually be somewhere under target/, so that an
+          # accidental no-op build can't satisfy the assertion above.
+          find target -name 'src_binding_release_aarch64-apple-darwin.rs' \
+            | grep -q . || {
+              echo "no fetched binding found under target/" >&2
+              exit 1
+            }
+
+      # The default path above only covers `<upstream>/<tag>/<file>`. This builds
+      # again from a flat filesystem mirror with the upstream fallback disabled,
+      # covering RUSTY_V8_MIRROR, the untagged cache layout and strict mode
+      # end-to-end. It reuses the artifacts the previous step downloaded, so it
+      # needs no network and cannot fall back to upstream without failing.
+      - name: Build from a flat filesystem mirror, hermetically
+        if: steps.rel.outputs.published == 'true'
+        shell: bash
+        run: |
+          MIRROR="$RUNNER_TEMP/flat-mirror"
+          mkdir -p "$MIRROR"
+          # Harvest what the previous build fetched, before cleaning it away.
+          # The static library is stored decompressed; putting it under the
+          # `.a.gz` name is fine because copy_archive sniffs the gzip magic
+          # rather than trusting the extension, so this also covers that branch.
+          LIB=$(find target -name librusty_v8.a | head -1)
+          BINDING=$(find target -name 'src_binding_release_aarch64-apple-darwin.rs' | head -1)
+          test -n "$LIB" && test -n "$BINDING"
+          cp "$LIB" "$MIRROR/librusty_v8_release_aarch64-apple-darwin.a.gz"
+          cp "$BINDING" "$MIRROR/src_binding_release_aarch64-apple-darwin.rs"
+
+          # Force the build script to re-resolve, then build with the upstream
+          # fallback disabled: every artifact must come from the flat mirror.
+          cargo clean --release --target aarch64-apple-darwin
+          RUSTY_V8_MIRROR="$MIRROR" RUSTY_V8_MIRROR_STRICT=1 \
+            cargo build --locked --release --target aarch64-apple-darwin
+          test ! -e gen/src_binding_release_aarch64-apple-darwin.rs
+
+      # Strict mode with no mirror has nothing to fetch from and must fail
+      # loudly rather than silently reaching upstream.
+      - name: Strict mode without a mirror fails
+        if: steps.rel.outputs.published == 'true'
+        shell: bash
+        run: |
+          cargo clean --release --target aarch64-apple-darwin
+          if RUSTY_V8_MIRROR_STRICT=1 \
+            cargo build --locked --release --target aarch64-apple-darwin \
+            > strict.log 2>&1; then
+            echo "expected the build to fail, but it succeeded" >&2
+            exit 1
+          fi
+          grep -q 'No candidate locations to fetch' strict.log
 
   publish:
     needs: [build, build-windows-arm64]

--- a/README.md
+++ b/README.md
@@ -65,9 +65,68 @@ We default to release builds of `v8` due to performance & CI reasons in `deno`.
 
 ## The `RUSTY_V8_MIRROR` environment variable
 
-Tells the build script where to get binary builds from. Understands `http://`
-and `https://` URLs, and file paths. The default is
-https://github.com/denoland/rusty_v8/releases.
+Tells the build script where to get the prebuilt static library and the
+generated bindings from. Understands `http://` and `https://` URLs, and file
+paths. The default is
+https://github.com/denoland/rusty_v8/releases/download.
+
+### Resolution order
+
+By default the build script downloads two artifacts — the static library
+(`librusty_v8_<features>_<profile>_<target>.a.gz`) and the bindings
+(`src_binding_<features>_<profile>_<target>.rs`) — from
+`<base>/<tag>/<file>`, where `<tag>` is `v<crate version>` (e.g. `v152.1.0`).
+For each artifact the following candidates are tried in order, and the first
+one that exists is used:
+
+1. `RUSTY_V8_ARCHIVE`, if set — a specific static library, static library only
+   (see below). Short-circuits everything else.
+2. The `RUSTY_V8_MIRROR` value, if set (see the layouts below).
+3. For a **filesystem** mirror laid out as a plain directory of artifacts, a
+   flat `<mirror>/<file>` lookup (no tag subdirectory).
+4. The upstream default releases, `<default base>/<tag>/<file>`.
+
+If nothing matches, the build fails with a message listing every location that
+was tried.
+
+### Overriding the tag
+
+`RUSTY_V8_MIRROR_TAG` overrides the `<tag>` path segment. The value is used
+**verbatim** (no `v` is prepended), so non-tag directories such as `nightly` or
+`pr-1234` also work:
+
+```bash
+# build a checkout whose Cargo.toml version isn't published yet using the
+# artifacts from the last published tag
+RUSTY_V8_MIRROR_TAG=v152.1.0 cargo build
+```
+
+### Templated mirrors
+
+If the `RUSTY_V8_MIRROR` value contains a `{` placeholder it is treated as a
+full URL/path template instead of a base. The following placeholders are
+substituted:
+
+| Placeholder  | Value                                                        |
+| ------------ | ------------------------------------------------------------ |
+| `{tag}`      | resolved tag (`RUSTY_V8_MIRROR_TAG` or `v<crate version>`)   |
+| `{version}`  | raw crate version, no `v` prefix                             |
+| `{target}`   | Rust target triple                                           |
+| `{profile}`  | `release` or `debug`                                         |
+| `{features}` | ` `, `_ptrcomp`, `_sandbox`, or `_ptrcomp_sandbox`           |
+| `{file}`     | full artifact filename                                       |
+
+```bash
+RUSTY_V8_MIRROR='https://my-cache.example.com/rusty_v8/{tag}/{file}' cargo build
+```
+
+### Strict mode
+
+`RUSTY_V8_MIRROR_STRICT=1` stops the candidate list after the mirror entries,
+so the build never falls back to the upstream releases. Use this for hermetic
+CI that must never reach the network.
+
+### File-based mirrors
 
 File-based mirrors are good for using cached downloads. First, point the
 environment variable to a suitable location:
@@ -75,26 +134,31 @@ environment variable to a suitable location:
     # you might want to add this to your .bashrc
     $ export RUSTY_V8_MIRROR=$HOME/.cache/rusty_v8
 
-Then populate the cache:
+Then populate the cache. The artifacts are gzip-compressed (`.gz`) and named per
+target and profile:
 
 ```bash
 #!/bin/bash
 
 # see https://github.com/denoland/rusty_v8/releases
 
-for REL in v0.13.0 v0.12.0; do
-  mkdir -p $RUSTY_V8_MIRROR/$REL
+for REL in v152.1.0 v152.0.0; do
+  mkdir -p "$RUSTY_V8_MIRROR/$REL"
   for FILE in \
-    librusty_v8_debug_x86_64-unknown-linux-gnu.a \
-    librusty_v8_release_x86_64-unknown-linux-gnu.a \
+    librusty_v8_release_x86_64-unknown-linux-gnu.a.gz \
+    src_binding_release_x86_64-unknown-linux-gnu.rs \
   ; do
-    if [ ! -f $RUSTY_V8_MIRROR/$REL/$FILE ]; then
-      wget -O $RUSTY_V8_MIRROR/$REL/$FILE \
-        https://github.com/denoland/rusty_v8/releases/download/$REL/$FILE
+    if [ ! -f "$RUSTY_V8_MIRROR/$REL/$FILE" ]; then
+      wget -O "$RUSTY_V8_MIRROR/$REL/$FILE" \
+        "https://github.com/denoland/rusty_v8/releases/download/$REL/$FILE"
     fi
   done
 done
 ```
+
+Artifacts may also be dropped straight into `$RUSTY_V8_MIRROR` with no tag
+subdirectory (the flat layout from step 3 above), which makes a directory of
+downloaded files usable as a cache without knowing the tag.
 
 ## The `RUSTY_V8_ARCHIVE` environment variable
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,20 @@ one that exists is used:
 3. For a **filesystem** mirror laid out as a plain directory of artifacts, a
    flat `<mirror>/<file>` lookup (no tag subdirectory).
 4. The upstream default releases, `<default base>/<tag>/<file>`.
+5. For the bindings only: the copy shipped inside the crate at
+   `gen/<file>`, if present. A published crate always ships it, so a mirror that
+   carries only the static library does not force a network fetch — and strict
+   mode does not fail — when the correct bindings are already on disk.
 
 If nothing matches, the build fails with a message listing every location that
 was tried.
+
+> ⚠️ **Untagged layout.** Candidate 3 has no tag in the path, and artifact
+> filenames do not encode a version, so an artifact left over from another
+> release is indistinguishable from the right one. When a build resolves through
+> the flat layout it emits a `cargo:warning=`; see the ABI mismatch note below
+> for why that matters. Use the `<mirror>/<tag>/<file>` layout if you keep more
+> than one version around.
 
 ### Overriding the tag
 
@@ -128,6 +139,10 @@ substituted:
 RUSTY_V8_MIRROR='https://my-cache.example.com/rusty_v8/{tag}/{file}' cargo build
 ```
 
+Only the placeholders above are recognised. A misspelled one would otherwise
+survive expansion and surface as an opaque 404, so the build fails immediately
+and names the offenders.
+
 ### Strict mode
 
 `RUSTY_V8_MIRROR_STRICT=1` stops the candidate list after the mirror entries,
@@ -137,6 +152,10 @@ CI that must never reach the network. It is honored unconditionally: if no
 fails with an explicit error rather than silently reaching upstream. A hermetic
 build that also needs the bindings without a mirror can point
 `RUSTY_V8_SRC_BINDING_PATH` at them directly.
+
+An artifact already fetched by an earlier build is reused, so the usual
+workflow of populating a cache once with network access and then building
+offline works without a mirror configured.
 
 ### File-based mirrors
 

--- a/README.md
+++ b/README.md
@@ -107,14 +107,14 @@ If the `RUSTY_V8_MIRROR` value contains a `{` placeholder it is treated as a
 full URL/path template instead of a base. The following placeholders are
 substituted:
 
-| Placeholder  | Value                                                        |
-| ------------ | ------------------------------------------------------------ |
-| `{tag}`      | resolved tag (`RUSTY_V8_MIRROR_TAG` or `v<crate version>`)   |
-| `{version}`  | raw crate version, no `v` prefix                             |
-| `{target}`   | Rust target triple                                           |
-| `{profile}`  | `release` or `debug`                                         |
-| `{features}` | ` `, `_ptrcomp`, `_sandbox`, or `_ptrcomp_sandbox`           |
-| `{file}`     | full artifact filename                                       |
+| Placeholder  | Value                                                                        |
+| ------------ | ---------------------------------------------------------------------------- |
+| `{tag}`      | resolved tag (`RUSTY_V8_MIRROR_TAG` or `v<crate version>`)                    |
+| `{version}`  | raw crate version, no `v` prefix                                             |
+| `{target}`   | Rust target triple                                                           |
+| `{profile}`  | `release`, or `debug` only when `V8_FORCE_DEBUG=true` on a non-Windows target |
+| `{features}` | empty, or `_ptrcomp`, `_sandbox`, `_ptrcomp_sandbox`                          |
+| `{file}`     | full artifact filename                                                       |
 
 ```bash
 RUSTY_V8_MIRROR='https://my-cache.example.com/rusty_v8/{tag}/{file}' cargo build
@@ -124,7 +124,9 @@ RUSTY_V8_MIRROR='https://my-cache.example.com/rusty_v8/{tag}/{file}' cargo build
 
 `RUSTY_V8_MIRROR_STRICT=1` stops the candidate list after the mirror entries,
 so the build never falls back to the upstream releases. Use this for hermetic
-CI that must never reach the network.
+CI that must never reach the network. It only takes effect when `RUSTY_V8_MIRROR`
+is also set — with no mirror configured there is nothing to be strict about, and
+it is ignored so the build can still reach upstream.
 
 ### File-based mirrors
 

--- a/README.md
+++ b/README.md
@@ -101,20 +101,28 @@ was tried.
 RUSTY_V8_MIRROR_TAG=v152.1.0 cargo build
 ```
 
+> ⚠️ **ABI mismatch risk.** This pairs the checkout's Rust sources with a
+> `librusty_v8.a` and `src_binding_*.rs` generated from a *different* V8. The
+> layout `static_assert`s that would catch a mismatch were compiled into the old
+> archive and cannot fire, so a mismatch may link and then corrupt memory at
+> runtime. Only use a tag you know is ABI-compatible with this checkout. The
+> build emits a `cargo:warning=` whenever the resolved tag differs from
+> `v<crate version>`.
+
 ### Templated mirrors
 
 If the `RUSTY_V8_MIRROR` value contains a `{` placeholder it is treated as a
 full URL/path template instead of a base. The following placeholders are
 substituted:
 
-| Placeholder  | Value                                                                        |
-| ------------ | ---------------------------------------------------------------------------- |
-| `{tag}`      | resolved tag (`RUSTY_V8_MIRROR_TAG` or `v<crate version>`)                    |
-| `{version}`  | raw crate version, no `v` prefix                                             |
-| `{target}`   | Rust target triple                                                           |
-| `{profile}`  | `release`, or `debug` only when `V8_FORCE_DEBUG=true` on a non-Windows target |
-| `{features}` | empty, or `_ptrcomp`, `_sandbox`, `_ptrcomp_sandbox`                          |
-| `{file}`     | full artifact filename                                                       |
+| Placeholder  | Value                                                      |
+| ------------ | ---------------------------------------------------------- |
+| `{tag}`      | resolved tag (`RUSTY_V8_MIRROR_TAG` or `v<crate version>`) |
+| `{version}`  | raw crate version, no `v` prefix                           |
+| `{target}`   | Rust target triple                                         |
+| `{profile}`  | `release`, or `debug` (`V8_FORCE_DEBUG=true`, non-Windows) |
+| `{features}` | empty, or `_ptrcomp`, `_sandbox`, `_ptrcomp_sandbox`       |
+| `{file}`     | full artifact filename                                     |
 
 ```bash
 RUSTY_V8_MIRROR='https://my-cache.example.com/rusty_v8/{tag}/{file}' cargo build
@@ -124,9 +132,11 @@ RUSTY_V8_MIRROR='https://my-cache.example.com/rusty_v8/{tag}/{file}' cargo build
 
 `RUSTY_V8_MIRROR_STRICT=1` stops the candidate list after the mirror entries,
 so the build never falls back to the upstream releases. Use this for hermetic
-CI that must never reach the network. It only takes effect when `RUSTY_V8_MIRROR`
-is also set — with no mirror configured there is nothing to be strict about, and
-it is ignored so the build can still reach upstream.
+CI that must never reach the network. It is honored unconditionally: if no
+`RUSTY_V8_MIRROR` is set there is nowhere left to fetch from, and the build
+fails with an explicit error rather than silently reaching upstream. A hermetic
+build that also needs the bindings without a mirror can point
+`RUSTY_V8_SRC_BINDING_PATH` at them directly.
 
 ### File-based mirrors
 

--- a/build.rs
+++ b/build.rs
@@ -102,6 +102,7 @@ fn main() {
   if is_cargo_doc || is_rls {
     // Don't fetch a missing binding here: docs.rs/RLS may have no network, and
     // a published crate already ships it.
+    warn_on_tag_override();
     print_prebuilt_src_binding_path(false);
     return;
   }
@@ -165,7 +166,17 @@ fn main() {
 /// cannot fire, so a mismatch can link and then corrupt memory at runtime. The
 /// feature is legitimate (e.g. building an unpublished version against the last
 /// released artifacts), but the risk should be surfaced.
+///
+/// The tag is only consulted for artifacts that are actually resolved by tag, so
+/// the warning is suppressed when both the static library and the bindings are
+/// supplied explicitly and the tag is therefore unused.
 fn warn_on_tag_override() {
+  let lib_from_tag = env::var_os("RUSTY_V8_ARCHIVE").is_none();
+  let binding_from_tag = env::var_os("RUSTY_V8_SRC_BINDING_PATH").is_none();
+  if !lib_from_tag && !binding_from_tag {
+    return;
+  }
+
   let tag = mirror_tag();
   let expected = format!("v{}", env::var("CARGO_PKG_VERSION").unwrap());
   if tag != expected {
@@ -779,8 +790,11 @@ const DEFAULT_MIRROR_BASE: &str =
   "https://github.com/denoland/rusty_v8/releases/download";
 
 fn is_http_url(s: &str) -> bool {
-  let lower = s.to_ascii_lowercase();
-  lower.starts_with("http:") || lower.starts_with("https:")
+  let starts_with_ignore_case = |prefix: &str| {
+    s.len() >= prefix.len()
+      && s.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
+  };
+  starts_with_ignore_case("http:") || starts_with_ignore_case("https:")
 }
 
 /// The release tag (directory segment) that artifacts are looked up under.
@@ -795,10 +809,47 @@ fn mirror_tag() -> String {
   }
 }
 
+/// The placeholders a templated `RUSTY_V8_MIRROR` may use.
+const TEMPLATE_PLACEHOLDERS: [&str; 6] =
+  ["tag", "version", "target", "profile", "features", "file"];
+
+/// Check that `template` only uses placeholders from [`TEMPLATE_PLACEHOLDERS`].
+///
+/// A misspelled placeholder would otherwise survive expansion verbatim and
+/// surface as an opaque 404, so it is reported up front. Returns the offending
+/// fragments, in order.
+fn validate_mirror_template(template: &str) -> Result<(), Vec<String>> {
+  let mut unknown = Vec::new();
+  let mut rest = template;
+  while let Some(open) = rest.find('{') {
+    rest = &rest[open + 1..];
+    match rest.find('}') {
+      Some(close) => {
+        let name = &rest[..close];
+        if !TEMPLATE_PLACEHOLDERS.contains(&name) {
+          unknown.push(format!("{{{name}}}"));
+        }
+        rest = &rest[close + 1..];
+      }
+      None => {
+        unknown.push("unterminated '{'".to_string());
+        break;
+      }
+    }
+  }
+  if unknown.is_empty() {
+    Ok(())
+  } else {
+    Err(unknown)
+  }
+}
+
 /// Expand a templated `RUSTY_V8_MIRROR` value. See [`artifact_urls`].
 ///
 /// The substitution values are passed in rather than read from the environment
-/// so this stays a pure function that can be unit tested.
+/// so this stays a pure function that can be unit tested. Validate the template
+/// with [`validate_mirror_template`] first; unknown placeholders are left
+/// untouched here.
 fn expand_mirror_template(
   template: &str,
   tag: &str,
@@ -901,8 +952,27 @@ fn artifact_urls_from(
 fn artifact_urls(file: &str) -> Vec<Candidate> {
   let version = env::var("CARGO_PKG_VERSION").unwrap();
   let target = env::var("TARGET").unwrap();
+  let mirror = env::var("RUSTY_V8_MIRROR").ok();
+
+  if let Some(mirror) = &mirror
+    && mirror.contains('{')
+    && let Err(unknown) = validate_mirror_template(mirror)
+  {
+    panic!(
+      "RUSTY_V8_MIRROR is a template but uses unknown placeholders: {}.\n\
+       Supported placeholders are {}.\n\
+       Template: {mirror}",
+      unknown.join(", "),
+      TEMPLATE_PLACEHOLDERS
+        .iter()
+        .map(|p| format!("{{{p}}}"))
+        .collect::<Vec<_>>()
+        .join(", "),
+    );
+  }
+
   artifact_urls_from(
-    env::var("RUSTY_V8_MIRROR").ok().as_deref(),
+    mirror.as_deref(),
     &mirror_tag(),
     env_bool("RUSTY_V8_MIRROR_STRICT"),
     &version,
@@ -975,6 +1045,7 @@ fn replace_non_alphanumeric(url: &str) -> String {
 }
 
 /// The outcome of trying a single artifact candidate.
+#[derive(Debug)]
 enum FetchError {
   /// The candidate is absent (missing file, failed download). Fall through to
   /// the next candidate.
@@ -985,15 +1056,63 @@ enum FetchError {
   Fatal(String),
 }
 
+/// Warn that `what` was resolved through the untagged flat mirror layout.
+///
+/// That path has no tag in it, and artifact filenames don't encode a version, so
+/// an artifact left over from another release is indistinguishable from the right
+/// one — the same hazard `RUSTY_V8_MIRROR_TAG` is warned about. Emitted on every
+/// build that resolves this way, including cached ones, so it can't be missed by
+/// looking at the wrong build.
+fn warn_untagged_mirror(what: &str, url: &str) {
+  println!(
+    "cargo:warning=Using {what} from the untagged mirror path {url}. That \
+     filename does not encode a version, so an artifact left over from another \
+     release can be picked up here; a layout mismatch may link and then corrupt \
+     memory at runtime. Use the <mirror>/<tag>/<file> layout if that is a \
+     concern."
+  );
+}
+
 /// Fetch each candidate in `urls` into `filename`, stopping at the first that
 /// succeeds. A [`FetchError::Fatal`] aborts immediately. If every candidate is
 /// a [`FetchError::Miss`], panic with the full list of what was tried and the
 /// available escape hatches. `what` names the artifact for the diagnostics
 /// (e.g. "the V8 static library").
 fn download_artifact(urls: &[Candidate], filename: &Path, what: &str) {
+  // A previous build already fetched this artifact from one of the candidates.
+  // Checked once here rather than per candidate so that an earlier candidate
+  // which misses (e.g. a mirror that doesn't carry this file) isn't re-probed on
+  // every incremental build.
+  if filename.exists()
+    && let Ok(sum) = fs::read_to_string(static_checksum_path(filename))
+    && let Some(cached) = urls.iter().find(|candidate| candidate.url == sum)
+  {
+    println!(
+      "Already downloaded {} from {}",
+      filename.display(),
+      cached.url
+    );
+    if cached.is_cache {
+      warn_untagged_mirror(what, &cached.url);
+    }
+    return;
+  }
+
   if urls.is_empty() {
     // Only reachable with RUSTY_V8_MIRROR_STRICT set and no mirror configured:
     // strict suppresses upstream, leaving nothing to try.
+    if filename.exists() {
+      // Nothing to fetch from, but the artifact is already in place from an
+      // earlier build. Failing here would break the natural hermetic workflow
+      // (populate the cache once with network, then build offline), so use it.
+      println!(
+        "cargo:warning=RUSTY_V8_MIRROR_STRICT is set with no RUSTY_V8_MIRROR, \
+         so there is nowhere to fetch {what} from. Using the copy already at {} \
+         from an earlier build; it cannot be verified against a source.",
+        filename.display()
+      );
+      return;
+    }
     panic!(
       "No candidate locations to fetch {what} from. RUSTY_V8_MIRROR_STRICT is \
        set but RUSTY_V8_MIRROR is not, so the upstream fallback is disabled and \
@@ -1008,13 +1127,20 @@ fn download_artifact(urls: &[Candidate], filename: &Path, what: &str) {
     let url = &candidate.url;
     println!("Trying artifact candidate: {url}");
     match try_download_file(candidate, filename) {
-      Ok(()) => return,
+      Ok(()) => {
+        if candidate.is_cache {
+          warn_untagged_mirror(what, url);
+        }
+        return;
+      }
       Err(FetchError::Fatal(reason)) => {
         panic!(
-          "Found {what} at {url} but could not use it: {reason}\n\
-           This source was chosen deliberately (a pinned mirror or the upstream \
-           release), so the build aborts rather than silently using a different \
-           one."
+          "Failed to use {what} from {url}: {reason}\n\
+           Aborting instead of trying the remaining candidates: either this \
+           source was chosen deliberately (a pinned mirror or the upstream \
+           release) and silently substituting another would hide the problem, \
+           or the failure is local (unwritable output directory, full disk) and \
+           would recur for every candidate."
         );
       }
       Err(FetchError::Miss(reason)) => {
@@ -1040,6 +1166,10 @@ fn download_artifact(urls: &[Candidate], filename: &Path, what: &str) {
 /// Copy/decompress `src` into `filename`, demoting a fatal failure to a
 /// [`FetchError::Miss`] when the candidate is a best-effort cache — a corrupt
 /// cache entry should fall through, not abort.
+///
+/// This covers failures to *read* the candidate's contents. A local write
+/// failure is not demoted: it would recur for every candidate, so aborting with
+/// the real reason beats reporting every candidate as absent.
 fn use_archive(
   candidate: &Candidate,
   src: &str,
@@ -1057,22 +1187,14 @@ fn use_archive(
 /// into `filename`. A [`FetchError::Miss`] means the candidate was absent and
 /// the caller should fall through; a [`FetchError::Fatal`] means it was found
 /// but unusable and the build should abort.
+///
+/// The "already fetched" short-circuit lives in [`download_artifact`], which
+/// checks the recorded URL against every candidate at once.
 fn try_download_file(
   candidate: &Candidate,
   filename: &Path,
 ) -> Result<(), FetchError> {
   let url = &candidate.url;
-
-  // Checksum (i.e: url) to avoid re-downloading/re-copying. Compare against the
-  // URL being requested (not a fixed one) so this works for every artifact and
-  // for filesystem mirrors as well as HTTP downloads.
-  if filename.exists()
-    && let Ok(c) = fs::read_to_string(static_checksum_path(filename))
-    && c == *url
-  {
-    println!("Already downloaded {url}");
-    return Ok(());
-  }
 
   if !is_http_url(url) {
     // A filesystem path: an explicit archive, a file mirror, or a flat cache.
@@ -1080,7 +1202,7 @@ fn try_download_file(
       return Err(FetchError::Miss(format!("file not found: {url}")));
     }
     use_archive(candidate, url, filename)?;
-    write_checksum(filename, url)?;
+    write_checksum(filename, url);
     return Ok(());
   }
 
@@ -1093,7 +1215,7 @@ fn try_download_file(
     if path.exists() {
       match copy_archive(&path.to_string_lossy(), filename) {
         Ok(()) => {
-          write_checksum(filename, url)?;
+          write_checksum(filename, url);
           return Ok(());
         }
         Err(FetchError::Fatal(reason)) => {
@@ -1135,10 +1257,11 @@ fn try_download_file(
 
   // Move the file into place, then record the checksum only after the copy
   // succeeds so a failed/interrupted copy can't leave a `.sum` that points at a
-  // truncated artifact.
-  use_archive(candidate, &tmpfile.to_string_lossy(), filename)?;
-  write_checksum(filename, url)?;
+  // truncated artifact. The tmpfile is cleaned up either way.
+  let copied = use_archive(candidate, &tmpfile.to_string_lossy(), filename);
   let _ = fs::remove_file(&tmpfile);
+  copied?;
+  write_checksum(filename, url);
 
   Ok(())
 }
@@ -1202,13 +1325,18 @@ fn download_with_curl(url: &str, tmpfile: &Path) -> bool {
 /// Record the source `url` of the artifact now sitting at `filename`, so a
 /// later build can skip re-fetching it. Written only after the artifact is
 /// fully in place.
-fn write_checksum(filename: &Path, url: &str) -> Result<(), FetchError> {
-  fs::write(static_checksum_path(filename), url).map_err(|e| {
-    FetchError::Fatal(format!(
-      "could not write checksum for {}: {e}",
+///
+/// Best-effort: the record is purely an optimisation, so a write failure warns
+/// and leaves the artifact usable rather than failing a build whose artifact is
+/// already correct. The next build simply re-fetches.
+fn write_checksum(filename: &Path, url: &str) {
+  if let Err(e) = fs::write(static_checksum_path(filename), url) {
+    println!(
+      "cargo:warning=Could not record the download marker for {} ({e}); the \
+       artifact is usable but will be re-fetched on the next build.",
       filename.display()
-    ))
-  })
+    );
+  }
 }
 
 fn download_static_lib_binaries() {
@@ -1405,11 +1533,17 @@ fn print_link_flags() {
 ///   checkout, which ships only `gen/.gitkeep`) — it is fetched from upstream,
 ///   but only when `fetch_when_missing` is true.
 ///
-/// `fetch_when_missing` gates *only* that last, missing-file case. The
-/// `DOCS_RS`/RLS early-exit passes `false`: those contexts may have no network,
-/// and a published crate already ships the binding, so a missing one falls
-/// through to the `include!` diagnostic in `src/binding.rs` rather than panic.
-/// (A mirror set on that path still downloads, matching prior behaviour.)
+/// When a shipped binding exists it is appended as the *last* candidate, after
+/// the mirror entries and after upstream. A mirror therefore still wins, but a
+/// mirror that carries only the static library — or `RUSTY_V8_MIRROR_STRICT`
+/// with a mirror that lacks the bindings — falls back to the correct file
+/// already in the crate instead of reaching the network or failing.
+///
+/// `fetch_when_missing` gates *only* the missing-file case. The `DOCS_RS`/RLS
+/// early-exit passes `false`: those contexts may have no network, and a
+/// published crate already ships the binding, so a missing one falls through to
+/// the `include!` diagnostic in `src/binding.rs` rather than panic. (A mirror
+/// set on that path still downloads, matching prior behaviour.)
 fn print_prebuilt_src_binding_path(fetch_when_missing: bool) {
   if let Ok(binding) = env::var("RUSTY_V8_SRC_BINDING_PATH") {
     println!("cargo:rustc-env=RUSTY_V8_SRC_BINDING_PATH={binding}");
@@ -1431,7 +1565,16 @@ fn print_prebuilt_src_binding_path(fetch_when_missing: bool) {
     // Fetch into OUT_DIR rather than the (possibly read-only, registry-owned)
     // source tree. OUT_DIR always exists, so no directory creation is needed.
     let out = PathBuf::from(env::var("OUT_DIR").unwrap()).join(&name);
-    let urls = artifact_urls(&name);
+    let mut urls = artifact_urls(&name);
+    // A binding shipped with the crate is a valid last resort, so a mirror that
+    // carries only the static library doesn't force a network fetch (or a hard
+    // failure under strict mode) when the right file is already on disk.
+    if shipped.exists() {
+      urls.push(Candidate {
+        url: shipped.to_string_lossy().into_owned(),
+        is_cache: false,
+      });
+    }
     download_artifact(&urls, &out, "the V8 bindings");
     out
   } else {
@@ -2022,5 +2165,193 @@ edge [fontsize=10]
       None, "v1.2.3", true, "1.2.3", "t", "release", "", "lib.a.gz",
     );
     assert!(c.is_empty());
+  }
+
+  #[test]
+  fn test_is_http_url() {
+    assert!(is_http_url("http://a/b"));
+    assert!(is_http_url("https://a/b"));
+    assert!(is_http_url("HTTPS://a/b"));
+    assert!(!is_http_url("/srv/mirror"));
+    assert!(!is_http_url("file:///srv/mirror"));
+    assert!(!is_http_url("C:\\mirror"));
+    // Shorter than the prefixes; must not panic on the slice.
+    assert!(!is_http_url("ht"));
+    assert!(!is_http_url(""));
+  }
+
+  #[test]
+  fn test_validate_mirror_template() {
+    assert!(validate_mirror_template("https://c/{tag}/{file}").is_ok());
+    assert!(
+      validate_mirror_template(
+        "{tag}{version}{target}{profile}{features}{file}"
+      )
+      .is_ok()
+    );
+    // No placeholders at all is vacuously fine; the caller only reaches this
+    // for values containing `{`.
+    assert!(validate_mirror_template("https://c/plain").is_ok());
+
+    assert_eq!(
+      validate_mirror_template("https://c/{taggg}/{file}"),
+      Err(vec!["{taggg}".to_string()])
+    );
+    // Reports every offender, in order, and keeps scanning past a good one.
+    assert_eq!(
+      validate_mirror_template("https://c/{tag}/{nope}/{file}/{alsono}"),
+      Err(vec!["{nope}".to_string(), "{alsono}".to_string()])
+    );
+    assert_eq!(
+      validate_mirror_template("https://c/{tag"),
+      Err(vec!["unterminated '{'".to_string()])
+    );
+  }
+
+  /// A fresh scratch directory for the filesystem tests. Keyed by test name so
+  /// concurrently-running tests don't collide.
+  fn scratch_dir(name: &str) -> PathBuf {
+    let dir = env::temp_dir()
+      .join(format!("rusty_v8_build_test_{name}_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+  }
+
+  /// A file with a well-formed gzip header followed by a garbage deflate stream,
+  /// so the header parses and decompression then fails. `0xff` as the first
+  /// deflate byte sets the reserved BTYPE, which is always invalid.
+  fn write_corrupt_gzip(path: &Path) {
+    let mut bytes = vec![0x1f, 0x8b, 0x08, 0x00]; // magic, deflate, no flags
+    bytes.extend_from_slice(&[0x00; 4]); // mtime
+    bytes.extend_from_slice(&[0x00, 0xff]); // xfl, os
+    bytes.extend_from_slice(&[0xff, 0xff, 0xff, 0xff]); // invalid deflate
+    fs::write(path, bytes).unwrap();
+  }
+
+  fn deliberate(url: &str) -> Candidate {
+    Candidate {
+      url: url.to_string(),
+      is_cache: false,
+    }
+  }
+
+  #[test]
+  fn test_copy_archive_plain_file() {
+    let dir = scratch_dir("copy_plain");
+    let src = dir.join("src.bin");
+    let dst = dir.join("dst.bin");
+    fs::write(&src, b"not gzipped").unwrap();
+
+    copy_archive(&src.to_string_lossy(), &dst).unwrap();
+
+    assert_eq!(fs::read(&dst).unwrap(), b"not gzipped");
+    // The staging file must not be left behind.
+    assert!(!dst.with_extension("copytmp").exists());
+  }
+
+  #[test]
+  fn test_copy_archive_corrupt_gzip_leaves_destination_intact() {
+    let dir = scratch_dir("copy_corrupt");
+    let src = dir.join("src.bin");
+    let dst = dir.join("dst.bin");
+    write_corrupt_gzip(&src);
+    fs::write(&dst, b"previous good artifact").unwrap();
+
+    let err = copy_archive(&src.to_string_lossy(), &dst);
+    assert!(matches!(err, Err(FetchError::Fatal(_))));
+
+    // The whole point of staging: a failed decompress must not truncate a
+    // previously good artifact.
+    assert_eq!(fs::read(&dst).unwrap(), b"previous good artifact");
+    assert!(!dst.with_extension("copytmp").exists());
+  }
+
+  #[test]
+  fn test_try_download_file_absent_fs_candidate_is_miss() {
+    let dir = scratch_dir("miss");
+    let dst = dir.join("dst.bin");
+    let missing = dir.join("nope.bin");
+
+    let err = try_download_file(&deliberate(&missing.to_string_lossy()), &dst);
+    assert!(matches!(err, Err(FetchError::Miss(_))));
+    assert!(!dst.exists());
+  }
+
+  #[test]
+  fn test_try_download_file_records_checksum_and_reuses_it() {
+    let dir = scratch_dir("checksum");
+    let src = dir.join("src.bin");
+    let dst = dir.join("dst.bin");
+    fs::write(&src, b"payload").unwrap();
+    let url = src.to_string_lossy().into_owned();
+
+    try_download_file(&deliberate(&url), &dst).unwrap();
+    assert_eq!(fs::read(&dst).unwrap(), b"payload");
+    assert_eq!(fs::read_to_string(static_checksum_path(&dst)).unwrap(), url);
+
+    // download_artifact short-circuits on the recorded URL rather than copying
+    // again: change the source, and the stale destination is kept.
+    fs::write(&src, b"changed").unwrap();
+    download_artifact(&[deliberate(&url)], &dst, "the test artifact");
+    assert_eq!(fs::read(&dst).unwrap(), b"payload");
+  }
+
+  #[test]
+  fn test_try_download_file_corrupt_cache_demotes_to_miss() {
+    let dir = scratch_dir("demote");
+    let src = dir.join("src.bin");
+    let dst = dir.join("dst.bin");
+    write_corrupt_gzip(&src);
+    let candidate = Candidate {
+      url: src.to_string_lossy().into_owned(),
+      is_cache: true,
+    };
+
+    // A corrupt *cache* entry must fall through to the next candidate ...
+    let err = try_download_file(&candidate, &dst);
+    assert!(matches!(err, Err(FetchError::Miss(_))));
+
+    // ... while the same corruption from a deliberate source aborts.
+    let err = try_download_file(&deliberate(&candidate.url), &dst);
+    assert!(matches!(err, Err(FetchError::Fatal(_))));
+  }
+
+  #[test]
+  fn test_download_artifact_falls_through_miss_to_later_candidate() {
+    let dir = scratch_dir("fallthrough");
+    let good = dir.join("good.bin");
+    let dst = dir.join("dst.bin");
+    fs::write(&good, b"from the second candidate").unwrap();
+
+    download_artifact(
+      &[
+        deliberate(&dir.join("absent.bin").to_string_lossy()),
+        deliberate(&good.to_string_lossy()),
+      ],
+      &dst,
+      "the test artifact",
+    );
+
+    assert_eq!(fs::read(&dst).unwrap(), b"from the second candidate");
+  }
+
+  #[test]
+  fn test_download_artifact_empty_list_uses_existing_artifact() {
+    let dir = scratch_dir("empty_existing");
+    let dst = dir.join("dst.bin");
+    fs::write(&dst, b"already here").unwrap();
+
+    // Strict mode with no mirror yields no candidates. A build that needs no
+    // network must not fail just because there is nowhere to fetch from.
+    download_artifact(&[], &dst, "the test artifact");
+    assert_eq!(fs::read(&dst).unwrap(), b"already here");
+  }
+
+  #[test]
+  #[should_panic(expected = "No candidate locations")]
+  fn test_download_artifact_empty_list_without_artifact_panics() {
+    let dir = scratch_dir("empty_absent");
+    download_artifact(&[], &dir.join("dst.bin"), "the test artifact");
   }
 }

--- a/build.rs
+++ b/build.rs
@@ -150,9 +150,33 @@ fn main() {
     return;
   }
 
+  warn_on_tag_override();
+
   print_prebuilt_src_binding_path(true);
 
   download_static_lib_binaries();
+}
+
+/// Warn when the resolved mirror tag differs from `v{CARGO_PKG_VERSION}`.
+///
+/// `RUSTY_V8_MIRROR_TAG` pairs this checkout's Rust sources with a prebuilt
+/// `librusty_v8.a` and `src_binding_*.rs` generated from a *different* V8. The
+/// layout `static_assert`s that would catch a mismatch live in the old `.a` and
+/// cannot fire, so a mismatch can link and then corrupt memory at runtime. The
+/// feature is legitimate (e.g. building an unpublished version against the last
+/// released artifacts), but the risk should be surfaced.
+fn warn_on_tag_override() {
+  let tag = mirror_tag();
+  let expected = format!("v{}", env::var("CARGO_PKG_VERSION").unwrap());
+  if tag != expected {
+    println!(
+      "cargo:warning=Using prebuilt V8 artifacts from tag '{tag}' but this \
+       crate is version {expected}. The prebuilt library and bindings were \
+       generated from a different V8; a layout mismatch may link and then \
+       corrupt memory at runtime. Ensure '{tag}' is ABI-compatible with this \
+       checkout."
+    );
+  }
 }
 
 fn acquire_lock() -> LockFile {
@@ -793,67 +817,110 @@ fn expand_mirror_template(
     .replace("{file}", file)
 }
 
-/// Ordered list of candidate locations to try for artifact `file` (e.g.
-/// `librusty_v8_release_<target>.a.gz` or `src_binding_release_<target>.rs`).
+/// A single artifact location to try.
+#[derive(Debug)]
+struct Candidate {
+  /// An `http(s)://` URL or a filesystem path.
+  url: String,
+  /// Whether this is a best-effort *cache* (a flat directory of downloaded
+  /// artifacts, or the local `~/.cargo/.rusty_v8` cache) rather than a
+  /// deliberately chosen source. A corrupt artifact from a cache falls through
+  /// to the next candidate; a corrupt artifact from a deliberate source (a
+  /// pinned mirror, upstream) aborts the build.
+  is_cache: bool,
+}
+
+/// Pure candidate-list builder. All inputs are explicit (nothing is read from
+/// the environment) so the ordering matrix can be unit tested. See
+/// [`artifact_urls`] for the env-reading wrapper.
 ///
 /// Resolution order (see the `RUSTY_V8_MIRROR` section in the README):
 ///
-/// 1. The `RUSTY_V8_MIRROR` value, if set. When it contains a `{` placeholder
-///    it is treated as a full template; otherwise it is a base and the
-///    historical `<base>/<tag>/<file>` layout is used, plus a flat
-///    `<base>/<file>` layout for filesystem mirrors used as a plain cache.
-/// 2. The upstream default releases base, unless `RUSTY_V8_MIRROR_STRICT` is
-///    set *and* a mirror is configured (hermetic builds that must never reach
-///    the network). Strict mode with no mirror is a no-op, so the list is
-///    never empty.
+/// 1. `mirror`, if set. When it contains a `{` placeholder it is treated as a
+///    full template; otherwise it is a base and the historical
+///    `<base>/<tag>/<file>` layout is used, plus a flat `<base>/<file>` cache
+///    layout for filesystem mirrors.
+/// 2. The upstream default releases base, unless `strict` is set (hermetic
+///    builds that must never reach the network).
 ///
-/// With no env vars set this is exactly `[<default base>/<tag>/<file>]`.
-fn artifact_urls(file: &str) -> Vec<String> {
-  let tag = mirror_tag();
-  let mirror = env::var("RUSTY_V8_MIRROR").ok();
+/// `strict` is honored unconditionally: with no mirror it yields an empty list,
+/// which the caller reports as "strict mode set but nowhere to fetch from"
+/// rather than silently reaching the network.
+#[allow(clippy::too_many_arguments)]
+fn artifact_urls_from(
+  mirror: Option<&str>,
+  tag: &str,
+  strict: bool,
+  version: &str,
+  target: &str,
+  profile: &str,
+  features: &str,
+  file: &str,
+) -> Vec<Candidate> {
   let mut candidates = Vec::new();
 
-  if let Some(mirror) = &mirror {
+  if let Some(mirror) = mirror {
     if mirror.contains('{') {
       // The mirror is a template; expand placeholders and use it verbatim.
-      let version = env::var("CARGO_PKG_VERSION").unwrap();
-      let target = env::var("TARGET").unwrap();
-      candidates.push(expand_mirror_template(
-        mirror,
-        &tag,
-        &version,
-        &target,
-        prebuilt_profile(),
-        &prebuilt_features_suffix(),
-        file,
-      ));
+      candidates.push(Candidate {
+        url: expand_mirror_template(
+          mirror, tag, version, target, profile, features, file,
+        ),
+        is_cache: false,
+      });
     } else {
-      // Historical layout: `<base>/<tag>/<file>`.
-      candidates.push(format!("{mirror}/{tag}/{file}"));
+      // Historical layout: `<base>/<tag>/<file>` — a deliberate source.
+      candidates.push(Candidate {
+        url: format!("{mirror}/{tag}/{file}"),
+        is_cache: false,
+      });
       // Flat layout `<base>/<file>` for a plain directory of downloaded
       // artifacts used as a cache. Only meaningful for filesystem mirrors.
       if !is_http_url(mirror) {
-        candidates.push(format!("{mirror}/{file}"));
+        candidates.push(Candidate {
+          url: format!("{mirror}/{file}"),
+          is_cache: true,
+        });
       }
     }
   }
 
-  // Fall back to the upstream releases, unless strict mode forbids it. Strict
-  // mode only takes effect when a mirror is configured — otherwise there is
-  // nothing to be strict about and suppressing this would leave no candidates.
-  let strict = mirror.is_some() && env_bool("RUSTY_V8_MIRROR_STRICT");
+  // Fall back to the upstream releases unless strict mode forbids the network.
   if !strict {
-    candidates.push(format!("{DEFAULT_MIRROR_BASE}/{tag}/{file}"));
+    candidates.push(Candidate {
+      url: format!("{DEFAULT_MIRROR_BASE}/{tag}/{file}"),
+      is_cache: false,
+    });
   }
 
   candidates
 }
 
+/// Ordered list of candidate locations to try for artifact `file` (e.g.
+/// `librusty_v8_release_<target>.a.gz` or `src_binding_release_<target>.rs`).
+fn artifact_urls(file: &str) -> Vec<Candidate> {
+  let version = env::var("CARGO_PKG_VERSION").unwrap();
+  let target = env::var("TARGET").unwrap();
+  artifact_urls_from(
+    env::var("RUSTY_V8_MIRROR").ok().as_deref(),
+    &mirror_tag(),
+    env_bool("RUSTY_V8_MIRROR_STRICT"),
+    &version,
+    &target,
+    prebuilt_profile(),
+    &prebuilt_features_suffix(),
+    file,
+  )
+}
+
 /// Candidate URLs for the prebuilt static library archive.
-fn static_lib_urls() -> Vec<String> {
+fn static_lib_urls() -> Vec<Candidate> {
   // An explicit archive short-circuits everything (static library only).
   if let Ok(custom_archive) = env::var("RUSTY_V8_ARCHIVE") {
-    return vec![custom_archive];
+    return vec![Candidate {
+      url: custom_archive,
+      is_cache: false,
+    }];
   }
   let target = env::var("TARGET").unwrap();
   let profile = prebuilt_profile();
@@ -921,16 +988,33 @@ enum FetchError {
 /// Fetch each candidate in `urls` into `filename`, stopping at the first that
 /// succeeds. A [`FetchError::Fatal`] aborts immediately. If every candidate is
 /// a [`FetchError::Miss`], panic with the full list of what was tried and the
-/// available escape hatches.
-fn download_artifact(urls: &[String], filename: &Path) {
+/// available escape hatches. `what` names the artifact for the diagnostics
+/// (e.g. "the V8 static library").
+fn download_artifact(urls: &[Candidate], filename: &Path, what: &str) {
+  if urls.is_empty() {
+    // Only reachable with RUSTY_V8_MIRROR_STRICT set and no mirror configured:
+    // strict suppresses upstream, leaving nothing to try.
+    panic!(
+      "No candidate locations to fetch {what} from. RUSTY_V8_MIRROR_STRICT is \
+       set but RUSTY_V8_MIRROR is not, so the upstream fallback is disabled and \
+       there is nowhere to fetch from. Set RUSTY_V8_MIRROR (and, for the \
+       bindings, optionally RUSTY_V8_SRC_BINDING_PATH), or unset \
+       RUSTY_V8_MIRROR_STRICT."
+    );
+  }
+
   let mut failures = Vec::new();
-  for url in urls {
+  for candidate in urls {
+    let url = &candidate.url;
     println!("Trying artifact candidate: {url}");
-    match try_download_file(url, filename) {
+    match try_download_file(candidate, filename) {
       Ok(()) => return,
       Err(FetchError::Fatal(reason)) => {
         panic!(
-          "Found a V8 prebuilt artifact at {url} but could not use it: {reason}"
+          "Found {what} at {url} but could not use it: {reason}\n\
+           This source was chosen deliberately (a pinned mirror or the upstream \
+           release), so the build aborts rather than silently using a different \
+           one."
         );
       }
       Err(FetchError::Miss(reason)) => {
@@ -940,7 +1024,7 @@ fn download_artifact(urls: &[String], filename: &Path) {
     }
   }
   panic!(
-    "Failed to obtain a V8 prebuilt artifact.\n\
+    "Failed to obtain {what}.\n\
      Tried the following candidates, in order:\n{}\n\n\
      This is usually because no prebuilt archive is published for your target \
      or version. Ways to fix this:\n\
@@ -953,17 +1037,38 @@ fn download_artifact(urls: &[String], filename: &Path) {
   );
 }
 
-/// Try to fetch a single `url` (an `http(s)://` URL or a filesystem path) into
-/// `filename`. A [`FetchError::Miss`] means the candidate was absent and the
-/// caller should fall through; a [`FetchError::Fatal`] means it was found but
-/// unusable and the build should abort.
-fn try_download_file(url: &str, filename: &Path) -> Result<(), FetchError> {
+/// Copy/decompress `src` into `filename`, demoting a fatal failure to a
+/// [`FetchError::Miss`] when the candidate is a best-effort cache — a corrupt
+/// cache entry should fall through, not abort.
+fn use_archive(
+  candidate: &Candidate,
+  src: &str,
+  filename: &Path,
+) -> Result<(), FetchError> {
+  match copy_archive(src, filename) {
+    Err(FetchError::Fatal(reason)) if candidate.is_cache => {
+      Err(FetchError::Miss(reason))
+    }
+    other => other,
+  }
+}
+
+/// Try to fetch a single `candidate` (an `http(s)://` URL or a filesystem path)
+/// into `filename`. A [`FetchError::Miss`] means the candidate was absent and
+/// the caller should fall through; a [`FetchError::Fatal`] means it was found
+/// but unusable and the build should abort.
+fn try_download_file(
+  candidate: &Candidate,
+  filename: &Path,
+) -> Result<(), FetchError> {
+  let url = &candidate.url;
+
   // Checksum (i.e: url) to avoid re-downloading/re-copying. Compare against the
   // URL being requested (not a fixed one) so this works for every artifact and
   // for filesystem mirrors as well as HTTP downloads.
   if filename.exists()
     && let Ok(c) = fs::read_to_string(static_checksum_path(filename))
-    && c == url
+    && c == *url
   {
     println!("Already downloaded {url}");
     return Ok(());
@@ -974,20 +1079,33 @@ fn try_download_file(url: &str, filename: &Path) -> Result<(), FetchError> {
     if !Path::new(url).exists() {
       return Err(FetchError::Miss(format!("file not found: {url}")));
     }
-    copy_archive(url, filename)?;
+    use_archive(candidate, url, filename)?;
     write_checksum(filename, url)?;
     return Ok(());
   }
 
-  // If there is a `.cargo/.rusty_v8/<escaped URL>` file, use that instead
-  // of downloading.
+  // If there is a `.cargo/.rusty_v8/<escaped URL>` file, use that instead of
+  // downloading. This is a local cache, so a corrupt entry is evicted and we
+  // fall through to a fresh download rather than aborting.
   if let Ok(mut path) = home::cargo_home() {
     path = path.join(".rusty_v8").join(replace_non_alphanumeric(url));
     println!("Looking for download in '{path:?}'");
     if path.exists() {
-      copy_archive(&path.to_string_lossy(), filename)?;
-      write_checksum(filename, url)?;
-      return Ok(());
+      match copy_archive(&path.to_string_lossy(), filename) {
+        Ok(()) => {
+          write_checksum(filename, url)?;
+          return Ok(());
+        }
+        Err(FetchError::Fatal(reason)) => {
+          println!(
+            "Cached download at {} is unusable ({reason}); removing and \
+             re-downloading",
+            path.display()
+          );
+          let _ = fs::remove_file(&path);
+        }
+        Err(e) => return Err(e),
+      }
     }
   }
 
@@ -1001,92 +1119,84 @@ fn try_download_file(url: &str, filename: &Path) -> Result<(), FetchError> {
 
   // Try downloading with deno first, then python, then curl.
   println!("Downloading {url}");
-  let status = which("deno").ok().and_then(|deno| {
-    println!("Trying with Deno...");
-    Command::new(deno)
-      .arg("eval")
-      .arg(
-        "const [url, path] = Deno.args; \
-         const resp = await fetch(url); \
-         if (!resp.ok) Deno.exit(1); \
-         const file = await Deno.open(path, { write: true, create: true }); \
-         await resp.body.pipeTo(file.writable);",
-      )
-      // Note: `deno eval` runs with all permissions implicitly granted and does
-      // not accept `--allow-*` flags, so passing them here makes `deno eval`
-      // error out ("unexpected argument '--allow-net'") and the download
-      // silently falls back to Python/curl.
-      .arg("--")
-      .arg(url)
-      .arg(&tmpfile)
-      .status()
-      .ok()
-      .filter(|s| s.success())
-  });
+  let downloaded = download_with_deno(url, &tmpfile)
+    || download_with_python(url, &tmpfile)
+    || download_with_curl(url, &tmpfile);
 
-  // Try downloading with python. Python is a V8 build dependency,
-  // so this saves us from adding a Rust HTTP client dependency.
-  let status = match status {
-    Some(status) => Some(status),
-    _ => {
-      println!("Trying with Python...");
-      let python_status = Command::new(python())
-        .arg("./tools/download_file.py")
-        .arg("--url")
-        .arg(url)
-        .arg("--filename")
-        .arg(&tmpfile)
-        .status();
-
-      // Python is only a required dependency for `V8_FROM_SOURCE` builds.
-      // If python is not available, try falling back to curl.
-      match python_status {
-        Ok(status) if status.success() => Some(status),
-        _ => {
-          // A missing `curl` binary must not panic: fall through to the
-          // "all downloaders failed" path so the next candidate is tried.
-          println!("Python downloader failed, trying with curl.");
-          Command::new("curl")
-            .arg("-L")
-            .arg("-f")
-            .arg("-s")
-            .arg("-o")
-            .arg(&tmpfile)
-            .arg(url)
-            .status()
-            .ok()
-            .filter(|s| s.success())
-        }
-      }
-    }
-  };
-
-  // Did any downloader succeed? A failure here means the artifact could not be
-  // fetched from this URL (404, network error, no downloader available), which
-  // is a miss — the next candidate may still have it.
-  match status {
-    Some(status) if status.success() => {}
-    _ => {
-      return Err(FetchError::Miss(format!(
-        "no downloader (deno, python, or curl) could fetch {url}"
-      )));
-    }
-  }
-  if !tmpfile.exists() {
+  // A failure here means the artifact could not be fetched from this URL (404,
+  // network error, no downloader available), which is a miss — the next
+  // candidate may still have it. Don't leave a partial tmpfile behind.
+  if !downloaded || !tmpfile.exists() {
+    let _ = fs::remove_file(&tmpfile);
     return Err(FetchError::Miss(format!(
-      "downloader reported success but {} is missing",
-      tmpfile.display()
+      "could not download {url} (tried deno, python, and curl)"
     )));
   }
 
   // Move the file into place, then record the checksum only after the copy
   // succeeds so a failed/interrupted copy can't leave a `.sum` that points at a
   // truncated artifact.
-  copy_archive(&tmpfile.to_string_lossy(), filename)?;
+  use_archive(candidate, &tmpfile.to_string_lossy(), filename)?;
   write_checksum(filename, url)?;
   let _ = fs::remove_file(&tmpfile);
 
   Ok(())
+}
+
+/// Download `url` to `tmpfile` with Deno. Returns whether it succeeded.
+fn download_with_deno(url: &str, tmpfile: &Path) -> bool {
+  let Ok(deno) = which("deno") else {
+    return false;
+  };
+  println!("Trying with Deno...");
+  Command::new(deno)
+    .arg("eval")
+    .arg(
+      "const [url, path] = Deno.args; \
+       const resp = await fetch(url); \
+       if (!resp.ok) Deno.exit(1); \
+       const file = await Deno.open(path, { write: true, create: true }); \
+       await resp.body.pipeTo(file.writable);",
+    )
+    // Note: `deno eval` runs with all permissions implicitly granted and does
+    // not accept `--allow-*` flags, so passing them here makes `deno eval`
+    // error out ("unexpected argument '--allow-net'") and the download
+    // silently falls back to Python/curl.
+    .arg("--")
+    .arg(url)
+    .arg(tmpfile)
+    .status()
+    .is_ok_and(|s| s.success())
+}
+
+/// Download `url` to `tmpfile` with Python. Returns whether it succeeded.
+/// Python is a V8 build dependency, so this saves us from adding a Rust HTTP
+/// client dependency; it is not guaranteed to be present for prebuilt builds.
+fn download_with_python(url: &str, tmpfile: &Path) -> bool {
+  println!("Trying with Python...");
+  Command::new(python())
+    .arg("./tools/download_file.py")
+    .arg("--url")
+    .arg(url)
+    .arg("--filename")
+    .arg(tmpfile)
+    .status()
+    .is_ok_and(|s| s.success())
+}
+
+/// Download `url` to `tmpfile` with curl. Returns whether it succeeded. A
+/// missing `curl` binary is just a `false`, not a panic.
+fn download_with_curl(url: &str, tmpfile: &Path) -> bool {
+  println!("Trying with curl...");
+  Command::new("curl")
+    .arg("-L")
+    .arg("-f")
+    .arg("-s")
+    .arg("-o")
+    .arg(tmpfile)
+    .arg(url)
+    .status()
+    .is_ok_and(|s| s.success())
 }
 
 /// Record the source `url` of the artifact now sitting at `filename`, so a
@@ -1109,7 +1219,7 @@ fn download_static_lib_binaries() {
   fs::create_dir_all(&dir).unwrap();
   println!("cargo:rustc-link-search={}", dir.display());
 
-  download_artifact(&urls, &static_lib_path());
+  download_artifact(&urls, &static_lib_path(), "the V8 static library");
 }
 
 fn decompress_to_writer<R, W>(input: &mut R, output: &mut W) -> io::Result<()>
@@ -1284,13 +1394,22 @@ fn print_link_flags() {
 
 /// Point `RUSTY_V8_SRC_BINDING_PATH` at the prebuilt bindings.
 ///
-/// When `fetch_when_missing` is true and the binding isn't already present in
-/// this checkout, it is downloaded (from the mirror/upstream) so a git checkout
-/// gets a build-script diagnostic instead of a confusing `include!` failure in
-/// `src/binding.rs`. The `DOCS_RS`/RLS early-exit path passes `false`: those
-/// contexts may have no network, and a published crate already ships the
-/// binding, so a missing one should fall through to the `include!` diagnostic
-/// rather than panic.
+/// A published crate ships the binding in `gen/<name>.rs`; when it is present
+/// and no mirror is configured, it is used as-is. Otherwise the binding is
+/// fetched into `OUT_DIR` (never written back into the source tree) and the env
+/// var points there:
+///
+/// - A mirror is configured — the binding is fetched from it (with the usual
+///   fallback), regardless of `fetch_when_missing`.
+/// - No mirror, but the binding is missing from this checkout (e.g. a git
+///   checkout, which ships only `gen/.gitkeep`) — it is fetched from upstream,
+///   but only when `fetch_when_missing` is true.
+///
+/// `fetch_when_missing` gates *only* that last, missing-file case. The
+/// `DOCS_RS`/RLS early-exit passes `false`: those contexts may have no network,
+/// and a published crate already ships the binding, so a missing one falls
+/// through to the `include!` diagnostic in `src/binding.rs` rather than panic.
+/// (A mirror set on that path still downloads, matching prior behaviour.)
 fn print_prebuilt_src_binding_path(fetch_when_missing: bool) {
   if let Ok(binding) = env::var("RUSTY_V8_SRC_BINDING_PATH") {
     println!("cargo:rustc-env=RUSTY_V8_SRC_BINDING_PATH={binding}");
@@ -1302,25 +1421,29 @@ fn print_prebuilt_src_binding_path(fetch_when_missing: bool) {
   let features = prebuilt_features_suffix();
   let name = format!("src_binding{features}_{profile}_{target}.rs");
 
-  let src_binding_path = get_dirs().root.join("gen").join(name.clone());
+  // The binding shipped with a published crate.
+  let shipped = get_dirs().root.join("gen").join(&name);
+  let mirror_set = env::var_os("RUSTY_V8_MIRROR").is_some();
 
-  // Fetch the binding when a mirror is explicitly configured (existing
-  // behaviour), or when it is missing from this checkout and fetching is
-  // allowed. A published crate ships `gen/<name>.rs`, so a plain `cargo build`
-  // that already has it skips this entirely.
-  if env::var_os("RUSTY_V8_MIRROR").is_some()
-    || (fetch_when_missing && !src_binding_path.exists())
-  {
-    if let Some(parent) = src_binding_path.parent() {
-      fs::create_dir_all(parent).unwrap();
-    }
+  let binding_path = if shipped.exists() && !mirror_set {
+    shipped
+  } else if mirror_set || fetch_when_missing {
+    // Fetch into OUT_DIR rather than the (possibly read-only, registry-owned)
+    // source tree. OUT_DIR always exists, so no directory creation is needed.
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap()).join(&name);
     let urls = artifact_urls(&name);
-    download_artifact(&urls, &src_binding_path);
-  }
+    download_artifact(&urls, &out, "the V8 bindings");
+    out
+  } else {
+    // Not shipped, no mirror, and fetching is not allowed here (docs.rs/RLS).
+    // Point at the (missing) shipped path so `include!` produces its own
+    // diagnostic, exactly as before this change.
+    shipped
+  };
 
   println!(
     "cargo:rustc-env=RUSTY_V8_SRC_BINDING_PATH={}",
-    src_binding_path.display()
+    binding_path.display()
   );
 }
 
@@ -1765,9 +1888,10 @@ edge [fontsize=10]
       "https://cache.example.com/aarch64-apple-darwin/v152.1.0/release_ptrcomp/152.1.0/librusty_v8_ptrcomp_release_aarch64-apple-darwin.a.gz"
     );
 
-    // Empty features and a repeated placeholder.
+    // Empty features, plain filesystem path (not a `file://` URL, which the
+    // filesystem candidate does not support).
     let out = expand_mirror_template(
-      "file:///mnt/{tag}/{file}",
+      "/mnt/{tag}/{file}",
       "nightly",
       "152.1.0",
       "x86_64-unknown-linux-gnu",
@@ -1777,7 +1901,126 @@ edge [fontsize=10]
     );
     assert_eq!(
       out,
-      "file:///mnt/nightly/src_binding_debug_x86_64-unknown-linux-gnu.rs"
+      "/mnt/nightly/src_binding_debug_x86_64-unknown-linux-gnu.rs"
     );
+  }
+
+  fn urls(candidates: &[Candidate]) -> Vec<(&str, bool)> {
+    candidates
+      .iter()
+      .map(|c| (c.url.as_str(), c.is_cache))
+      .collect()
+  }
+
+  const UP: &str = "https://github.com/denoland/rusty_v8/releases/download";
+
+  #[test]
+  fn test_artifact_urls_no_mirror() {
+    // No mirror: exactly one candidate, the upstream default at the tag.
+    let c = artifact_urls_from(
+      None, "v1.2.3", false, "1.2.3", "t", "release", "", "lib.a.gz",
+    );
+    assert_eq!(
+      urls(&c),
+      [(format!("{UP}/v1.2.3/lib.a.gz").as_str(), false)]
+    );
+  }
+
+  #[test]
+  fn test_artifact_urls_http_mirror() {
+    // HTTP mirror: `<base>/<tag>/<file>` then upstream. No flat candidate.
+    let c = artifact_urls_from(
+      Some("https://m.example.com"),
+      "v1.2.3",
+      false,
+      "1.2.3",
+      "t",
+      "release",
+      "",
+      "lib.a.gz",
+    );
+    assert_eq!(
+      urls(&c),
+      [
+        ("https://m.example.com/v1.2.3/lib.a.gz", false),
+        (format!("{UP}/v1.2.3/lib.a.gz").as_str(), false),
+      ]
+    );
+  }
+
+  #[test]
+  fn test_artifact_urls_fs_mirror_has_flat_cache() {
+    // Filesystem mirror: tag layout, then a flat cache candidate, then upstream.
+    let c = artifact_urls_from(
+      Some("/srv/mirror"),
+      "v1.2.3",
+      false,
+      "1.2.3",
+      "t",
+      "release",
+      "",
+      "lib.a.gz",
+    );
+    assert_eq!(
+      urls(&c),
+      [
+        ("/srv/mirror/v1.2.3/lib.a.gz", false),
+        ("/srv/mirror/lib.a.gz", true),
+        (format!("{UP}/v1.2.3/lib.a.gz").as_str(), false),
+      ]
+    );
+  }
+
+  #[test]
+  fn test_artifact_urls_template_mirror() {
+    // Template mirror: exactly the expanded template, then upstream. No flat.
+    let c = artifact_urls_from(
+      Some("https://c/{target}/{tag}/{file}"),
+      "v1.2.3",
+      false,
+      "1.2.3",
+      "aarch64",
+      "release",
+      "",
+      "lib.a.gz",
+    );
+    assert_eq!(
+      urls(&c),
+      [
+        ("https://c/aarch64/v1.2.3/lib.a.gz", false),
+        (format!("{UP}/v1.2.3/lib.a.gz").as_str(), false),
+      ]
+    );
+  }
+
+  #[test]
+  fn test_artifact_urls_strict_with_mirror_drops_upstream() {
+    let c = artifact_urls_from(
+      Some("/srv/mirror"),
+      "v1.2.3",
+      true,
+      "1.2.3",
+      "t",
+      "release",
+      "",
+      "lib.a.gz",
+    );
+    assert_eq!(
+      urls(&c),
+      [
+        ("/srv/mirror/v1.2.3/lib.a.gz", false),
+        ("/srv/mirror/lib.a.gz", true),
+      ]
+    );
+  }
+
+  #[test]
+  fn test_artifact_urls_strict_without_mirror_is_empty() {
+    // Strict is honored unconditionally: no mirror + strict => nowhere to fetch.
+    // The caller turns this empty list into an explicit error.
+    let c = artifact_urls_from(
+      None, "v1.2.3", true, "1.2.3", "t", "release", "", "lib.a.gz",
+    );
+    assert!(c.is_empty());
   }
 }

--- a/build.rs
+++ b/build.rs
@@ -68,6 +68,8 @@ fn main() {
     "OUT_DIR",
     "RUSTY_V8_ARCHIVE",
     "RUSTY_V8_MIRROR",
+    "RUSTY_V8_MIRROR_TAG",
+    "RUSTY_V8_MIRROR_STRICT",
     "RUSTY_V8_SRC_BINDING_PATH",
     "SCCACHE",
     "V8_FORCE_DEBUG",
@@ -747,21 +749,94 @@ fn static_lib_name(suffix: &str) -> String {
   }
 }
 
-fn static_lib_url() -> String {
-  if let Ok(custom_archive) = env::var("RUSTY_V8_ARCHIVE") {
-    return custom_archive;
+const DEFAULT_MIRROR_BASE: &str =
+  "https://github.com/denoland/rusty_v8/releases/download";
+
+fn is_http_url(s: &str) -> bool {
+  s.starts_with("http:") || s.starts_with("https:")
+}
+
+/// The release tag (directory segment) that artifacts are looked up under.
+///
+/// `RUSTY_V8_MIRROR_TAG` overrides it verbatim (no `v` is prepended), so
+/// non-tag-shaped directories such as `nightly` or `pr-1234` work. The default
+/// is `v{CARGO_PKG_VERSION}`.
+fn mirror_tag() -> String {
+  match env::var("RUSTY_V8_MIRROR_TAG") {
+    Ok(tag) => tag,
+    Err(_) => format!("v{}", env::var("CARGO_PKG_VERSION").unwrap()),
   }
-  let default_base = "https://github.com/denoland/rusty_v8/releases/download";
-  let base =
-    env::var("RUSTY_V8_MIRROR").unwrap_or_else(|_| default_base.into());
+}
+
+/// Expand a templated `RUSTY_V8_MIRROR` value. See [`artifact_urls`].
+fn expand_mirror_template(template: &str, tag: &str, file: &str) -> String {
   let version = env::var("CARGO_PKG_VERSION").unwrap();
   let target = env::var("TARGET").unwrap();
   let profile = prebuilt_profile();
   let features = prebuilt_features_suffix();
-  format!(
-    "{base}/v{version}/{}.gz",
-    static_lib_name(&format!("{features}_{profile}_{target}")),
-  )
+  template
+    .replace("{tag}", tag)
+    .replace("{version}", &version)
+    .replace("{target}", &target)
+    .replace("{profile}", profile)
+    .replace("{features}", &features)
+    .replace("{file}", file)
+}
+
+/// Ordered list of candidate locations to try for artifact `file` (e.g.
+/// `librusty_v8_release_<target>.a.gz` or `src_binding_release_<target>.rs`).
+///
+/// Resolution order (see the `RUSTY_V8_MIRROR` section in the README):
+///
+/// 1. The `RUSTY_V8_MIRROR` value, if set. When it contains a `{` placeholder
+///    it is treated as a full template; otherwise it is a base and the
+///    historical `<base>/<tag>/<file>` layout is used, plus a flat
+///    `<base>/<file>` layout for filesystem mirrors used as a plain cache.
+/// 2. The upstream default releases base, unless `RUSTY_V8_MIRROR_STRICT` is
+///    set (hermetic builds that must never reach the network).
+///
+/// With no env vars set this is exactly `[<default base>/<tag>/<file>]`.
+fn artifact_urls(file: &str) -> Vec<String> {
+  let tag = mirror_tag();
+  let mut candidates = Vec::new();
+
+  if let Ok(mirror) = env::var("RUSTY_V8_MIRROR") {
+    if mirror.contains('{') {
+      // The mirror is a template; expand placeholders and use it verbatim.
+      candidates.push(expand_mirror_template(&mirror, &tag, file));
+    } else {
+      // Historical layout: `<base>/<tag>/<file>`.
+      candidates.push(format!("{mirror}/{tag}/{file}"));
+      // Flat layout `<base>/<file>` for a plain directory of downloaded
+      // artifacts used as a cache. Only meaningful for filesystem mirrors.
+      if !is_http_url(&mirror) {
+        candidates.push(format!("{mirror}/{file}"));
+      }
+    }
+  }
+
+  // Fall back to the upstream releases, unless strict mode forbids the network.
+  if !env_bool("RUSTY_V8_MIRROR_STRICT") {
+    candidates.push(format!("{DEFAULT_MIRROR_BASE}/{tag}/{file}"));
+  }
+
+  candidates
+}
+
+/// Candidate URLs for the prebuilt static library archive.
+fn static_lib_urls() -> Vec<String> {
+  // An explicit archive short-circuits everything (static library only).
+  if let Ok(custom_archive) = env::var("RUSTY_V8_ARCHIVE") {
+    return vec![custom_archive];
+  }
+  let target = env::var("TARGET").unwrap();
+  let profile = prebuilt_profile();
+  let features = prebuilt_features_suffix();
+  let file = format!(
+    "{}.gz",
+    static_lib_name(&format!("{features}_{profile}_{target}"))
+  );
+  artifact_urls(&file)
 }
 
 fn static_lib_path() -> PathBuf {
@@ -806,17 +881,56 @@ fn replace_non_alphanumeric(url: &str) -> String {
     .collect()
 }
 
-fn download_file(url: &str, filename: &Path) {
-  if !url.starts_with("http:") && !url.starts_with("https:") {
-    copy_archive(url, filename);
-    return;
+/// Fetch each candidate in `urls` into `filename`, stopping at the first that
+/// succeeds. If they all fail, panic with the full list of what was tried and
+/// the available escape hatches.
+fn download_artifact(urls: &[String], filename: &Path) {
+  let mut failures = Vec::new();
+  for url in urls {
+    println!("Trying artifact candidate: {url}");
+    match try_download_file(url, filename) {
+      Ok(()) => return,
+      Err(reason) => {
+        println!("  skipped {url}: {reason}");
+        failures.push(format!("  - {url}\n      {reason}"));
+      }
+    }
+  }
+  panic!(
+    "Failed to obtain a V8 prebuilt artifact.\n\
+     Tried the following candidates, in order:\n{}\n\n\
+     This is usually because no prebuilt archive is published for your target \
+     or version. Ways to fix this:\n\
+     \x20 RUSTY_V8_ARCHIVE=<path|url>  use a specific static library archive\n\
+     \x20 RUSTY_V8_MIRROR=<base|template>  fetch artifacts from another location\n\
+     \x20 RUSTY_V8_MIRROR_TAG=<tag>  override the release tag/directory \
+     (default v<crate version>)\n\
+     \x20 V8_FROM_SOURCE=1  build V8 from source instead of downloading",
+    failures.join("\n"),
+  );
+}
+
+/// Try to fetch a single `url` (an `http(s)://` URL or a filesystem path) into
+/// `filename`. Returns `Err` with a human-readable reason on a recoverable
+/// miss so the caller can fall through to the next candidate.
+fn try_download_file(url: &str, filename: &Path) -> Result<(), String> {
+  if !is_http_url(url) {
+    // A filesystem path: an explicit archive, a file mirror, or a flat cache.
+    if !Path::new(url).exists() {
+      return Err(format!("file not found: {url}"));
+    }
+    return copy_archive(url, filename);
   }
 
-  // Checksum (i.e: url) to avoid re-downloads
-  match fs::read_to_string(static_checksum_path(filename)) {
-    Ok(c) if c == static_lib_url() => return,
-    _ => {}
-  };
+  // Checksum (i.e: url) to avoid re-downloads. Compare against the URL being
+  // requested (not a fixed one) so this works for every artifact.
+  if filename.exists()
+    && let Ok(c) = fs::read_to_string(static_checksum_path(filename))
+    && c == url
+  {
+    println!("Already downloaded {url}");
+    return Ok(());
+  }
 
   // If there is a `.cargo/.rusty_v8/<escaped URL>` file, use that instead
   // of downloading.
@@ -824,15 +938,16 @@ fn download_file(url: &str, filename: &Path) {
     path = path.join(".rusty_v8").join(replace_non_alphanumeric(url));
     println!("Looking for download in '{path:?}'");
     if path.exists() {
-      copy_archive(&path.to_string_lossy(), filename);
-      return;
+      copy_archive(&path.to_string_lossy(), filename)?;
+      return Ok(());
     }
   }
 
   let tmpfile = filename.with_extension("tmp");
   if tmpfile.exists() {
     println!("Deleting old tmpfile {}", tmpfile.display());
-    fs::remove_file(&tmpfile).unwrap();
+    fs::remove_file(&tmpfile)
+      .map_err(|e| format!("could not remove {}: {e}", tmpfile.display()))?;
   }
 
   // Try downloading with deno first, then python, then curl.
@@ -863,7 +978,7 @@ fn download_file(url: &str, filename: &Path) {
   // Try downloading with python. Python is a V8 build dependency,
   // so this saves us from adding a Rust HTTP client dependency.
   let status = match status {
-    Some(status) => status,
+    Some(status) => Some(status),
     _ => {
       println!("Trying with Python...");
       let python_status = Command::new(python())
@@ -877,8 +992,10 @@ fn download_file(url: &str, filename: &Path) {
       // Python is only a required dependency for `V8_FROM_SOURCE` builds.
       // If python is not available, try falling back to curl.
       match python_status {
-        Ok(status) if status.success() => status,
+        Ok(status) if status.success() => Some(status),
         _ => {
+          // A missing `curl` binary must not panic: fall through to the
+          // "all downloaders failed" path so the next candidate is tried.
           println!("Python downloader failed, trying with curl.");
           Command::new("curl")
             .arg("-L")
@@ -888,42 +1005,49 @@ fn download_file(url: &str, filename: &Path) {
             .arg(&tmpfile)
             .arg(url)
             .status()
-            .unwrap()
+            .ok()
+            .filter(|s| s.success())
         }
       }
     }
   };
 
-  // Assert DL was successful
-  if !status.success() {
-    panic!(
-      "Failed to download V8 prebuilt archive from {url}\n\
-     This is usually because no prebuilt archive is published for your target, \
-     in which case you should compile V8 from source by setting V8_FROM_SOURCE=1. \
-     It can also indicate a network connectivity problem."
-    );
+  // Did any downloader succeed?
+  match status {
+    Some(status) if status.success() => {}
+    _ => {
+      return Err(format!(
+        "no downloader (deno, python, or curl) could fetch {url}"
+      ));
+    }
   }
-  assert!(tmpfile.exists());
+  if !tmpfile.exists() {
+    return Err(format!(
+      "downloader reported success but {} is missing",
+      tmpfile.display()
+    ));
+  }
 
   // Write checksum (i.e url) & move file
-  fs::write(static_checksum_path(filename), url).unwrap();
-  copy_archive(&tmpfile.to_string_lossy(), filename);
-  fs::remove_file(&tmpfile).unwrap();
+  fs::write(static_checksum_path(filename), url).map_err(|e| {
+    format!("could not write checksum for {}: {e}", filename.display())
+  })?;
+  copy_archive(&tmpfile.to_string_lossy(), filename)?;
+  fs::remove_file(&tmpfile)
+    .map_err(|e| format!("could not remove {}: {e}", tmpfile.display()))?;
 
-  assert!(filename.exists());
-  assert!(static_checksum_path(filename).exists());
-  assert!(!tmpfile.exists());
+  Ok(())
 }
 
 fn download_static_lib_binaries() {
-  let url = static_lib_url();
-  println!("static lib URL: {url}");
+  let urls = static_lib_urls();
+  println!("static lib candidates: {urls:?}");
 
   let dir = static_lib_dir();
   fs::create_dir_all(&dir).unwrap();
   println!("cargo:rustc-link-search={}", dir.display());
 
-  download_file(&url, &static_lib_path());
+  download_artifact(&urls, &static_lib_path());
 }
 
 fn decompress_to_writer<R, W>(input: &mut R, output: &mut W) -> io::Result<()>
@@ -979,22 +1103,35 @@ where
 /// Instead, it copies the file contents to a new file.
 /// This is necessary because the V8 archive could live inside a read-only
 /// filesystem, and subsequent builds would fail to overwrite it.
-fn copy_archive(url: &str, filename: &Path) {
+fn copy_archive(url: &str, filename: &Path) -> Result<(), String> {
   println!("Copying {url} to {filename:?}");
-  let mut src = fs::File::open(url).unwrap();
-  let mut dst = fs::File::create(filename).unwrap();
+  let mut src = fs::File::open(url)
+    .map_err(|e| format!("could not open source archive {url}: {e}"))?;
+  let mut dst = fs::File::create(filename).map_err(|e| {
+    format!("could not create {} from {url}: {e}", filename.display())
+  })?;
 
   // Allow both GZIP and non-GZIP downloads
   let mut header = [0; 2];
-  src.read_exact(&mut header).unwrap();
-  src.seek(io::SeekFrom::Start(0)).unwrap();
+  src
+    .read_exact(&mut header)
+    .and_then(|()| src.seek(io::SeekFrom::Start(0)))
+    .map_err(|e| format!("could not read archive header from {url}: {e}"))?;
   if header == [0x1f, 0x8b] {
     println!("Detected GZIP archive: {url}");
-    decompress_to_writer(&mut src, &mut dst).unwrap();
+    decompress_to_writer(&mut src, &mut dst).map_err(|e| {
+      format!(
+        "could not decompress {url} into {}: {e}",
+        filename.display()
+      )
+    })?;
   } else {
     println!("Not a GZIP archive: {url}");
-    io::copy(&mut src, &mut dst).unwrap();
+    io::copy(&mut src, &mut dst).map_err(|e| {
+      format!("could not copy {url} into {}: {e}", filename.display())
+    })?;
   }
+  Ok(())
 }
 
 fn print_link_flags() {
@@ -1064,10 +1201,15 @@ fn print_prebuilt_src_binding_path() {
 
   let src_binding_path = get_dirs().root.join("gen").join(name.clone());
 
-  if let Ok(base) = env::var("RUSTY_V8_MIRROR") {
-    let version = env::var("CARGO_PKG_VERSION").unwrap();
-    let url = format!("{base}/v{version}/{name}");
-    download_file(&url, &src_binding_path);
+  // Fetch the binding when a mirror is configured (existing behaviour), or when
+  // it is missing from this checkout. A git checkout has no `gen/<name>.rs`, so
+  // fetching it from the mirror/upstream turns a missing binding into a build
+  // script diagnostic rather than a confusing `include!` failure in
+  // `src/binding.rs`. A published crate ships `gen/<name>.rs`, so with no env
+  // vars set this is skipped and behaves exactly as before.
+  if env::var_os("RUSTY_V8_MIRROR").is_some() || !src_binding_path.exists() {
+    let urls = artifact_urls(&name);
+    download_artifact(&urls, &src_binding_path);
   }
 
   println!(

--- a/build.rs
+++ b/build.rs
@@ -100,7 +100,9 @@ fn main() {
 
   // Early exit
   if is_cargo_doc || is_rls {
-    print_prebuilt_src_binding_path();
+    // Don't fetch a missing binding here: docs.rs/RLS may have no network, and
+    // a published crate already ships it.
+    print_prebuilt_src_binding_path(false);
     return;
   }
 
@@ -148,7 +150,7 @@ fn main() {
     return;
   }
 
-  print_prebuilt_src_binding_path();
+  print_prebuilt_src_binding_path(true);
 
   download_static_lib_binaries();
 }
@@ -753,7 +755,8 @@ const DEFAULT_MIRROR_BASE: &str =
   "https://github.com/denoland/rusty_v8/releases/download";
 
 fn is_http_url(s: &str) -> bool {
-  s.starts_with("http:") || s.starts_with("https:")
+  let lower = s.to_ascii_lowercase();
+  lower.starts_with("http:") || lower.starts_with("https:")
 }
 
 /// The release tag (directory segment) that artifacts are looked up under.
@@ -769,17 +772,24 @@ fn mirror_tag() -> String {
 }
 
 /// Expand a templated `RUSTY_V8_MIRROR` value. See [`artifact_urls`].
-fn expand_mirror_template(template: &str, tag: &str, file: &str) -> String {
-  let version = env::var("CARGO_PKG_VERSION").unwrap();
-  let target = env::var("TARGET").unwrap();
-  let profile = prebuilt_profile();
-  let features = prebuilt_features_suffix();
+///
+/// The substitution values are passed in rather than read from the environment
+/// so this stays a pure function that can be unit tested.
+fn expand_mirror_template(
+  template: &str,
+  tag: &str,
+  version: &str,
+  target: &str,
+  profile: &str,
+  features: &str,
+  file: &str,
+) -> String {
   template
     .replace("{tag}", tag)
-    .replace("{version}", &version)
-    .replace("{target}", &target)
+    .replace("{version}", version)
+    .replace("{target}", target)
     .replace("{profile}", profile)
-    .replace("{features}", &features)
+    .replace("{features}", features)
     .replace("{file}", file)
 }
 
@@ -793,30 +803,46 @@ fn expand_mirror_template(template: &str, tag: &str, file: &str) -> String {
 ///    historical `<base>/<tag>/<file>` layout is used, plus a flat
 ///    `<base>/<file>` layout for filesystem mirrors used as a plain cache.
 /// 2. The upstream default releases base, unless `RUSTY_V8_MIRROR_STRICT` is
-///    set (hermetic builds that must never reach the network).
+///    set *and* a mirror is configured (hermetic builds that must never reach
+///    the network). Strict mode with no mirror is a no-op, so the list is
+///    never empty.
 ///
 /// With no env vars set this is exactly `[<default base>/<tag>/<file>]`.
 fn artifact_urls(file: &str) -> Vec<String> {
   let tag = mirror_tag();
+  let mirror = env::var("RUSTY_V8_MIRROR").ok();
   let mut candidates = Vec::new();
 
-  if let Ok(mirror) = env::var("RUSTY_V8_MIRROR") {
+  if let Some(mirror) = &mirror {
     if mirror.contains('{') {
       // The mirror is a template; expand placeholders and use it verbatim.
-      candidates.push(expand_mirror_template(&mirror, &tag, file));
+      let version = env::var("CARGO_PKG_VERSION").unwrap();
+      let target = env::var("TARGET").unwrap();
+      candidates.push(expand_mirror_template(
+        mirror,
+        &tag,
+        &version,
+        &target,
+        prebuilt_profile(),
+        &prebuilt_features_suffix(),
+        file,
+      ));
     } else {
       // Historical layout: `<base>/<tag>/<file>`.
       candidates.push(format!("{mirror}/{tag}/{file}"));
       // Flat layout `<base>/<file>` for a plain directory of downloaded
       // artifacts used as a cache. Only meaningful for filesystem mirrors.
-      if !is_http_url(&mirror) {
+      if !is_http_url(mirror) {
         candidates.push(format!("{mirror}/{file}"));
       }
     }
   }
 
-  // Fall back to the upstream releases, unless strict mode forbids the network.
-  if !env_bool("RUSTY_V8_MIRROR_STRICT") {
+  // Fall back to the upstream releases, unless strict mode forbids it. Strict
+  // mode only takes effect when a mirror is configured — otherwise there is
+  // nothing to be strict about and suppressing this would leave no candidates.
+  let strict = mirror.is_some() && env_bool("RUSTY_V8_MIRROR_STRICT");
+  if !strict {
     candidates.push(format!("{DEFAULT_MIRROR_BASE}/{tag}/{file}"));
   }
 
@@ -881,16 +907,33 @@ fn replace_non_alphanumeric(url: &str) -> String {
     .collect()
 }
 
+/// The outcome of trying a single artifact candidate.
+enum FetchError {
+  /// The candidate is absent (missing file, failed download). Fall through to
+  /// the next candidate.
+  Miss(String),
+  /// The candidate was found but could not be used (corrupt archive, disk
+  /// full, unwritable destination). Abort — falling back would silently ignore
+  /// a broken but deliberately chosen source, e.g. a pinned mirror.
+  Fatal(String),
+}
+
 /// Fetch each candidate in `urls` into `filename`, stopping at the first that
-/// succeeds. If they all fail, panic with the full list of what was tried and
-/// the available escape hatches.
+/// succeeds. A [`FetchError::Fatal`] aborts immediately. If every candidate is
+/// a [`FetchError::Miss`], panic with the full list of what was tried and the
+/// available escape hatches.
 fn download_artifact(urls: &[String], filename: &Path) {
   let mut failures = Vec::new();
   for url in urls {
     println!("Trying artifact candidate: {url}");
     match try_download_file(url, filename) {
       Ok(()) => return,
-      Err(reason) => {
+      Err(FetchError::Fatal(reason)) => {
+        panic!(
+          "Found a V8 prebuilt artifact at {url} but could not use it: {reason}"
+        );
+      }
+      Err(FetchError::Miss(reason)) => {
         println!("  skipped {url}: {reason}");
         failures.push(format!("  - {url}\n      {reason}"));
       }
@@ -911,24 +954,28 @@ fn download_artifact(urls: &[String], filename: &Path) {
 }
 
 /// Try to fetch a single `url` (an `http(s)://` URL or a filesystem path) into
-/// `filename`. Returns `Err` with a human-readable reason on a recoverable
-/// miss so the caller can fall through to the next candidate.
-fn try_download_file(url: &str, filename: &Path) -> Result<(), String> {
-  if !is_http_url(url) {
-    // A filesystem path: an explicit archive, a file mirror, or a flat cache.
-    if !Path::new(url).exists() {
-      return Err(format!("file not found: {url}"));
-    }
-    return copy_archive(url, filename);
-  }
-
-  // Checksum (i.e: url) to avoid re-downloads. Compare against the URL being
-  // requested (not a fixed one) so this works for every artifact.
+/// `filename`. A [`FetchError::Miss`] means the candidate was absent and the
+/// caller should fall through; a [`FetchError::Fatal`] means it was found but
+/// unusable and the build should abort.
+fn try_download_file(url: &str, filename: &Path) -> Result<(), FetchError> {
+  // Checksum (i.e: url) to avoid re-downloading/re-copying. Compare against the
+  // URL being requested (not a fixed one) so this works for every artifact and
+  // for filesystem mirrors as well as HTTP downloads.
   if filename.exists()
     && let Ok(c) = fs::read_to_string(static_checksum_path(filename))
     && c == url
   {
     println!("Already downloaded {url}");
+    return Ok(());
+  }
+
+  if !is_http_url(url) {
+    // A filesystem path: an explicit archive, a file mirror, or a flat cache.
+    if !Path::new(url).exists() {
+      return Err(FetchError::Miss(format!("file not found: {url}")));
+    }
+    copy_archive(url, filename)?;
+    write_checksum(filename, url)?;
     return Ok(());
   }
 
@@ -939,6 +986,7 @@ fn try_download_file(url: &str, filename: &Path) -> Result<(), String> {
     println!("Looking for download in '{path:?}'");
     if path.exists() {
       copy_archive(&path.to_string_lossy(), filename)?;
+      write_checksum(filename, url)?;
       return Ok(());
     }
   }
@@ -946,8 +994,9 @@ fn try_download_file(url: &str, filename: &Path) -> Result<(), String> {
   let tmpfile = filename.with_extension("tmp");
   if tmpfile.exists() {
     println!("Deleting old tmpfile {}", tmpfile.display());
-    fs::remove_file(&tmpfile)
-      .map_err(|e| format!("could not remove {}: {e}", tmpfile.display()))?;
+    fs::remove_file(&tmpfile).map_err(|e| {
+      FetchError::Fatal(format!("could not remove {}: {e}", tmpfile.display()))
+    })?;
   }
 
   // Try downloading with deno first, then python, then curl.
@@ -1012,31 +1061,44 @@ fn try_download_file(url: &str, filename: &Path) -> Result<(), String> {
     }
   };
 
-  // Did any downloader succeed?
+  // Did any downloader succeed? A failure here means the artifact could not be
+  // fetched from this URL (404, network error, no downloader available), which
+  // is a miss — the next candidate may still have it.
   match status {
     Some(status) if status.success() => {}
     _ => {
-      return Err(format!(
+      return Err(FetchError::Miss(format!(
         "no downloader (deno, python, or curl) could fetch {url}"
-      ));
+      )));
     }
   }
   if !tmpfile.exists() {
-    return Err(format!(
+    return Err(FetchError::Miss(format!(
       "downloader reported success but {} is missing",
       tmpfile.display()
-    ));
+    )));
   }
 
-  // Write checksum (i.e url) & move file
-  fs::write(static_checksum_path(filename), url).map_err(|e| {
-    format!("could not write checksum for {}: {e}", filename.display())
-  })?;
+  // Move the file into place, then record the checksum only after the copy
+  // succeeds so a failed/interrupted copy can't leave a `.sum` that points at a
+  // truncated artifact.
   copy_archive(&tmpfile.to_string_lossy(), filename)?;
-  fs::remove_file(&tmpfile)
-    .map_err(|e| format!("could not remove {}: {e}", tmpfile.display()))?;
+  write_checksum(filename, url)?;
+  let _ = fs::remove_file(&tmpfile);
 
   Ok(())
+}
+
+/// Record the source `url` of the artifact now sitting at `filename`, so a
+/// later build can skip re-fetching it. Written only after the artifact is
+/// fully in place.
+fn write_checksum(filename: &Path, url: &str) -> Result<(), FetchError> {
+  fs::write(static_checksum_path(filename), url).map_err(|e| {
+    FetchError::Fatal(format!(
+      "could not write checksum for {}: {e}",
+      filename.display()
+    ))
+  })
 }
 
 fn download_static_lib_binaries() {
@@ -1103,12 +1165,38 @@ where
 /// Instead, it copies the file contents to a new file.
 /// This is necessary because the V8 archive could live inside a read-only
 /// filesystem, and subsequent builds would fail to overwrite it.
-fn copy_archive(url: &str, filename: &Path) -> Result<(), String> {
+///
+/// The contents are written to a staging file and renamed into place only once
+/// the copy/decompress fully succeeds, so a mid-way failure (corrupt gzip, disk
+/// full) can't truncate a previously good `filename`.
+fn copy_archive(url: &str, filename: &Path) -> Result<(), FetchError> {
   println!("Copying {url} to {filename:?}");
-  let mut src = fs::File::open(url)
-    .map_err(|e| format!("could not open source archive {url}: {e}"))?;
-  let mut dst = fs::File::create(filename).map_err(|e| {
-    format!("could not create {} from {url}: {e}", filename.display())
+  let staging = filename.with_extension("copytmp");
+  let result = copy_archive_to(url, &staging);
+  if result.is_err() {
+    let _ = fs::remove_file(&staging);
+    return result;
+  }
+  fs::rename(&staging, filename).map_err(|e| {
+    let _ = fs::remove_file(&staging);
+    FetchError::Fatal(format!(
+      "could not move {} into place at {}: {e}",
+      staging.display(),
+      filename.display()
+    ))
+  })
+}
+
+/// Copy/decompress the archive at `url` into the staging file `dst_path`.
+fn copy_archive_to(url: &str, dst_path: &Path) -> Result<(), FetchError> {
+  let mut src = fs::File::open(url).map_err(|e| {
+    FetchError::Fatal(format!("could not open source archive {url}: {e}"))
+  })?;
+  let mut dst = fs::File::create(dst_path).map_err(|e| {
+    FetchError::Fatal(format!(
+      "could not create {} from {url}: {e}",
+      dst_path.display()
+    ))
   })?;
 
   // Allow both GZIP and non-GZIP downloads
@@ -1116,22 +1204,28 @@ fn copy_archive(url: &str, filename: &Path) -> Result<(), String> {
   src
     .read_exact(&mut header)
     .and_then(|()| src.seek(io::SeekFrom::Start(0)))
-    .map_err(|e| format!("could not read archive header from {url}: {e}"))?;
+    .map_err(|e| {
+      FetchError::Fatal(format!(
+        "could not read archive header from {url}: {e}"
+      ))
+    })?;
   if header == [0x1f, 0x8b] {
     println!("Detected GZIP archive: {url}");
     decompress_to_writer(&mut src, &mut dst).map_err(|e| {
-      format!(
+      FetchError::Fatal(format!(
         "could not decompress {url} into {}: {e}",
-        filename.display()
-      )
-    })?;
+        dst_path.display()
+      ))
+    })
   } else {
     println!("Not a GZIP archive: {url}");
-    io::copy(&mut src, &mut dst).map_err(|e| {
-      format!("could not copy {url} into {}: {e}", filename.display())
-    })?;
+    io::copy(&mut src, &mut dst).map(|_| ()).map_err(|e| {
+      FetchError::Fatal(format!(
+        "could not copy {url} into {}: {e}",
+        dst_path.display()
+      ))
+    })
   }
-  Ok(())
 }
 
 fn print_link_flags() {
@@ -1188,7 +1282,16 @@ fn print_link_flags() {
   }
 }
 
-fn print_prebuilt_src_binding_path() {
+/// Point `RUSTY_V8_SRC_BINDING_PATH` at the prebuilt bindings.
+///
+/// When `fetch_when_missing` is true and the binding isn't already present in
+/// this checkout, it is downloaded (from the mirror/upstream) so a git checkout
+/// gets a build-script diagnostic instead of a confusing `include!` failure in
+/// `src/binding.rs`. The `DOCS_RS`/RLS early-exit path passes `false`: those
+/// contexts may have no network, and a published crate already ships the
+/// binding, so a missing one should fall through to the `include!` diagnostic
+/// rather than panic.
+fn print_prebuilt_src_binding_path(fetch_when_missing: bool) {
   if let Ok(binding) = env::var("RUSTY_V8_SRC_BINDING_PATH") {
     println!("cargo:rustc-env=RUSTY_V8_SRC_BINDING_PATH={binding}");
     return;
@@ -1201,13 +1304,16 @@ fn print_prebuilt_src_binding_path() {
 
   let src_binding_path = get_dirs().root.join("gen").join(name.clone());
 
-  // Fetch the binding when a mirror is configured (existing behaviour), or when
-  // it is missing from this checkout. A git checkout has no `gen/<name>.rs`, so
-  // fetching it from the mirror/upstream turns a missing binding into a build
-  // script diagnostic rather than a confusing `include!` failure in
-  // `src/binding.rs`. A published crate ships `gen/<name>.rs`, so with no env
-  // vars set this is skipped and behaves exactly as before.
-  if env::var_os("RUSTY_V8_MIRROR").is_some() || !src_binding_path.exists() {
+  // Fetch the binding when a mirror is explicitly configured (existing
+  // behaviour), or when it is missing from this checkout and fetching is
+  // allowed. A published crate ships `gen/<name>.rs`, so a plain `cargo build`
+  // that already has it skips this entirely.
+  if env::var_os("RUSTY_V8_MIRROR").is_some()
+    || (fetch_when_missing && !src_binding_path.exists())
+  {
+    if let Some(parent) = src_binding_path.parent() {
+      fs::create_dir_all(parent).unwrap();
+    }
     let urls = artifact_urls(&name);
     download_artifact(&urls, &src_binding_path);
   }
@@ -1641,5 +1747,37 @@ edge [fontsize=10]
     let clang_bin = env::temp_dir()
       .join(format!("rusty_v8_missing_clang_{}", std::process::id()));
     assert!(clang_resource_dir(&clang_bin).is_err());
+  }
+
+  #[test]
+  fn test_expand_mirror_template() {
+    let out = expand_mirror_template(
+      "https://cache.example.com/{target}/{tag}/{profile}{features}/{version}/{file}",
+      "v152.1.0",
+      "152.1.0",
+      "aarch64-apple-darwin",
+      "release",
+      "_ptrcomp",
+      "librusty_v8_ptrcomp_release_aarch64-apple-darwin.a.gz",
+    );
+    assert_eq!(
+      out,
+      "https://cache.example.com/aarch64-apple-darwin/v152.1.0/release_ptrcomp/152.1.0/librusty_v8_ptrcomp_release_aarch64-apple-darwin.a.gz"
+    );
+
+    // Empty features and a repeated placeholder.
+    let out = expand_mirror_template(
+      "file:///mnt/{tag}/{file}",
+      "nightly",
+      "152.1.0",
+      "x86_64-unknown-linux-gnu",
+      "debug",
+      "",
+      "src_binding_debug_x86_64-unknown-linux-gnu.rs",
+    );
+    assert_eq!(
+      out,
+      "file:///mnt/nightly/src_binding_debug_x86_64-unknown-linux-gnu.rs"
+    );
   }
 }


### PR DESCRIPTION
This PR relaxes the assumptions that `RUSTY_V8_MIRROR` makes about the release
tag. Today the build script looks for artifacts only under
`<mirror>/v<crate version>/<file>`. That layout fails for development checkouts
whose version is not published yet, and for plain directories of downloaded
artifacts. This PR is the first of a series; a later PR relaxes the check-only
and rust-analyzer path.

Changes are in `build.rs`, `README.md`, and `.github/workflows/ci.yml`.

## Tag override

The new `RUSTY_V8_MIRROR_TAG` variable overrides the tag path segment. The
build script uses the value verbatim and does not prepend a `v`, so directories
such as `nightly` or `pr-1234` work:

```
RUSTY_V8_MIRROR_TAG=v152.1.0 cargo build
```

Because this pairs the checkout's Rust sources with a `librusty_v8.a` and
`src_binding_*.rs` generated from a possibly-different V8, the build emits a
`cargo:warning=` whenever the resolved tag differs from `v<crate version>`, and
the README calls out the ABI-mismatch risk.

## Templated mirror URLs

If the `RUSTY_V8_MIRROR` value contains a `{` character it is treated as a full
template instead of a base. Placeholders: `{tag}`, `{version}`, `{target}`,
`{profile}`, `{features}`, `{file}`. No placeholder ⇒ current
`{base}/{tag}/{file}` behaviour, so existing mirrors are unaffected.

## Candidate list

`static_lib_url() -> String` becomes `artifact_urls(file) -> Vec<Candidate>`.
Each candidate is tried in order and the first that exists is used: the mirror
URL (tag layout or template) if `RUSTY_V8_MIRROR` is set; a flat `{base}/{file}`
layout for a plain filesystem mirror used as a cache; and the upstream default
base. `RUSTY_V8_ARCHIVE` still short-circuits, for the static library only.

Each candidate carries whether it is a *deliberate source* (a pinned mirror, the
upstream release) or a best-effort *cache* (the flat filesystem layout, the
`~/.cargo/.rusty_v8` download cache). A `FetchError::Miss` (absent artifact —
404, missing file, no downloader) falls through to the next candidate; a
`FetchError::Fatal` (present but corrupt/unusable) aborts — **except** for cache
candidates, where corruption is demoted to a miss (and the bad cache entry
evicted) so the build falls through rather than hard-failing.

`RUSTY_V8_MIRROR_STRICT=1` stops the list after the mirror entries, for hermetic
CI that must not reach the network. It is honored unconditionally: with no
mirror set the list is empty and the build fails with an explicit error rather
than silently reaching upstream.

## Bindings: new capability

Previously a bare git checkout (which ships only `gen/.gitkeep`) could not build
in prebuilt mode at all — `cargo build` without `V8_FROM_SOURCE` or a mirror
always failed at `include!(env!("RUSTY_V8_SRC_BINDING_PATH"))`. This PR makes
that path work: the binding is fetched through the same candidate list and
written into `OUT_DIR` (never into the registry-owned source tree). A published
crate that ships `gen/<name>.rs` still uses it as-is with no fetch, so the
common case is unchanged. The `DOCS_RS`/RLS early-exit does not fetch a missing
binding (no network there), leaving the `include!` diagnostic in place.

A new `prebuilt-git-checkout` CI job exercises this path end to end; it
self-skips when the current crate version has no published release yet (e.g. a
version-bump PR).

## Errors, safety, and the checksum fix

- One panic at the end of the candidate list naming every URL tried and the
  escape hatches (`RUSTY_V8_ARCHIVE`, `RUSTY_V8_MIRROR`, `RUSTY_V8_MIRROR_TAG`,
  `V8_FROM_SOURCE=1`); a distinct message for the empty-list (strict) and Fatal
  cases.
- `copy_archive` stages to a sibling temp and renames on success, so a corrupt
  gzip or full disk can't truncate a previously-good `librusty_v8.a`.
- The checksum is written only after the copy fully succeeds, and the
  redundant-download check now compares against the requested URL rather than
  `static_lib_url()` (bindings were re-fetched every build; this also makes tag
  changes invalidate the cache correctly).
- The downloader is split into `download_with_{deno,python,curl}`; a missing
  `curl` is a miss, not a panic.

## Tests / housekeeping

`RUSTY_V8_MIRROR_TAG` and `RUSTY_V8_MIRROR_STRICT` are registered for
`rerun-if-env-changed`. `artifact_urls_from` is a pure function with an
ordering-matrix table test (no mirror; http; fs + flat cache; template; strict
with and without a mirror), plus a template-expansion test. The README
`RUSTY_V8_MIRROR` section is rewritten (tag override, template, fallback order,
strict mode) and the stale `v0.13.0`/pre-`.gz` cache example refreshed.

Behaviour is unchanged for a published crate with none of the new variables set.
Existing `<base>/v<version>/<file>` mirrors keep working. No public API change,
no change to the `V8_FROM_SOURCE` path, no new dependency.

Closes bartlomieju/orchid-inbox#148
