### PR TITLE
fix: return Value from Function::get_name

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -55,7 +55,7 @@ unsafe extern "C" {
     argc: int,
     argv: *const *const Value,
   ) -> *const Object;
-  fn v8__Function__GetName(this: *const Function) -> *const String;
+  fn v8__Function__GetName(this: *const Function) -> *const Value;
   fn v8__Function__SetName(this: *const Function, name: *const String);
   fn v8__Function__GetScriptColumnNumber(this: *const Function) -> int;
   fn v8__Function__GetScriptLineNumber(this: *const Function) -> int;
@@ -1093,7 +1093,7 @@ impl Function {
   }
 
   #[inline(always)]
-  pub fn get_name<'s>(&self, scope: &PinScope<'s, '_>) -> Local<'s, String> {
+  pub fn get_name<'s>(&self, scope: &PinScope<'s, '_>) -> Local<'s, Value> {
     unsafe { scope.cast_local(|_| v8__Function__GetName(self)).unwrap() }
   }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -11222,6 +11222,17 @@ fn function_names() {
     let v8_name = func.get_name(scope);
     assert_eq!(v8_name.to_rust_string_lossy(scope), "");
   }
+
+  // v8::Function::GetName() returns undefined for callable proxies.
+  {
+    let func: v8::Local<v8::Function> =
+      eval(scope, "new Proxy(function () {}, {})")
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let v8_name: v8::Local<v8::Value> = func.get_name(scope);
+    assert!(v8_name.is_undefined());
+  }
 }
 
 // https://github.com/denoland/rusty_v8/issues/849


### PR DESCRIPTION
Match V8's `Function::GetName` return type instead of assuming every function name is a `String`.

https://v8.github.io/api/head/classv8_1_1Function.html#a145a91e74d5adb78c8b710618253b487