### PR TITLE
Fix unsound Send impl for inspector::CharacterArray (T: Copy -> T: Sync) 

### DIFF
--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -1144,7 +1144,7 @@ where
   }
 }
 
-unsafe impl<T> Send for CharacterArray<'_, T> where T: Copy {}
+unsafe impl<T> Send for CharacterArray<'_, T> where T: Sync {}
 unsafe impl<T> Sync for CharacterArray<'_, T> where T: Sync {}
 
 impl fmt::Display for CharacterArray<'_, u8> {


### PR DESCRIPTION
# Fix unsound `Send` impl for `inspector::CharacterArray` (`T: Copy` → `T: Sync`)

`CharacterArray<'a, T>` is semantically a borrowed slice `&[T]` (safe `From<&[T]>` constructor, `Deref<Target = [T]>`), but its handwritten `Send` impl requires `T: Copy` while the `Sync` impl on the same type correctly requires `T: Sync`.

For a `&[T]`-like type the correct condition is `T: Sync` in both directions (`&[T]: Send ⇔ T: Sync`). `T: Copy` neither implies nor is implied by `T: Sync` — e.g. `&'static Cell<i32>` is `Copy` but `!Sync`, so safe code can currently send `CharacterArray<'static, &'static Cell<i32>>` across threads and obtain shared `&Cell<i32>` accesses — a data race without any `unsafe` at the use site.

The fix tightens the `Send` bound to `T: Sync`. All in-tree instantiations are `u8`/`u16` (both `Sync`), so nothing else is affected.
