### PR TITLE
feat: expose Context::DetachGlobal

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2216,6 +2216,10 @@ const v8::Object* v8__Context__Global(const v8::Context& self) {
   return local_to_ptr(ptr_to_local(&self)->Global());
 }
 
+void v8__Context__DetachGlobal(v8::Context& self) {
+  ptr_to_local(&self)->DetachGlobal();
+}
+
 uint32_t v8__Context__GetNumberOfEmbedderDataFields(const v8::Context& self) {
   return ptr_to_local(&self)->GetNumberOfEmbedderDataFields();
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -28,6 +28,7 @@ unsafe extern "C" {
   ) -> *const Context;
   fn v8__Isolate__GetCurrent() -> *mut RealIsolate;
   fn v8__Context__Global(this: *const Context) -> *const Object;
+  fn v8__Context__DetachGlobal(this: *const Context);
   fn v8__Context__GetExtrasBindingObject(this: *const Context)
   -> *const Object;
   fn v8__Context__GetNumberOfEmbedderDataFields(this: *const Context) -> u32;
@@ -143,11 +144,40 @@ impl Context {
     unsafe { scope.cast_local(|_| v8__Context__Global(self)) }.unwrap()
   }
 
+  /// Detaches this context's global proxy so the global object can be reused
+  /// to create a new context through [`ContextOptions::global_object`]. The new
+  /// context must use the same global template as this context. Calling this
+  /// method more than once has no additional effect.
+  ///
+  /// Detaching resets the context's security token to its default unique state,
+  /// revoking cross-context access previously granted through a shared token.
+  ///
+  /// This also disassociates the context from its microtask queue. Pending
+  /// microtasks associated with this context will not run.
+  ///
+  /// A reference previously returned by [`Self::get_microtask_queue`] does not
+  /// keep the queue alive. With the default `v8_cppgc_microtask_queue=true`,
+  /// detaching removes this context's contribution to keeping the queue alive
+  /// after its [`crate::MicrotaskQueueHandle`] has been dropped. The handle or
+  /// another associated context must keep the queue alive while using any such
+  /// reference.
+  #[inline(always)]
+  pub fn detach_global(&self) {
+    unsafe { v8__Context__DetachGlobal(self) }
+  }
+
   /// Returns the microtask queue associated with this context.
   ///
   /// Returns `None` if the context has no microtask queue, which is the case
   /// after its global object has been detached — detaching clears the native
   /// context's microtask queue pointer.
+  ///
+  /// The returned reference does not own or root the queue. If the context is
+  /// later detached with the default `v8_cppgc_microtask_queue=true`, the
+  /// context no longer keeps the queue alive after its
+  /// [`crate::MicrotaskQueueHandle`] has been dropped. Do not use a reference
+  /// obtained before detachment unless the handle or another associated
+  /// context still keeps the queue alive.
   #[inline(always)]
   pub fn get_microtask_queue(&self) -> Option<&MicrotaskQueue> {
     let queue = unsafe { v8__Context__GetMicrotaskQueue(self) };

--- a/src/microtask.rs
+++ b/src/microtask.rs
@@ -111,10 +111,10 @@ impl MicrotaskQueue {
 /// This handle must be dropped before its isolate is disposed because dropping
 /// it releases a root through the isolate's heap.
 ///
-/// With the default `v8_cppgc_microtask_queue` GN setting, contexts associated
-/// with the queue keep it alive after this handle is dropped. If that setting
-/// is disabled through `EXTRA_GN_ARGS`, this handle owns the queue and must
-/// outlive every associated context.
+/// With the default `v8_cppgc_microtask_queue` GN setting, each associated
+/// context keeps the queue alive after this handle is dropped until it is
+/// detached. If that setting is disabled through `EXTRA_GN_ARGS`, this handle
+/// owns the queue and must outlive every associated context.
 #[derive(Debug)]
 pub struct MicrotaskQueueHandle(NonNull<MicrotaskQueueHandleRaw>);
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -13459,6 +13459,121 @@ fn microtask_queue_new() {
 }
 
 #[test]
+fn context_detach_global_reuses_global_object() {
+  let _setup_guard = setup::parallel_test();
+  let mut isolate = v8::Isolate::new(Default::default());
+
+  let scope = pin!(v8::HandleScope::new(&mut isolate));
+  let scope = scope.init();
+  let global_template = v8::ObjectTemplate::new(&scope);
+  let context = v8::Context::new(
+    &scope,
+    v8::ContextOptions {
+      global_template: Some(global_template),
+      ..Default::default()
+    },
+  );
+  let global_object = context.global(&scope);
+
+  context.detach_global();
+  let reused_context = v8::Context::new(
+    &scope,
+    v8::ContextOptions {
+      global_template: Some(global_template),
+      global_object: Some(global_object.into()),
+      ..Default::default()
+    },
+  );
+
+  assert_eq!(global_object, reused_context.global(&scope));
+}
+
+#[test]
+#[should_panic(
+  expected = "cannot set a microtask queue on a context whose global object has been detached"
+)]
+fn context_set_microtask_queue_panics_after_detach() {
+  let _setup_guard = setup::parallel_test();
+  let mut isolate = v8::Isolate::new(Default::default());
+
+  let scope = pin!(v8::HandleScope::new(&mut isolate));
+  let mut scope = scope.init();
+  let queue =
+    v8::MicrotaskQueue::new(&mut scope, v8::MicrotasksPolicy::Explicit);
+  let context = v8::Context::new(&scope, Default::default());
+
+  context.detach_global();
+  context.set_microtask_queue(queue.as_ref());
+}
+
+#[test]
+fn context_detach_global_cancels_its_microtasks() {
+  let _setup_guard = setup::parallel_test();
+  let mut isolate = v8::Isolate::new(Default::default());
+
+  let scope = pin!(v8::HandleScope::new(&mut isolate));
+  let mut scope = scope.init();
+  let queue =
+    v8::MicrotaskQueue::new(&mut scope, v8::MicrotasksPolicy::Explicit);
+
+  let detached_context = v8::Context::new(&scope, Default::default());
+  detached_context.set_microtask_queue(queue.as_ref());
+  let active_context = v8::Context::new(&scope, Default::default());
+  active_context.set_microtask_queue(queue.as_ref());
+
+  static DETACHED_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+  static ACTIVE_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+  DETACHED_CALL_COUNT.store(0, Ordering::SeqCst);
+  ACTIVE_CALL_COUNT.store(0, Ordering::SeqCst);
+
+  {
+    let mut context_scope = v8::ContextScope::new(&mut scope, detached_context);
+    let task = v8::Function::new(
+      &mut context_scope,
+      |_: &mut v8::PinScope,
+       _: v8::FunctionCallbackArguments,
+       _: v8::ReturnValue<v8::Value>| {
+        DETACHED_CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+      },
+    )
+    .unwrap();
+    queue.enqueue_microtask(&mut context_scope, task);
+  }
+  let active_task = {
+    let mut context_scope = v8::ContextScope::new(&mut scope, active_context);
+    let task = v8::Function::new(
+      &mut context_scope,
+      |_: &mut v8::PinScope,
+       _: v8::FunctionCallbackArguments,
+       _: v8::ReturnValue<v8::Value>| {
+        ACTIVE_CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+      },
+    )
+    .unwrap();
+    queue.enqueue_microtask(&mut context_scope, task);
+    task
+  };
+
+  detached_context.detach_global();
+  assert!(detached_context.get_microtask_queue().is_none());
+  {
+    let mut context_scope = v8::ContextScope::new(&mut scope, active_context);
+    queue.perform_checkpoint(&mut context_scope);
+  }
+
+  assert_eq!(DETACHED_CALL_COUNT.load(Ordering::SeqCst), 0);
+  assert_eq!(ACTIVE_CALL_COUNT.load(Ordering::SeqCst), 1);
+
+  {
+    let mut context_scope = v8::ContextScope::new(&mut scope, active_context);
+    queue.enqueue_microtask(&mut context_scope, active_task);
+    queue.perform_checkpoint(&mut context_scope);
+  }
+  assert_eq!(DETACHED_CALL_COUNT.load(Ordering::SeqCst), 0);
+  assert_eq!(ACTIVE_CALL_COUNT.load(Ordering::SeqCst), 2);
+}
+
+#[test]
 fn clear_slots_annex_uninitialized() {
   let _setup_guard = setup::parallel_test();
   let mut isolate = v8::Isolate::new(Default::default());


### PR DESCRIPTION
## Summary

- expose `Context::detach_global(&self)` as a thin binding over V8 `Context::DetachGlobal()`
- document global proxy reuse, idempotence, microtask disassociation, and the lifetime constraint on previously returned queue references
- test two contexts sharing a microtask queue, with tasks enqueued under their corresponding context scopes
- verify that detached-context work is skipped, active-context work still runs, and the shared queue remains reusable

Closes #2059.

## Testing

- `cargo fmt --check`
- `clang-format-19 --verbose --Werror --dry-run src/*.cc src/*.hpp src/*.h`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=third_party/rust-toolchain/lib cargo doc --no-deps --locked`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=third_party/rust-toolchain/lib cargo clippy --all-targets --locked -- -D clippy::all`
- `V8_FROM_SOURCE=1 LIBCLANG_PATH=third_party/rust-toolchain/lib cargo nextest run --all-targets --locked --no-fail-fast` (361 passed)