### PR TITLE
fix: make Context::get_microtask_queue return Option

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -15,6 +15,7 @@ use crate::support::int;
 use std::any::TypeId;
 use std::collections::HashMap;
 use std::ffi::c_void;
+use std::ptr::NonNull;
 use std::ptr::{null, null_mut};
 use std::rc::Rc;
 
@@ -142,13 +143,31 @@ impl Context {
     unsafe { scope.cast_local(|_| v8__Context__Global(self)) }.unwrap()
   }
 
+  /// Returns the microtask queue associated with this context.
+  ///
+  /// Returns `None` if the context has no microtask queue, which is the case
+  /// after its global object has been detached — detaching clears the native
+  /// context's microtask queue pointer.
   #[inline(always)]
-  pub fn get_microtask_queue(&self) -> &MicrotaskQueue {
-    unsafe { &*v8__Context__GetMicrotaskQueue(self) }
+  pub fn get_microtask_queue(&self) -> Option<&MicrotaskQueue> {
+    let queue = unsafe { v8__Context__GetMicrotaskQueue(self) };
+    NonNull::new(queue.cast_mut()).map(|queue| unsafe { &*queue.as_ptr() })
   }
 
+  /// Associates this context with the given microtask queue.
+  ///
+  /// # Panics
+  ///
+  /// Panics if this context has no microtask queue, i.e. if its global object
+  /// has been detached. V8 unconditionally dereferences the existing queue
+  /// when setting a new one, so a detached context cannot be re-associated
+  /// with a microtask queue.
   #[inline(always)]
   pub fn set_microtask_queue(&self, microtask_queue: &MicrotaskQueue) {
+    assert!(
+      self.get_microtask_queue().is_some(),
+      "cannot set a microtask queue on a context whose global object has been detached"
+    );
     unsafe {
       v8__Context__SetMicrotaskQueue(self, microtask_queue);
     }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -13394,7 +13394,7 @@ fn microtask_queue() {
   let mut scope = scope.init();
   let context = v8::Context::new(&scope, Default::default());
 
-  let queue = context.get_microtask_queue();
+  let queue = context.get_microtask_queue().unwrap();
   let mut scope = v8::ContextScope::new(&mut scope, context);
 
   static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -13428,7 +13428,10 @@ fn microtask_queue_new() {
   let context = v8::Context::new(&scope, Default::default());
 
   context.set_microtask_queue(queue.as_ref());
-  assert!(std::ptr::eq(context.get_microtask_queue(), queue.as_ref()));
+  assert!(std::ptr::eq(
+    context.get_microtask_queue().unwrap(),
+    queue.as_ref()
+  ));
 
   let mut scope = v8::ContextScope::new(&mut scope, context);
   static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -13448,7 +13451,10 @@ fn microtask_queue_new() {
   // released and cppgc runs.
   drop(queue);
   scope.request_garbage_collection_for_testing(v8::GarbageCollectionType::Full);
-  context.get_microtask_queue().perform_checkpoint(&mut scope);
+  context
+    .get_microtask_queue()
+    .unwrap()
+    .perform_checkpoint(&mut scope);
   assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 1);
 }
 


### PR DESCRIPTION
V8's Context::DetachGlobal() clears the native context's microtask queue
pointer, so a context can legitimately have no queue. get_microtask_queue
built a Rust reference straight out of that raw pointer with no null check,
which would be instant UB on a detached context, and set_microtask_queue
reaches a V8 ApiCheck that unconditionally dereferences the existing queue,
which would segfault inside V8 from safe Rust. Neither is reachable today
because rusty_v8 does not expose a way to detach a context, but both become
reachable the moment it does.

The getter now returns Option<&MicrotaskQueue> and yields None for a detached
context; the setter asserts the context still has a queue and panics with a
clear message rather than crashing in V8. This is a breaking change to the
getter's signature, and a prerequisite for exposing Context::DetachGlobal as
requested in #2059.