### PR TITLE
feat: expose `Module::HasTopLevelAwait`

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -3901,6 +3901,10 @@ bool v8__Module__IsGraphAsync(const v8::Module& self) {
   return ptr_to_local(&self)->IsGraphAsync();
 }
 
+bool v8__Module__HasTopLevelAwait(const v8::Module& self) {
+  return ptr_to_local(&self)->HasTopLevelAwait();
+}
+
 bool v8__Module__IsSourceTextModule(const v8::Module& self) {
   return ptr_to_local(&self)->IsSourceTextModule();
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -241,6 +241,7 @@ unsafe extern "C" {
     context: *const Context,
   ) -> *const Value;
   fn v8__Module__IsGraphAsync(this: *const Module) -> bool;
+  fn v8__Module__HasTopLevelAwait(this: *const Module) -> bool;
   fn v8__Module__IsSourceTextModule(this: *const Module) -> bool;
   fn v8__Module__IsSyntheticModule(this: *const Module) -> bool;
   fn v8__Module__CreateSyntheticModule(
@@ -492,6 +493,18 @@ impl Module {
   #[inline(always)]
   pub fn is_graph_async(&self) -> bool {
     unsafe { v8__Module__IsGraphAsync(self) }
+  }
+
+  /// Returns whether this module is individually asynchronous (for example,
+  /// if it's a Source Text Module Record containing a top-level await).
+  /// See [[HasTLA]] in <https://tc39.es/ecma262/#sec-cyclic-module-records>
+  ///
+  /// Unlike [`Self::is_graph_async`], this says nothing about the module's
+  /// dependencies and imposes no requirement on the module's status, so it can
+  /// be called on a module that has only been compiled.
+  #[inline(always)]
+  pub fn has_top_level_await(&self) -> bool {
+    unsafe { v8__Module__HasTopLevelAwait(self) }
   }
 
   /// Returns whether the module is a SourceTextModule.

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -5400,6 +5400,47 @@ fn module_stalled_top_level_await() {
 }
 
 #[test]
+fn module_has_top_level_await() {
+  let _setup_guard = setup::parallel_test();
+  let isolate = &mut v8::Isolate::new(Default::default());
+  {
+    v8::scope!(let scope, isolate);
+
+    let context = v8::Context::new(scope, Default::default());
+    let scope = &mut v8::ContextScope::new(scope, context);
+    let origin = mock_script_origin(scope, "foo.js");
+
+    // Unlike IsGraphAsync, this is a property of the module alone, so it
+    // answers before the module has been instantiated.
+    let source_text =
+      v8::String::new(scope, "await Promise.resolve();").unwrap();
+    let mut source =
+      v8::script_compiler::Source::new(source_text, Some(&origin));
+    let module =
+      v8::script_compiler::compile_module(scope, &mut source).unwrap();
+    assert_eq!(v8::ModuleStatus::Uninstantiated, module.get_status());
+    assert!(module.has_top_level_await());
+
+    // A module that merely imports one is an async *graph*, but has no
+    // top-level await of its own. The resolve callback compiles the specifier
+    // itself as the dependency's source.
+    let source_text =
+      v8::String::new(scope, "import \"await Promise.resolve();\";").unwrap();
+    let mut source =
+      v8::script_compiler::Source::new(source_text, Some(&origin));
+    let importer =
+      v8::script_compiler::compile_module(scope, &mut source).unwrap();
+    assert!(!importer.has_top_level_await());
+
+    importer
+      .instantiate_module(scope, compile_specifier_as_module_resolve_callback)
+      .unwrap();
+    assert!(importer.is_graph_async());
+    assert!(!importer.has_top_level_await());
+  }
+}
+
+#[test]
 fn import_attributes() {
   let _setup_guard = setup::parallel_test();
   let isolate = &mut v8::Isolate::new(Default::default());


### PR DESCRIPTION
`Module::IsGraphAsync` is already bound, but it answers a different question: it walks the whole linked graph, and it requires the module to be instantiated. `HasTopLevelAwait` is the module's own `[[HasTLA]]` — no dependencies, and no status precondition (`api.cc` reads the bit straight off the `SourceTextModule` and returns `false` for anything else), so it can be called on a module that has only been compiled.

That distinction matters to an embedder implementing a rule the spec states in terms of `[[HasTLA]]`. Disallowing top-level await in a service worker's module script, for instance, is currently only approximable:

- instantiate the whole graph first — which means resolving and fetching every import just to answer the question — and then over-reject on a dependency's await; or
- guess from the source, by compiling it as a classic script and then again inside an `(async () => { ... })` wrapper. That cannot tell `import`-plus-`await` apart from `import` alone, since import declarations fail both probes.

The test covers both halves of the distinction: the answer is available while the module is still `Uninstantiated`, and a module that only *imports* an awaiting one is `is_graph_async()` but not `has_top_level_await()`.

Verified locally with `cargo check --lib` and `cargo fmt --check`. I could not run the test suite here — `binding.cc` is compiled by GN, so a new wrapper needs a from-source V8 build, and the checkout has no `third_party/icu` data for the test targets either. Relying on CI for that.